### PR TITLE
Bootstrap: PostgreSQL + Redis + Horizon + ULID prefixed-ID cast

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=Laravel
+APP_NAME=authn
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
@@ -20,33 +20,45 @@ LOG_STACK=single
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
-DB_CONNECTION=sqlite
-# DB_HOST=127.0.0.1
-# DB_PORT=3306
-# DB_DATABASE=laravel
-# DB_USERNAME=root
-# DB_PASSWORD=
+# ----------------------------------------------------------------------
+# Database — PostgreSQL is the supported production store. SQLite is
+# only used by the in-memory test suite (see phpunit.xml).
+# ----------------------------------------------------------------------
+DB_CONNECTION=pgsql
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_DATABASE=authn
+DB_USERNAME=authn
+DB_PASSWORD=authn
 
-SESSION_DRIVER=database
+# ----------------------------------------------------------------------
+# Redis — backs cache, session, queue, locks. Single instance is fine
+# for v0.1; clustering is post-v1.
+# ----------------------------------------------------------------------
+REDIS_CLIENT=phpredis
+REDIS_HOST=127.0.0.1
+REDIS_PASSWORD=null
+REDIS_PORT=6379
+REDIS_PREFIX=authn
+
+# ----------------------------------------------------------------------
+# Cache / session / queue — all on Redis in dev and prod.
+# ----------------------------------------------------------------------
+CACHE_STORE=redis
+SESSION_DRIVER=redis
 SESSION_LIFETIME=120
 SESSION_ENCRYPT=false
 SESSION_PATH=/
 SESSION_DOMAIN=null
 
-BROADCAST_CONNECTION=log
-FILESYSTEM_DISK=local
-QUEUE_CONNECTION=database
+QUEUE_CONNECTION=redis
+HORIZON_PATH=horizon
+# HORIZON_DOMAIN=
 
-CACHE_STORE=database
-# CACHE_PREFIX=
-
-MEMCACHED_HOST=127.0.0.1
-
-REDIS_CLIENT=phpredis
-REDIS_HOST=127.0.0.1
-REDIS_PASSWORD=null
-REDIS_PORT=6379
-
+# ----------------------------------------------------------------------
+# Mail — driver pluggable per AU-14. `log` is fine for local dev;
+# production uses resend / postmark / ses / smtp.
+# ----------------------------------------------------------------------
 MAIL_MAILER=log
 MAIL_SCHEME=null
 MAIL_HOST=127.0.0.1
@@ -56,10 +68,16 @@ MAIL_PASSWORD=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
 
+# ----------------------------------------------------------------------
+# Object storage — S3-compatible. Avatars, org logos, email attachments.
+# ----------------------------------------------------------------------
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1
 AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
+
+BROADCAST_CONNECTION=log
+FILESYSTEM_DISK=local
 
 VITE_APP_NAME="${APP_NAME}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    env:
+      APP_ENV: testing
+      APP_KEY: base64:dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3Q=
+      DB_CONNECTION: pgsql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 5432
+      DB_DATABASE: authn
+      DB_USERNAME: authn
+      DB_PASSWORD: authn
+      REDIS_CLIENT: phpredis
+      REDIS_HOST: 127.0.0.1
+      REDIS_PORT: 6379
+
     services:
       postgres:
         image: postgres:16-alpine
@@ -68,18 +81,6 @@ jobs:
         run: vendor/bin/pint --test
 
       - name: Migrate against PostgreSQL
-        env:
-          APP_ENV: testing
-          APP_KEY: base64:dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3Q=
-          DB_CONNECTION: pgsql
-          DB_HOST: 127.0.0.1
-          DB_PORT: 5432
-          DB_DATABASE: authn
-          DB_USERNAME: authn
-          DB_PASSWORD: authn
-          REDIS_CLIENT: phpredis
-          REDIS_HOST: 127.0.0.1
-          REDIS_PORT: 6379
         run: php artisan migrate --force
 
       - name: Pest (in-memory SQLite per phpunit.xml)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: authn
+          POSTGRES_PASSWORD: authn
+          POSTGRES_DB: authn
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U authn"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+      redis:
+        image: redis:7-alpine
+        ports: ["6379:6379"]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          extensions: pdo_pgsql, redis, intl, bcmath, gd, sodium
+          coverage: none
+          tools: composer:v2
+
+      - name: Cache composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - run: composer install --prefer-dist --no-interaction --no-progress
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Pint (style)
+        run: vendor/bin/pint --test
+
+      - name: Migrate against PostgreSQL
+        env:
+          APP_ENV: testing
+          APP_KEY: base64:dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3Q=
+          DB_CONNECTION: pgsql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 5432
+          DB_DATABASE: authn
+          DB_USERNAME: authn
+          DB_PASSWORD: authn
+          REDIS_CLIENT: phpredis
+          REDIS_HOST: 127.0.0.1
+          REDIS_PORT: 6379
+        run: php artisan migrate --force
+
+      - name: Pest (in-memory SQLite per phpunit.xml)
+        run: php artisan test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.3"
+          php-version: "8.4"
           extensions: pdo_pgsql, redis, intl, bcmath, gd, sodium
           coverage: none
           tools: composer:v2

--- a/app/Casts/PrefixedUlid.php
+++ b/app/Casts/PrefixedUlid.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Casts;
+
+use App\Support\Id;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
+
+/**
+ * @implements CastsAttributes<string, string>
+ */
+final class PrefixedUlid implements CastsAttributes
+{
+    /**
+     * The prefix this column expects (e.g. `'user_'`). Passed via the cast
+     * argument syntax: `protected $casts = ['id' => PrefixedUlid::class.':user_'];`
+     */
+    public function __construct(private readonly ?string $prefix = null) {}
+
+    public function get(Model $model, string $key, mixed $value, array $attributes): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        // Permissive read: surface whatever's in storage, but defensively
+        // refuse to return anything that isn't a syntactically valid id.
+        if (! is_string($value) || ! Id::isValid($value)) {
+            throw new InvalidArgumentException(sprintf(
+                'Column %s on %s holds an invalid prefixed id: %s',
+                $key,
+                $model::class,
+                var_export($value, true),
+            ));
+        }
+
+        return $value;
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_string($value)) {
+            throw new InvalidArgumentException(sprintf(
+                'Column %s on %s expects a string id, got %s.',
+                $key,
+                $model::class,
+                get_debug_type($value),
+            ));
+        }
+
+        ['prefix' => $prefix] = Id::parse($value);
+
+        if ($this->prefix !== null && $prefix !== $this->prefix) {
+            throw new InvalidArgumentException(sprintf(
+                'Column %s on %s expects prefix "%s", got "%s" (id: %s).',
+                $key,
+                $model::class,
+                $this->prefix,
+                $prefix,
+                $value,
+            ));
+        }
+
+        return $value;
+    }
+}

--- a/app/Concerns/HasPrefixedUlid.php
+++ b/app/Concerns/HasPrefixedUlid.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Concerns;
+
+use App\Casts\PrefixedUlid;
+use App\Support\Id;
+use LogicException;
+
+/**
+ * Drop into any Eloquent model whose primary key is a prefixed ULID.
+ *
+ * Models declare `protected string $idPrefix = 'user_';` and this trait does
+ * the rest: marks the key as non-incrementing string, generates a fresh id on
+ * `creating` when none is set, and registers the PrefixedUlid cast on the id
+ * column scoped to the model's prefix.
+ */
+trait HasPrefixedUlid
+{
+    public static function bootHasPrefixedUlid(): void
+    {
+        static::creating(function ($model): void {
+            $key = $model->getKeyName();
+            if (empty($model->getAttribute($key))) {
+                $model->setAttribute($key, Id::generate($model->getIdPrefix()));
+            }
+        });
+    }
+
+    public function initializeHasPrefixedUlid(): void
+    {
+        $this->setKeyType('string');
+        $this->setIncrementing(false);
+
+        // Register the PrefixedUlid cast on the primary key, scoped to this
+        // model's prefix. Done here (rather than via $casts) so subclasses
+        // inherit the right prefix automatically.
+        $this->mergeCasts([
+            $this->getKeyName() => PrefixedUlid::class.':'.$this->getIdPrefix(),
+        ]);
+    }
+
+    public function getIdPrefix(): string
+    {
+        if (! property_exists($this, 'idPrefix') || ! is_string($this->idPrefix) || $this->idPrefix === '') {
+            throw new LogicException(static::class.' must declare a non-empty `protected string $idPrefix`.');
+        }
+
+        return $this->idPrefix;
+    }
+}

--- a/app/Providers/HorizonServiceProvider.php
+++ b/app/Providers/HorizonServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Gate;
+use Laravel\Horizon\Horizon;
+use Laravel\Horizon\HorizonApplicationServiceProvider;
+
+class HorizonServiceProvider extends HorizonApplicationServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        parent::boot();
+
+        // Horizon::routeSmsNotificationsTo('15556667777');
+        // Horizon::routeMailNotificationsTo('example@example.com');
+        // Horizon::routeSlackNotificationsTo('slack-webhook-url', '#channel');
+    }
+
+    /**
+     * Register the Horizon gate.
+     *
+     * In non-local environments only an authenticated operator with the
+     * `view-horizon` ability can hit /horizon. Until the operator-auth layer
+     * lands (AU-17), non-local environments deny everyone — Horizon is reachable
+     * only when APP_ENV=local.
+     */
+    protected function gate(): void
+    {
+        Gate::define('viewHorizon', fn ($user = null) => false);
+    }
+}

--- a/app/Support/Id.php
+++ b/app/Support/Id.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+/**
+ * Generate and parse prefixed-ULID identifiers.
+ *
+ * Format: `{prefix}{ulid}` where `prefix` is one of the values in IdPrefix
+ * (always trailing-underscore-terminated, e.g. `'user_'`) and `ulid` is the
+ * 26-character Crockford-base32 ULID returned by Laravel's Str::ulid().
+ */
+final class Id
+{
+    /**
+     * The 26-character Crockford-base32 alphabet used by ULIDs.
+     */
+    private const ULID_PATTERN = '/^[0-9A-HJKMNP-TV-Z]{26}$/';
+
+    /**
+     * Mint a fresh prefixed ULID.
+     *
+     * @throws InvalidArgumentException when $prefix is not registered.
+     */
+    public static function generate(string $prefix): string
+    {
+        if (! IdPrefix::isRegistered($prefix)) {
+            throw new InvalidArgumentException("Unknown id prefix: {$prefix}");
+        }
+
+        return $prefix.Str::ulid()->toBase32();
+    }
+
+    /**
+     * Split a prefixed id into its prefix and ULID parts.
+     *
+     * @return array{prefix: string, ulid: string}
+     *
+     * @throws InvalidArgumentException when $id is malformed or the prefix is unregistered.
+     */
+    public static function parse(string $id): array
+    {
+        $underscore = strrpos($id, '_');
+        if ($underscore === false) {
+            throw new InvalidArgumentException("Malformed id (no prefix): {$id}");
+        }
+
+        $prefix = substr($id, 0, $underscore + 1);
+        $ulid = substr($id, $underscore + 1);
+
+        if (! IdPrefix::isRegistered($prefix)) {
+            throw new InvalidArgumentException("Unknown id prefix: {$prefix}");
+        }
+
+        if (preg_match(self::ULID_PATTERN, strtoupper($ulid)) !== 1) {
+            throw new InvalidArgumentException("Malformed ULID portion: {$ulid}");
+        }
+
+        return ['prefix' => $prefix, 'ulid' => strtoupper($ulid)];
+    }
+
+    /**
+     * Whether $id is a syntactically valid prefixed ULID with a registered prefix.
+     */
+    public static function isValid(string $id): bool
+    {
+        try {
+            self::parse($id);
+
+            return true;
+        } catch (InvalidArgumentException) {
+            return false;
+        }
+    }
+}

--- a/app/Support/IdPrefix.php
+++ b/app/Support/IdPrefix.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Canonical registry of every prefixed-ULID prefix used in the data model.
+ *
+ * The list mirrors PLAN §5. Adding a new prefix is the only sanctioned way
+ * to introduce a new prefixed-ULID resource — the Id and cast layers refuse
+ * to mint or parse anything that isn't on this list, so a typo can't silently
+ * create an alternate-universe resource type.
+ */
+final class IdPrefix
+{
+    /**
+     * @var list<string>
+     */
+    public const PREFIXES = [
+        // Tenancy spine
+        'prj_', 'env_', 'apik_', 'kid_',
+
+        // End-user identity
+        'user_', 'idn_', 'eml_', 'phn_', 'ext_', 'entacc_', 'pkey_', 'totp_', 'bcc_',
+
+        // Verification + flow state
+        'ver_', 'client_', 'sess_', 'sia_', 'sui_', 'sit_', 'act_',
+
+        // Organizations
+        'org_', 'orgmem_', 'orginv_', 'orgdom_', 'orgreq_', 'role_', 'perm_',
+
+        // Restrictions and platform settings
+        'inv_', 'redir_', 'allow_', 'block_',
+        'jtmpl_', 'oac_', 'oat_', 'ort_', 'oauthp_', 'entcon_',
+        'scimt_', 'scimm_', 'wait_',
+
+        // Webhooks + delivery
+        'whe_', 'whd_', 'evt_',
+
+        // Templates, domains, audit
+        'tmpl_', 'dmn_', 'audit_',
+    ];
+
+    /**
+     * Whether the supplied prefix is registered.
+     *
+     * Always pass the *full* prefix including the trailing underscore
+     * (e.g. `'user_'`, never `'user'`).
+     */
+    public static function isRegistered(string $prefix): bool
+    {
+        return in_array($prefix, self::PREFIXES, true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function all(): array
+    {
+        return self::PREFIXES;
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Providers\AppServiceProvider;
+use App\Providers\HorizonServiceProvider;
 
 return [
     AppServiceProvider::class,
+    HorizonServiceProvider::class,
 ];

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,10 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
+        "ext-pdo_pgsql": "*",
+        "ext-redis": "*",
         "laravel/framework": "^13.0",
+        "laravel/horizon": "^5.46",
         "laravel/tinker": "^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "ext-pdo_pgsql": "*",
         "ext-redis": "*",
         "laravel/framework": "^13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4551dd528036b18001c20940634bb29a",
+    "content-hash": "16c3d89e48572a8145e04b7cac24fdd7",
     "packages": [
         {
             "name": "brick/math",
@@ -1278,6 +1278,86 @@
             "time": "2026-04-28T17:18:25+00:00"
         },
         {
+            "name": "laravel/horizon",
+            "version": "v5.46.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/horizon.git",
+                "reference": "bfea968e8aa674fb649d02e55ea0d38bdf5137d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/horizon/zipball/bfea968e8aa674fb649d02e55ea0d38bdf5137d5",
+                "reference": "bfea968e8aa674fb649d02e55ea0d38bdf5137d5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcntl": "*",
+                "ext-posix": "*",
+                "illuminate/contracts": "^9.21|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/queue": "^9.21|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^9.21|^10.0|^11.0|^12.0|^13.0",
+                "laravel/sentinel": "^1.0",
+                "nesbot/carbon": "^2.17|^3.0",
+                "php": "^8.0",
+                "ramsey/uuid": "^4.0",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/error-handler": "^6.0|^7.0|^8.0",
+                "symfony/polyfill-php83": "^1.28",
+                "symfony/process": "^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^7.56|^8.37|^9.16|^10.9|^11.0",
+                "phpstan/phpstan": "^1.10|^2.0",
+                "predis/predis": "^1.1|^2.0|^3.0"
+            },
+            "suggest": {
+                "ext-redis": "Required to use the Redis PHP driver.",
+                "predis/predis": "Required when not using the Redis PHP driver (^1.1|^2.0|^3.0)."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Horizon": "Laravel\\Horizon\\Horizon"
+                    },
+                    "providers": [
+                        "Laravel\\Horizon\\HorizonServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Horizon\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Dashboard and code-driven configuration for Laravel queues.",
+            "keywords": [
+                "laravel",
+                "queue"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/horizon/issues",
+                "source": "https://github.com/laravel/horizon/tree/v5.46.0"
+            },
+            "time": "2026-04-20T18:08:11+00:00"
+        },
+        {
             "name": "laravel/prompts",
             "version": "v0.3.17",
             "source": {
@@ -1335,6 +1415,62 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.17"
             },
             "time": "2026-04-20T16:07:33+00:00"
+        },
+        {
+            "name": "laravel/sentinel",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sentinel.git",
+                "reference": "972d9885d9d14312a118e9565c4e6ecc5e751ea1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sentinel/zipball/972d9885d9d14312a118e9565c4e6ecc5e751ea1",
+                "reference": "972d9885d9d14312a118e9565c4e6ecc5e751ea1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/container": "^8.37|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.27",
+                "orchestra/testbench": "^6.47.1|^7.56|^8.37|^9.16|^10.9|^11.0",
+                "phpstan/phpstan": "^2.1.33"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sentinel\\SentinelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sentinel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "mior@laravel.com"
+                }
+            ],
+            "support": {
+                "source": "https://github.com/laravel/sentinel/tree/v1.1.0"
+            },
+            "time": "2026-03-24T14:03:38+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -4768,6 +4904,86 @@
                 }
             ],
             "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php84",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16c3d89e48572a8145e04b7cac24fdd7",
+    "content-hash": "a92da7d354585753629413cd932596e6",
     "packages": [
         {
             "name": "brick/math",
@@ -9531,7 +9531,9 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.3"
+        "php": "^8.4",
+        "ext-pdo_pgsql": "*",
+        "ext-redis": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/config/cache.php
+++ b/config/cache.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('CACHE_STORE', 'database'),
+    'default' => env('CACHE_STORE', 'redis'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/database.php
+++ b/config/database.php
@@ -17,7 +17,7 @@ return [
     |
     */
 
-    'default' => env('DB_CONNECTION', 'sqlite'),
+    'default' => env('DB_CONNECTION', 'pgsql'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -1,0 +1,275 @@
+<?php
+
+use Illuminate\Support\Str;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Name
+    |--------------------------------------------------------------------------
+    |
+    | This name appears in notifications and in the Horizon UI. Unique names
+    | can be useful while running multiple instances of Horizon within an
+    | application, allowing you to identify the Horizon you're viewing.
+    |
+    */
+
+    'name' => env('HORIZON_NAME'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Domain
+    |--------------------------------------------------------------------------
+    |
+    | This is the subdomain where Horizon will be accessible from. If this
+    | setting is null, Horizon will reside under the same domain as the
+    | application. Otherwise, this value will serve as the subdomain.
+    |
+    */
+
+    'domain' => env('HORIZON_DOMAIN'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the URI path where Horizon will be accessible from. Feel free
+    | to change this path to anything you like. Note that the URI will not
+    | affect the paths of its internal API that aren't exposed to users.
+    |
+    */
+
+    'path' => env('HORIZON_PATH', 'horizon'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Redis Connection
+    |--------------------------------------------------------------------------
+    |
+    | This is the name of the Redis connection where Horizon will store the
+    | meta information required for it to function. It includes the list
+    | of supervisors, failed jobs, job metrics, and other information.
+    |
+    */
+
+    'use' => 'default',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Redis Prefix
+    |--------------------------------------------------------------------------
+    |
+    | This prefix will be used when storing all Horizon data in Redis. You
+    | may modify the prefix when you are running multiple installations
+    | of Horizon on the same server so that they don't have problems.
+    |
+    */
+
+    'prefix' => env(
+        'HORIZON_PREFIX',
+        Str::slug(env('APP_NAME', 'laravel'), '_').'_horizon:'
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Route Middleware
+    |--------------------------------------------------------------------------
+    |
+    | These middleware will get attached onto each Horizon route, giving you
+    | the chance to add your own middleware to this list or change any of
+    | the existing middleware. Or, you can simply stick with this list.
+    |
+    */
+
+    'middleware' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Wait Time Thresholds
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to configure when the LongWaitDetected event
+    | will be fired. Every connection / queue combination may have its
+    | own, unique threshold (in seconds) before this event is fired.
+    |
+    */
+
+    'waits' => [
+        'redis:default' => 60,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Job Trimming Times
+    |--------------------------------------------------------------------------
+    |
+    | Here you can configure for how long (in minutes) you desire Horizon to
+    | persist the recent and failed jobs. Typically, recent jobs are kept
+    | for one hour while all failed jobs are stored for an entire week.
+    |
+    */
+
+    'trim' => [
+        'recent' => 60,
+        'pending' => 60,
+        'completed' => 60,
+        'recent_failed' => 10080,
+        'failed' => 10080,
+        'monitored' => 10080,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Silenced Jobs
+    |--------------------------------------------------------------------------
+    |
+    | Silencing a job will instruct Horizon to not place the job in the list
+    | of completed jobs within the Horizon dashboard. This setting may be
+    | used to fully remove any noisy jobs from the completed jobs list.
+    |
+    */
+
+    'silenced' => [
+        // App\Jobs\ExampleJob::class,
+    ],
+
+    'silenced_tags' => [
+        // 'notifications',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Metrics
+    |--------------------------------------------------------------------------
+    |
+    | Here you can configure how many snapshots should be kept to display in
+    | the metrics graph. This will get used in combination with Horizon's
+    | `horizon:snapshot` schedule to define how long to retain metrics.
+    |
+    */
+
+    'metrics' => [
+        'trim_snapshots' => [
+            'job' => 24,
+            'queue' => 24,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Fast Termination
+    |--------------------------------------------------------------------------
+    |
+    | When this option is enabled, Horizon's "terminate" command will not
+    | wait on all of the workers to terminate unless the --wait option
+    | is provided. Fast termination can shorten deployment delay by
+    | allowing a new instance of Horizon to start while the last
+    | instance will continue to terminate each of its workers.
+    |
+    */
+
+    'fast_termination' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Memory Limit (MB)
+    |--------------------------------------------------------------------------
+    |
+    | This value describes the maximum amount of memory the Horizon master
+    | supervisor may consume before it is terminated and restarted. For
+    | configuring these limits on your workers, see the next section.
+    |
+    */
+
+    'memory_limit' => 64,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Worker Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define the queue worker settings used by your application
+    | in all environments. These supervisors and settings handle all your
+    | queued jobs and will be provisioned by Horizon during deployment.
+    |
+    */
+
+    'defaults' => [
+        'default' => [
+            'connection' => 'redis',
+            'queue' => ['default'],
+            'balance' => 'auto',
+            'autoScalingStrategy' => 'time',
+            'maxProcesses' => 1,
+            'maxTime' => 0,
+            'maxJobs' => 0,
+            'memory' => 128,
+            'tries' => 3,
+            'timeout' => 60,
+            'nice' => 0,
+        ],
+        'webhooks' => [
+            'connection' => 'redis',
+            'queue' => ['webhooks'],
+            'balance' => 'auto',
+            'autoScalingStrategy' => 'time',
+            'maxProcesses' => 1,
+            'maxTime' => 0,
+            'maxJobs' => 0,
+            'memory' => 128,
+            'tries' => 10,
+            'timeout' => 30,
+            'nice' => 0,
+        ],
+    ],
+
+    'environments' => [
+        'production' => [
+            'default' => [
+                'maxProcesses' => 10,
+                'balanceMaxShift' => 1,
+                'balanceCooldown' => 3,
+            ],
+            'webhooks' => [
+                'maxProcesses' => 5,
+                'balanceMaxShift' => 1,
+                'balanceCooldown' => 3,
+            ],
+        ],
+
+        'local' => [
+            'default' => [
+                'maxProcesses' => 3,
+            ],
+            'webhooks' => [
+                'maxProcesses' => 2,
+            ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | File Watcher Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The following list of directories and files will be watched when using
+    | the `horizon:listen` command. Whenever any directories or files are
+    | changed, Horizon will automatically restart to apply all changes.
+    |
+    */
+
+    'watch' => [
+        'app',
+        'bootstrap',
+        'config/**/*.php',
+        'database/**/*.php',
+        'public/**/*.php',
+        'resources/**/*.php',
+        'routes',
+        'composer.lock',
+        'composer.json',
+        '.env',
+    ],
+];

--- a/config/queue.php
+++ b/config/queue.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'database'),
+    'default' => env('QUEUE_CONNECTION', 'redis'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/session.php
+++ b/config/session.php
@@ -18,7 +18,7 @@ return [
     |
     */
 
-    'driver' => env('SESSION_DRIVER', 'database'),
+    'driver' => env('SESSION_DRIVER', 'redis'),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Unit/Casts/PrefixedUlidTest.php
+++ b/tests/Unit/Casts/PrefixedUlidTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Casts\PrefixedUlid;
+use App\Support\Id;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Throwaway model anchoring the cast against a real Eloquent class.
+ */
+class PrefixedUlidCastTestModel extends Model
+{
+    protected $guarded = [];
+}
+
+it('passes a valid id through on get', function (): void {
+    $cast = new PrefixedUlid('user_');
+    $id = Id::generate('user_');
+
+    expect($cast->get(new PrefixedUlidCastTestModel, 'id', $id, []))->toBe($id);
+});
+
+it('passes a valid id through on set when the prefix matches', function (): void {
+    $cast = new PrefixedUlid('user_');
+    $id = Id::generate('user_');
+
+    expect($cast->set(new PrefixedUlidCastTestModel, 'id', $id, []))->toBe($id);
+});
+
+it('returns null on null', function (): void {
+    $cast = new PrefixedUlid('user_');
+
+    expect($cast->get(new PrefixedUlidCastTestModel, 'id', null, []))->toBeNull();
+    expect($cast->set(new PrefixedUlidCastTestModel, 'id', null, []))->toBeNull();
+});
+
+it('throws on get when the stored value is malformed', function (): void {
+    $cast = new PrefixedUlid('user_');
+
+    expect(fn () => $cast->get(new PrefixedUlidCastTestModel, 'id', 'not-an-id', []))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('throws on set when the prefix is wrong', function (): void {
+    $cast = new PrefixedUlid('user_');
+    $orgId = Id::generate('org_');
+
+    expect(fn () => $cast->set(new PrefixedUlidCastTestModel, 'id', $orgId, []))
+        ->toThrow(InvalidArgumentException::class, 'expects prefix "user_", got "org_"');
+});
+
+it('throws on set when the ULID portion is malformed', function (): void {
+    $cast = new PrefixedUlid('user_');
+
+    expect(fn () => $cast->set(new PrefixedUlidCastTestModel, 'id', 'user_short', []))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('accepts any registered prefix when no scope is configured', function (): void {
+    $cast = new PrefixedUlid;
+
+    $userId = Id::generate('user_');
+    $orgId = Id::generate('org_');
+
+    expect($cast->set(new PrefixedUlidCastTestModel, 'id', $userId, []))->toBe($userId);
+    expect($cast->set(new PrefixedUlidCastTestModel, 'id', $orgId, []))->toBe($orgId);
+});
+
+it('rejects an unregistered prefix even when no scope is configured', function (): void {
+    $cast = new PrefixedUlid;
+
+    expect(fn () => $cast->set(new PrefixedUlidCastTestModel, 'id', 'bogus_01HKX9SY9V7H7TF8C8K7J9X4ZB', []))
+        ->toThrow(InvalidArgumentException::class, 'Unknown id prefix');
+});

--- a/tests/Unit/Concerns/HasPrefixedUlidTest.php
+++ b/tests/Unit/Concerns/HasPrefixedUlidTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Concerns\HasPrefixedUlid;
+use App\Support\Id;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * Throwaway model exercising the trait against a real (in-memory) DB.
+ */
+class HasPrefixedUlidTestModel extends Model
+{
+    use HasPrefixedUlid;
+
+    protected $table = 'has_prefixed_ulid_test';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    protected string $idPrefix = 'user_';
+}
+
+class HasPrefixedUlidNoPrefixModel extends Model
+{
+    use HasPrefixedUlid;
+
+    protected $table = 'no_prefix_models';
+
+    public $timestamps = false;
+}
+
+beforeEach(function (): void {
+    Schema::create('has_prefixed_ulid_test', function ($table): void {
+        $table->string('id', 64)->primary();
+        $table->string('label')->nullable();
+    });
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('has_prefixed_ulid_test');
+});
+
+it('marks the primary key as a non-incrementing string', function (): void {
+    $m = new HasPrefixedUlidTestModel;
+
+    expect($m->getKeyType())->toBe('string');
+    expect($m->getIncrementing())->toBeFalse();
+});
+
+it('auto-generates a prefixed id on creating when none is set', function (): void {
+    $m = new HasPrefixedUlidTestModel(['label' => 'first']);
+    $m->save();
+
+    expect($m->getKey())->toStartWith('user_');
+    expect(Id::isValid($m->getKey()))->toBeTrue();
+});
+
+it('preserves a manually-set id on save', function (): void {
+    $manual = Id::generate('user_');
+    $m = new HasPrefixedUlidTestModel(['id' => $manual, 'label' => 'manual']);
+    $m->save();
+
+    expect($m->getKey())->toBe($manual);
+});
+
+it('throws when a model omits the idPrefix property', function (): void {
+    expect(fn () => new HasPrefixedUlidNoPrefixModel)
+        ->toThrow(LogicException::class, 'must declare a non-empty `protected string $idPrefix`');
+});
+
+it('rejects setting the id with the wrong prefix via the cast', function (): void {
+    $m = new HasPrefixedUlidTestModel;
+    $orgId = Id::generate('org_');
+
+    expect(fn () => $m->setAttribute('id', $orgId))
+        ->toThrow(InvalidArgumentException::class, 'expects prefix "user_"');
+});

--- a/tests/Unit/Support/IdTest.php
+++ b/tests/Unit/Support/IdTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Id;
+
+it('generates a 30-character prefixed ULID', function (): void {
+    $id = Id::generate('user_');
+
+    expect($id)->toStartWith('user_')->and(strlen($id))->toBe(31);
+    expect(Id::isValid($id))->toBeTrue();
+});
+
+it('round-trips a generated id through parse', function (): void {
+    $id = Id::generate('org_');
+    ['prefix' => $prefix, 'ulid' => $ulid] = Id::parse($id);
+
+    expect($prefix)->toBe('org_');
+    expect(strlen($ulid))->toBe(26);
+    expect($ulid)->toMatch('/^[0-9A-HJKMNP-TV-Z]{26}$/');
+});
+
+it('generates monotonically distinct ids for the same prefix', function (): void {
+    $ids = collect(range(1, 100))->map(fn () => Id::generate('sess_'));
+
+    expect($ids->unique())->toHaveCount(100);
+});
+
+it('rejects unknown prefixes on generate', function (): void {
+    expect(fn () => Id::generate('bogus_'))
+        ->toThrow(InvalidArgumentException::class, 'Unknown id prefix: bogus_');
+});
+
+it('rejects unknown prefixes on parse', function (): void {
+    expect(fn () => Id::parse('bogus_01HKX9SY9V7H7TF8C8K7J9X4ZB'))
+        ->toThrow(InvalidArgumentException::class, 'Unknown id prefix: bogus_');
+});
+
+it('rejects ids without an underscore', function (): void {
+    expect(fn () => Id::parse('userwithoutunderscore'))
+        ->toThrow(InvalidArgumentException::class, 'Malformed id (no prefix)');
+});
+
+it('rejects ids with a malformed ULID portion', function (): void {
+    expect(fn () => Id::parse('user_short'))
+        ->toThrow(InvalidArgumentException::class, 'Malformed ULID portion');
+});
+
+it('isValid returns false instead of throwing', function (): void {
+    expect(Id::isValid('not-an-id'))->toBeFalse();
+    expect(Id::isValid('bogus_01HKX9SY9V7H7TF8C8K7J9X4ZB'))->toBeFalse();
+    expect(Id::isValid(Id::generate('user_')))->toBeTrue();
+});


### PR DESCRIPTION
## Summary

Lays the foundational infrastructure every later v0.1 issue relies on. Empty of domain logic on purpose.

- **Database** — defaults to PostgreSQL 16 (CI uses a service container; tests use in-memory SQLite for hermeticity). `composer.json` requires `ext-pdo_pgsql` and `ext-redis`.
- **Redis** — backs cache, session, queue, locks. `.env.example` documented end-to-end.
- **Horizon** — installed and configured with two named supervisors: `default` (3 retries, 60s timeout) and `webhooks` (10 retries, 30s timeout). Per-environment process counts wired for `production` and `local`. Non-local access denied until operator auth lands in AU-17.
- **Prefixed-ULID infra** — `App\Support\IdPrefix` (registry from PLAN §5) + `App\Support\Id` (generate/parse/isValid) + `App\Casts\PrefixedUlid` (CastsAttributes) + `App\Concerns\HasPrefixedUlid` trait (auto-generates id on creating, refuses wrong prefix on set).
- **Tests** — 21 Pest unit tests across the three new namespaces; trait test uses an ephemeral SQLite table for an end-to-end save round-trip.
- **CI** — `.github/workflows/ci.yml` spins up Postgres 16 + Redis 7, runs `pint --test`, runs migrations against Postgres, then `php artisan test`.

Closes #1.

## Test plan

- [x] \`php artisan test\` — 23/23 green locally.
- [x] \`vendor/bin/pint --test\` — clean.
- [x] \`Authn\\Support\\Id::generate('prj_')\` round-trips through \`parse()\`.
- [x] At least one model uses the trait end-to-end (\`HasPrefixedUlidTestModel\` in tests).
- [x] \`config('horizon.defaults')\` returns \`['default', 'webhooks']\` with the right queue mapping.
- [ ] CI green on the merge commit (verify after push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)