### PR TITLE
Routing modes (subdomain + path), host dispatcher, ResolveProjectFromHost

### DIFF
--- a/app/Http/Controllers/Bapi/PingController.php
+++ b/app/Http/Controllers/Bapi/PingController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Models\Environment;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Placeholder BAPI handler. Confirms the request was dispatched into the
+ * BAPI route group and that AuthenticateBapiKey resolved an environment.
+ * Real BAPI endpoints land in AU-13.
+ */
+final class PingController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        return response()->json([
+            'status' => 'ok',
+            'surface' => 'bapi',
+            'environment_id' => $env->id,
+            'project_id' => $env->project_id,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Dashboard/PingController.php
+++ b/app/Http/Controllers/Dashboard/PingController.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Dashboard;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Placeholder Dashboard handler. Real Dashboard pages land in AU-17.
+ */
+final class PingController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        return response()->json([
+            'status' => 'ok',
+            'surface' => 'dashboard',
+        ]);
+    }
+}

--- a/app/Http/Controllers/Fapi/PingController.php
+++ b/app/Http/Controllers/Fapi/PingController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Models\Environment;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Placeholder FAPI handler. Confirms the request was dispatched into the
+ * FAPI route group and that ResolveProjectFromHost resolved an environment.
+ * Real FAPI endpoints land in AU-8 / AU-9 / AU-10 / AU-11 / AU-12.
+ */
+final class PingController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        return response()->json([
+            'status' => 'ok',
+            'surface' => 'fapi',
+            'environment_id' => $env->id,
+            'environment_slug' => $env->slug,
+            'project_id' => $env->project_id,
+        ]);
+    }
+}

--- a/app/Http/Middleware/AuthenticateBapiKey.php
+++ b/app/Http/Middleware/AuthenticateBapiKey.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\ApiKey;
+use App\Models\Environment;
+use App\Models\Project;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Authenticates BAPI requests with an `Authorization: Bearer sk_…` header.
+ *
+ * Skeleton in AU-3:
+ *   - Resolves the ApiKey by SHA-256 hash.
+ *   - 401s on missing / unknown / revoked keys.
+ *   - Binds the resolved Environment + Project into the container.
+ *   - Updates `last_used_at` at most once per minute per key (Redis-backed
+ *     debounce).
+ *
+ * AU-13 layers idempotency, rate-limit accounting, and the
+ * `created_by_user_id` audit trail on top.
+ */
+final class AuthenticateBapiKey
+{
+    /**
+     * Cache key prefix for the per-key `last_used_at` debounce.
+     */
+    private const TOUCH_CACHE_PREFIX = 'apikey:touch:';
+
+    /** Debounce window for `last_used_at` writes (seconds). */
+    private const TOUCH_DEBOUNCE_SECONDS = 60;
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $token = $this->extractBearer($request);
+        if ($token === null) {
+            return $this->unauthorized('authentication_invalid', 'Missing Authorization header.');
+        }
+
+        if (! str_starts_with($token, 'sk_test_') && ! str_starts_with($token, 'sk_live_')) {
+            return $this->unauthorized('authentication_invalid', 'Authorization token is not a secret key.');
+        }
+
+        $hash = hash('sha256', $token);
+        $apiKey = ApiKey::query()
+            ->with('environment.project')
+            ->where('hashed_secret', $hash)
+            ->whereNull('revoked_at')
+            ->where('kind', ApiKey::KIND_SECRET)
+            ->first();
+
+        if ($apiKey === null) {
+            return $this->unauthorized('authentication_invalid', 'Unknown or revoked secret key.');
+        }
+
+        $this->touch($apiKey);
+
+        app()->instance(Environment::class, $apiKey->environment);
+        app()->instance(Project::class, $apiKey->environment->project);
+        app()->instance(ApiKey::class, $apiKey);
+
+        return $next($request);
+    }
+
+    private function extractBearer(Request $request): ?string
+    {
+        $header = $request->header('Authorization');
+        if (! is_string($header)) {
+            return null;
+        }
+
+        if (! preg_match('/^Bearer\s+(\S+)$/i', $header, $matches)) {
+            return null;
+        }
+
+        return $matches[1];
+    }
+
+    /**
+     * Update `last_used_at` at most once per minute per key. The cached
+     * sentinel acts as the debounce — if it's still present we skip the
+     * UPDATE, otherwise we set it (TTL = debounce window) and write.
+     */
+    private function touch(ApiKey $apiKey): void
+    {
+        $cacheKey = self::TOUCH_CACHE_PREFIX.$apiKey->id;
+
+        if (! Cache::add($cacheKey, 1, self::TOUCH_DEBOUNCE_SECONDS)) {
+            return;
+        }
+
+        $apiKey->forceFill(['last_used_at' => now()])->saveQuietly();
+    }
+
+    private function unauthorized(string $code, string $message): Response
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message.' Issue or rotate a secret key in the dashboard and pass it as `Authorization: Bearer <secret>`.',
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], 401);
+    }
+}

--- a/app/Http/Middleware/ResolveProjectFromHost.php
+++ b/app/Http/Middleware/ResolveProjectFromHost.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\Environment;
+use App\Models\Project;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Resolves the active Project + Environment for FAPI / Account Portal
+ * requests and binds them into the container as singletons. Downstream
+ * handlers read them via `app(Environment::class)` / `app(Project::class)`.
+ *
+ * Subdomain mode: the FAPI host is the leading subdomain label of the
+ *   request host. Look up the Environment by `frontend_api_host`.
+ * Path mode: the slug is the first path segment after the application
+ *   host. Look up the Environment by `slug`. The segment is left in the
+ *   request URI so route definitions like `/{env_slug}/v1/...` can still
+ *   match (Laravel's router handles the binding).
+ *
+ * On a reserved label or an unresolved env slug we 404 with the standard
+ * `errors[]` envelope using `code = environment_not_found`.
+ */
+final class ResolveProjectFromHost
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $slug = $this->extractEnvSlug($request);
+
+        if ($slug === null || $this->isReserved($slug)) {
+            return $this->notFound();
+        }
+
+        $environment = $this->resolveEnvironment($request, $slug);
+
+        if ($environment === null) {
+            return $this->notFound();
+        }
+
+        app()->instance(Environment::class, $environment);
+        app()->instance(Project::class, $environment->project);
+
+        return $next($request);
+    }
+
+    private function extractEnvSlug(Request $request): ?string
+    {
+        if ((string) config('authn.routing_mode') === 'subdomain') {
+            $host = $request->getHost();
+            $appHost = (string) config('authn.app_host');
+            $suffix = '.'.$appHost;
+
+            if (! str_ends_with($host, $suffix)) {
+                return null;
+            }
+
+            $label = substr($host, 0, -strlen($suffix));
+
+            return $label === '' ? null : $label;
+        }
+
+        // Path mode: first segment after the leading slash.
+        $segments = explode('/', ltrim($request->path(), '/'));
+        $first = $segments[0] ?? '';
+
+        return $first === '' ? null : $first;
+    }
+
+    private function isReserved(string $slug): bool
+    {
+        $reserved = (array) config('authn.reserved_env_slugs', []);
+
+        return in_array($slug, $reserved, true);
+    }
+
+    private function resolveEnvironment(Request $request, string $slug): ?Environment
+    {
+        $query = Environment::query()->with('project');
+
+        if ((string) config('authn.routing_mode') === 'subdomain') {
+            return $query->where('frontend_api_host', $request->getHost())->first();
+        }
+
+        return $query->where('slug', $slug)->first();
+    }
+
+    private function notFound(): Response
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => 'environment_not_found',
+                'message' => 'No environment matches this host.',
+                'long_message' => 'The host or env slug supplied in this request does not match any environment in this installation. If you control the environment, double-check that its frontend_api_host (subdomain mode) or slug (path mode) is set correctly.',
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], 404);
+    }
+}

--- a/app/Models/Environment.php
+++ b/app/Models/Environment.php
@@ -42,6 +42,7 @@ class Environment extends Model
     protected $fillable = [
         'project_id',
         'kind',
+        'slug',
         'frontend_api_host',
         'dashboard_url',
         'home_url',

--- a/app/Services/Tenancy/BootstrapService.php
+++ b/app/Services/Tenancy/BootstrapService.php
@@ -62,20 +62,25 @@ final class BootstrapService
             throw new InvalidArgumentException("Bootstrap admin email is not a valid email address: {$email}");
         }
 
-        $host = parse_url((string) $appUrl, PHP_URL_HOST) ?: 'localhost';
+        $appHost = parse_url((string) $appUrl, PHP_URL_HOST) ?: (string) config('authn.app_host', 'localhost');
+        $routingMode = (string) config('authn.routing_mode', 'subdomain');
 
-        return DB::transaction(function () use ($email, $password, $workspaceName, $host): array {
+        return DB::transaction(function () use ($email, $password, $workspaceName, $appHost, $routingMode): array {
             $project = Project::create([
                 'name' => 'authn.sh admin',
                 'slug' => Project::SYSTEM_SLUG,
                 'is_system' => true,
             ]);
 
+            $envSlug = Project::SYSTEM_SLUG;
+            $fapiHost = $routingMode === 'subdomain' ? $envSlug.'.'.$appHost : $appHost;
+
             $environment = Environment::create([
                 'project_id' => $project->id,
                 'kind' => Environment::KIND_PRODUCTION,
-                'frontend_api_host' => $host,
-                'home_url' => sprintf('https://%s', $host),
+                'slug' => $envSlug,
+                'frontend_api_host' => $fapiHost,
+                'home_url' => sprintf('https://%s', $appHost),
                 'allowed_origins' => [],
                 'appearance' => [],
             ]);

--- a/app/Support/Url.php
+++ b/app/Support/Url.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Models\Environment;
+
+/**
+ * Generates routing-mode-aware URLs for the four authn.sh surfaces:
+ * BAPI, Dashboard, FAPI, and Account Portal.
+ *
+ * Reads its inputs from `config('authn.*')` so a request never picks up
+ * unexpected env-var values mid-flight.
+ */
+final class Url
+{
+    public static function bapi(string $path = ''): string
+    {
+        return self::buildUrl((string) config('authn.bapi_host'), self::normalisePath(self::bapiPathPrefix(), $path));
+    }
+
+    public static function dashboard(string $path = ''): string
+    {
+        return self::buildUrl((string) config('authn.dashboard_host'), self::normalisePath(self::dashboardPathPrefix(), $path));
+    }
+
+    public static function fapi(Environment $environment, string $path = ''): string
+    {
+        $mode = (string) config('authn.routing_mode');
+        if ($mode === 'subdomain') {
+            return self::buildUrl($environment->frontend_api_host, self::normalisePath('', $path));
+        }
+
+        return self::buildUrl((string) config('authn.app_host'), self::normalisePath('/'.$environment->slug, $path));
+    }
+
+    public static function accountPortal(Environment $environment, string $path = ''): string
+    {
+        $mode = (string) config('authn.routing_mode');
+        if ($mode === 'subdomain') {
+            // Account Portal shares the FAPI host; routes are at the host root, not /v1.
+            return self::buildUrl($environment->frontend_api_host, self::normalisePath('', $path));
+        }
+
+        return self::buildUrl((string) config('authn.app_host'), self::normalisePath('/'.$environment->slug.'/account', $path));
+    }
+
+    /**
+     * Path prefix that BAPI routes are registered under. Empty string in
+     * subdomain mode (the host alone identifies BAPI); `/api` in path mode.
+     */
+    public static function bapiPathPrefix(): string
+    {
+        return config('authn.routing_mode') === 'path' ? '/api' : '';
+    }
+
+    public static function dashboardPathPrefix(): string
+    {
+        return config('authn.routing_mode') === 'path' ? '/dashboard' : '';
+    }
+
+    private static function buildUrl(string $host, string $path): string
+    {
+        $scheme = (string) config('authn.app_scheme', 'https');
+        $portSuffix = (string) config('authn.app_port_suffix', '');
+
+        return $scheme.'://'.$host.$portSuffix.$path;
+    }
+
+    private static function normalisePath(string $prefix, string $path): string
+    {
+        $path = '/'.ltrim($path, '/');
+        if ($path === '/') {
+            $path = '';
+        }
+
+        $prefix = rtrim($prefix, '/');
+
+        return $prefix.$path;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,17 +1,68 @@
 <?php
 
+use App\Http\Middleware\AuthenticateBapiKey;
+use App\Http\Middleware\ResolveProjectFromHost;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Support\Facades\Route;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
+        then: function (): void {
+            // The three authn.sh surfaces dispatch by host (subdomain mode) or by
+            // path prefix (path mode), driven by `config('authn.routing_mode')`.
+            // Order matters: BAPI and Dashboard register first so their host /
+            // prefix bindings win against the FAPI catch-all.
+            $routingMode = (string) config('authn.routing_mode', 'subdomain');
+            $bapiHost = (string) config('authn.bapi_host');
+            $dashboardHost = (string) config('authn.dashboard_host');
+            $appHost = (string) config('authn.app_host');
+
+            // -------- BAPI --------
+            $bapi = Route::middleware('bapi')->prefix('v1');
+            if ($routingMode === 'subdomain') {
+                $bapi->domain($bapiHost);
+            } else {
+                $bapi->prefix('api/v1');
+            }
+            $bapi->group(__DIR__.'/../routes/bapi.php');
+
+            // -------- Dashboard --------
+            $dashboard = Route::middleware('dashboard');
+            if ($routingMode === 'subdomain') {
+                $dashboard->domain($dashboardHost);
+            } else {
+                $dashboard->prefix('dashboard');
+            }
+            $dashboard->group(__DIR__.'/../routes/dashboard.php');
+
+            // -------- FAPI + Account Portal --------
+            $fapi = Route::middleware('fapi');
+            if ($routingMode === 'subdomain') {
+                // Wildcard subdomain capture; the env slug arrives as
+                // `{env_slug}` route parameter for any consumer that wants it.
+                $fapi->domain('{env_slug}.'.$appHost);
+            } else {
+                $fapi->prefix('{env_slug}');
+            }
+            $fapi->group(__DIR__.'/../routes/fapi.php');
+        },
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->group('bapi', [
+            AuthenticateBapiKey::class,
+        ]);
+
+        $middleware->group('dashboard', [
+            // Operator auth lands in AU-17.
+        ]);
+
+        $middleware->group('fapi', [
+            ResolveProjectFromHost::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/authn.php
+++ b/config/authn.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+|--------------------------------------------------------------------------
+| authn.sh configuration
+|--------------------------------------------------------------------------
+|
+| Per-installation knobs that don't fit elsewhere. Values are read from env
+| at boot and computed once into the config repository — request-time code
+| reads from `config('authn.*')`, never directly from `env()`.
+|
+| See PLAN §6 for the full routing-mode discussion.
+*/
+
+$rawAppUrl = env('AUTHN_APP_URL', env('APP_URL', 'http://localhost'));
+$appHost = parse_url((string) $rawAppUrl, PHP_URL_HOST) ?: 'localhost';
+$scheme = parse_url((string) $rawAppUrl, PHP_URL_SCHEME) ?: 'https';
+$port = parse_url((string) $rawAppUrl, PHP_URL_PORT);
+$portSuffix = $port !== null ? ':'.$port : '';
+
+$routingMode = env('AUTHN_ROUTING_MODE', 'subdomain');
+if (! in_array($routingMode, ['subdomain', 'path'], true)) {
+    $routingMode = 'subdomain';
+}
+
+return [
+
+    /*
+    |----------------------------------------------------------------------
+    | Routing mode
+    |----------------------------------------------------------------------
+    |
+    | `subdomain` (default for hosted authn.sh)
+    |   Each surface lives on its own host:
+    |     api.{app_host}             — BAPI
+    |     dashboard.{app_host}       — Dashboard
+    |     {env_slug}.{app_host}      — FAPI + Account Portal
+    |   Requires wildcard DNS + wildcard TLS (PLAN §17.3).
+    |
+    | `path` (recommended self-host default)
+    |   Everything lives on a single host, distinguished by URL prefix:
+    |     {app_host}/api/v1/...      — BAPI
+    |     {app_host}/dashboard/...   — Dashboard
+    |     {app_host}/{env_slug}/v1   — FAPI
+    |     {app_host}/{env_slug}/account — Account Portal
+    |   No wildcard DNS needed.
+    */
+
+    'routing_mode' => $routingMode,
+
+    /*
+    |----------------------------------------------------------------------
+    | Application URL host
+    |----------------------------------------------------------------------
+    |
+    | The canonical hostname of this authn.sh installation. Subdomain mode
+    | uses this as the base of every generated URL; path mode uses it as
+    | the single host. Pulled from AUTHN_APP_URL (falling back to APP_URL).
+    */
+
+    'app_host' => $appHost,
+    'app_scheme' => $scheme,
+    'app_port_suffix' => $portSuffix,
+
+    /*
+    |----------------------------------------------------------------------
+    | Derived hostnames
+    |----------------------------------------------------------------------
+    |
+    | These are the values code uses at routing dispatch time. Centralised
+    | here so the dispatcher and the URL helpers (App\Support\Url) agree.
+    */
+
+    'bapi_host' => $routingMode === 'subdomain' ? 'api.'.$appHost : $appHost,
+    'dashboard_host' => $routingMode === 'subdomain' ? 'dashboard.'.$appHost : $appHost,
+
+    /*
+    |----------------------------------------------------------------------
+    | Reserved env-slug labels
+    |----------------------------------------------------------------------
+    |
+    | Labels that customers cannot use as their environment slug because
+    | they collide with a system surface or a non-tenant subdomain. Routing
+    | dispatch refuses them up front so we don't even hit the DB.
+    |
+    | `_admin` is the legitimate slug of the system project's environment;
+    | it is NOT in this list — it resolves like any other env slug.
+    */
+
+    'reserved_env_slugs' => [
+        'api', 'dashboard', 'docs', 'site', 'www', 'mail', 'admin',
+        'status', 'help', 'support', 'blog', 'cdn', 'static', 'assets',
+        'horizon', 'health', 'up',
+    ],
+
+];

--- a/database/migrations/0003_01_01_000000_add_slug_to_environments.php
+++ b/database/migrations/0003_01_01_000000_add_slug_to_environments.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds the routing-time `slug` column to environments and drops the
+ * uniqueness on `frontend_api_host`.
+ *
+ * - In subdomain mode, every env has a unique full host (`acme.authn.sh`)
+ *   AND a slug (`acme`); both are derivable from each other.
+ * - In path mode, every env shares the same `frontend_api_host`
+ *   (`authn.sh`) — uniqueness moves to the slug, which is the path
+ *   segment used to dispatch requests to FAPI.
+ *
+ * The slug is the global routing identity in both modes. It must be
+ * unique across the whole installation.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('environments', function (Blueprint $table): void {
+            $table->dropUnique(['frontend_api_host']);
+            $table->string('slug', 64)->after('kind');
+        });
+
+        Schema::table('environments', function (Blueprint $table): void {
+            $table->unique('slug');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('environments', function (Blueprint $table): void {
+            $table->dropUnique(['slug']);
+            $table->dropColumn('slug');
+            $table->unique('frontend_api_host');
+        });
+    }
+};

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Bapi\PingController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Backend API (BAPI) routes
+|--------------------------------------------------------------------------
+|
+| Server-to-server endpoints. Authenticated by `Authorization: Bearer sk_…`.
+|
+| The route loader in bootstrap/app.php nests these under `/v1` and pins
+| them to the BAPI host (subdomain mode) or `/api` prefix (path mode).
+|
+| Real endpoints land in AU-13. The single placeholder route below confirms
+| the route group is wired up end-to-end.
+*/
+
+Route::get('/_ping', PingController::class)->name('bapi.ping');

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Dashboard\PingController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Dashboard routes
+|--------------------------------------------------------------------------
+|
+| Operator UI. Pinned to the Dashboard host (subdomain mode) or `/dashboard`
+| prefix (path mode). Auth lands in AU-17 (RequireAdminSession).
+*/
+
+Route::get('/_ping', PingController::class)->name('dashboard.ping');

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Fapi\PingController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Frontend API (FAPI) + Account Portal routes
+|--------------------------------------------------------------------------
+|
+| Browser-facing. The route loader in bootstrap/app.php nests these:
+|   subdomain mode — host = `*.{app_host}`, prefix per-group (`/v1`, ``)
+|   path mode      — prefix = `/{env_slug}/v1` for FAPI,
+|                              `/{env_slug}/account` for Account Portal
+|
+| Real endpoints land in AU-8 / AU-9 / AU-10 / AU-11 / AU-12 (FAPI) and
+| AU-16 (Account Portal). The placeholders below confirm the route group
+| is wired up end-to-end.
+*/
+
+Route::prefix('v1')->group(function (): void {
+    Route::get('/_ping', PingController::class)->name('fapi.ping');
+});
+
+Route::prefix('account')->group(function (): void {
+    Route::get('/_ping', PingController::class)->name('account_portal.ping');
+});

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,7 +1,0 @@
-<?php
-
-test('the application returns a successful response', function () {
-    $response = $this->get('/');
-
-    $response->assertStatus(200);
-});

--- a/tests/Feature/Http/AuthenticateBapiKeyTest.php
+++ b/tests/Feature/Http/AuthenticateBapiKeyTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ApiKey;
+use App\Models\Environment;
+use App\Services\Tenancy\BootstrapService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
+
+uses(RefreshDatabase::class);
+
+function reloadBapiRoutes(): void
+{
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+
+    $routingMode = (string) config('authn.routing_mode', 'subdomain');
+    $bapiHost = (string) config('authn.bapi_host');
+
+    $bapi = Route::middleware('bapi')->prefix('v1');
+    if ($routingMode === 'subdomain') {
+        $bapi->domain($bapiHost);
+    } else {
+        $bapi->prefix('api/v1');
+    }
+    $bapi->group(base_path('routes/bapi.php'));
+}
+
+function plantBootstrap(): array
+{
+    config([
+        'app.url' => 'https://authn.local',
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.bapi_host' => 'api.authn.local',
+    ]);
+    reloadBapiRoutes();
+
+    $service = app(BootstrapService::class);
+    $service->run([
+        'admin_email' => 'op@example.com',
+        'admin_password' => 'super-secret',
+        'workspace_name' => 'Acme Inc',
+        'app_url' => 'https://authn.local',
+    ]);
+
+    $env = Environment::firstOrFail();
+    $apiKey = ApiKey::where('environment_id', $env->id)
+        ->where('kind', ApiKey::KIND_SECRET)
+        ->firstOrFail();
+
+    $plaintext = 'sk_live_'.str_repeat('z', 32);
+    $apiKey->forceFill(['hashed_secret' => hash('sha256', $plaintext), 'last_used_at' => null])->saveQuietly();
+
+    Cache::flush();
+
+    return ['apiKey' => $apiKey->fresh(), 'plaintext' => $plaintext];
+}
+
+it('debounces last_used_at updates to once per minute', function (): void {
+    ['apiKey' => $apiKey, 'plaintext' => $plaintext] = plantBootstrap();
+
+    expect($apiKey->last_used_at)->toBeNull();
+
+    $this->withHeaders([
+        'Authorization' => 'Bearer '.$plaintext,
+        'Host' => 'api.authn.local',
+    ])->getJson('http://api.authn.local/v1/_ping')->assertOk();
+
+    $first = $apiKey->fresh()->last_used_at;
+    expect($first)->not->toBeNull();
+
+    // Second call within the debounce window: last_used_at should NOT advance.
+    $this->withHeaders([
+        'Authorization' => 'Bearer '.$plaintext,
+        'Host' => 'api.authn.local',
+    ])->getJson('http://api.authn.local/v1/_ping')->assertOk();
+
+    $second = $apiKey->fresh()->last_used_at;
+    expect($second->equalTo($first))->toBeTrue();
+});
+
+it('returns 401 when the bearer token is missing', function (): void {
+    plantBootstrap();
+
+    $this->withHeader('Host', 'api.authn.local')
+        ->getJson('http://api.authn.local/v1/_ping')
+        ->assertUnauthorized()
+        ->assertJsonPath('errors.0.code', 'authentication_invalid');
+});
+
+it('returns 401 when the bearer token does not match any api_key', function (): void {
+    plantBootstrap();
+
+    $this->withHeaders([
+        'Authorization' => 'Bearer sk_live_'.str_repeat('q', 32),
+        'Host' => 'api.authn.local',
+    ])
+        ->getJson('http://api.authn.local/v1/_ping')
+        ->assertUnauthorized()
+        ->assertJsonPath('errors.0.code', 'authentication_invalid');
+});
+
+it('returns 401 for a revoked api_key', function (): void {
+    ['apiKey' => $apiKey, 'plaintext' => $plaintext] = plantBootstrap();
+    $apiKey->forceFill(['revoked_at' => now()])->saveQuietly();
+
+    $this->withHeaders([
+        'Authorization' => 'Bearer '.$plaintext,
+        'Host' => 'api.authn.local',
+    ])
+        ->getJson('http://api.authn.local/v1/_ping')
+        ->assertUnauthorized();
+});
+
+it('refuses publishable keys at the BAPI bearer slot', function (): void {
+    plantBootstrap();
+    // A publishable key's plaintext is pk_*; ApiKey's `kind` filter ensures
+    // we don't accept them here.
+    $this->withHeaders([
+        'Authorization' => 'Bearer pk_live_'.str_repeat('p', 32),
+        'Host' => 'api.authn.local',
+    ])
+        ->getJson('http://api.authn.local/v1/_ping')
+        ->assertUnauthorized();
+});

--- a/tests/Feature/Routing/RoutingDispatchTest.php
+++ b/tests/Feature/Routing/RoutingDispatchTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ApiKey;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Services\Tenancy\BootstrapService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Reload the route stack against the current routing-mode config. Pest
+ * tests share an Application instance per test, but the route loader runs
+ * at boot — so we re-register all four groups manually after flipping the
+ * config.
+ */
+function reloadRoutes(): void
+{
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+
+    $routingMode = (string) config('authn.routing_mode', 'subdomain');
+    $bapiHost = (string) config('authn.bapi_host');
+    $dashboardHost = (string) config('authn.dashboard_host');
+    $appHost = (string) config('authn.app_host');
+
+    $bapi = Route::middleware('bapi')->prefix('v1');
+    if ($routingMode === 'subdomain') {
+        $bapi->domain($bapiHost);
+    } else {
+        $bapi->prefix('api/v1');
+    }
+    $bapi->group(base_path('routes/bapi.php'));
+
+    $dashboard = Route::middleware('dashboard');
+    if ($routingMode === 'subdomain') {
+        $dashboard->domain($dashboardHost);
+    } else {
+        $dashboard->prefix('dashboard');
+    }
+    $dashboard->group(base_path('routes/dashboard.php'));
+
+    $fapi = Route::middleware('fapi');
+    if ($routingMode === 'subdomain') {
+        $fapi->domain('{env_slug}.'.$appHost);
+    } else {
+        $fapi->prefix('{env_slug}');
+    }
+    $fapi->group(base_path('routes/fapi.php'));
+}
+
+function bootstrapRoutingFixture(): array
+{
+    config(['app.url' => 'https://authn.local']);
+
+    $service = app(BootstrapService::class);
+    $result = $service->run([
+        'admin_email' => 'op@example.com',
+        'admin_password' => 'super-secret',
+        'workspace_name' => 'Acme Inc',
+        'app_url' => 'https://authn.local',
+    ]);
+
+    expect($result)->not->toBeNull();
+
+    return $result;
+}
+
+function makeCustomerEnvironment(string $slug, string $kind = 'production'): Environment
+{
+    $project = Project::create([
+        'owner_organization_id' => null,
+        'name' => 'Customer '.$slug,
+        'slug' => 'customer-'.$slug,
+    ]);
+
+    $appHost = (string) config('authn.app_host');
+    $fapiHost = (string) config('authn.routing_mode') === 'subdomain'
+        ? $slug.'.'.$appHost
+        : $appHost;
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => $kind,
+        'slug' => $slug,
+        'frontend_api_host' => $fapiHost,
+    ]);
+}
+
+/* ------------------------------------------------------------------ subdomain mode */
+
+describe('subdomain mode', function (): void {
+    beforeEach(function (): void {
+        config([
+            'authn.routing_mode' => 'subdomain',
+            'authn.app_host' => 'authn.local',
+            'authn.bapi_host' => 'api.authn.local',
+            'authn.dashboard_host' => 'dashboard.authn.local',
+        ]);
+        reloadRoutes();
+    });
+
+    it('routes api.{app_host} → BAPI ping', function (): void {
+        bootstrapRoutingFixture();
+
+        // Bootstrap created an api key; resolve the secret and use it.
+        $env = Environment::firstOrFail();
+        $apiKey = ApiKey::where('environment_id', $env->id)
+            ->where('kind', ApiKey::KIND_SECRET)
+            ->firstOrFail();
+
+        // The plaintext is not stored — we have to mint one for testing
+        // by manufacturing a fresh sk_live_… token whose hash we plant
+        // into the row, then issuing it as the bearer.
+        $plaintext = 'sk_live_'.str_repeat('a', 32);
+        $apiKey->forceFill(['hashed_secret' => hash('sha256', $plaintext)])->saveQuietly();
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$plaintext,
+            'Host' => 'api.authn.local',
+        ])->getJson('http://api.authn.local/v1/_ping');
+
+        $response->assertOk()->assertJson([
+            'status' => 'ok',
+            'surface' => 'bapi',
+        ]);
+    });
+
+    it('routes dashboard.{app_host} → Dashboard ping', function (): void {
+        $response = $this->withHeader('Host', 'dashboard.authn.local')
+            ->getJson('http://dashboard.authn.local/_ping');
+
+        $response->assertOk()->assertJson([
+            'status' => 'ok',
+            'surface' => 'dashboard',
+        ]);
+    });
+
+    it('routes {env_slug}.{app_host} → FAPI ping with the resolved env', function (): void {
+        bootstrapRoutingFixture();
+        makeCustomerEnvironment('acme');
+
+        $response = $this->withHeader('Host', 'acme.authn.local')
+            ->getJson('http://acme.authn.local/v1/_ping');
+
+        $response->assertOk()->assertJson([
+            'status' => 'ok',
+            'surface' => 'fapi',
+            'environment_slug' => 'acme',
+        ]);
+    });
+
+    it('returns 404 environment_not_found for an unknown env subdomain', function (): void {
+        bootstrapRoutingFixture();
+
+        $response = $this->withHeader('Host', 'ghost.authn.local')
+            ->getJson('http://ghost.authn.local/v1/_ping');
+
+        $response->assertNotFound()->assertJsonPath('errors.0.code', 'environment_not_found');
+    });
+
+    it('returns 404 for reserved env-slug subdomains', function (): void {
+        $reserved = config('authn.reserved_env_slugs', []);
+        expect($reserved)->toContain('docs');
+
+        $response = $this->withHeader('Host', 'docs.authn.local')
+            ->getJson('http://docs.authn.local/v1/_ping');
+
+        $response->assertNotFound()->assertJsonPath('errors.0.code', 'environment_not_found');
+    });
+
+    it('routes the Account Portal at {env_slug}.{app_host}/account', function (): void {
+        bootstrapRoutingFixture();
+        makeCustomerEnvironment('beta');
+
+        $response = $this->withHeader('Host', 'beta.authn.local')
+            ->getJson('http://beta.authn.local/account/_ping');
+
+        $response->assertOk()->assertJson([
+            'environment_slug' => 'beta',
+        ]);
+    });
+});
+
+/* ------------------------------------------------------------------ path mode */
+
+describe('path mode', function (): void {
+    beforeEach(function (): void {
+        config([
+            'authn.routing_mode' => 'path',
+            'authn.app_host' => 'authn.local',
+            'authn.bapi_host' => 'authn.local',
+            'authn.dashboard_host' => 'authn.local',
+        ]);
+        reloadRoutes();
+    });
+
+    it('routes /api/v1/_ping → BAPI', function (): void {
+        bootstrapRoutingFixture();
+
+        $env = Environment::firstOrFail();
+        $apiKey = ApiKey::where('environment_id', $env->id)
+            ->where('kind', ApiKey::KIND_SECRET)
+            ->firstOrFail();
+        $plaintext = 'sk_test_'.str_repeat('b', 32);
+        $apiKey->forceFill(['hashed_secret' => hash('sha256', $plaintext)])->saveQuietly();
+
+        $response = $this->withHeader('Authorization', 'Bearer '.$plaintext)
+            ->getJson('http://authn.local/api/v1/_ping');
+
+        $response->assertOk()->assertJson(['surface' => 'bapi']);
+    });
+
+    it('routes /dashboard/_ping → Dashboard', function (): void {
+        $this->getJson('http://authn.local/dashboard/_ping')
+            ->assertOk()
+            ->assertJson(['surface' => 'dashboard']);
+    });
+
+    it('routes /{env_slug}/v1/_ping → FAPI', function (): void {
+        bootstrapRoutingFixture();
+        makeCustomerEnvironment('gamma');
+
+        $this->getJson('http://authn.local/gamma/v1/_ping')
+            ->assertOk()
+            ->assertJson([
+                'surface' => 'fapi',
+                'environment_slug' => 'gamma',
+            ]);
+    });
+
+    it('returns 404 for an unknown env-slug path segment', function (): void {
+        $this->getJson('http://authn.local/nope/v1/_ping')
+            ->assertNotFound()
+            ->assertJsonPath('errors.0.code', 'environment_not_found');
+    });
+
+    it('routes /{env_slug}/account/_ping → Account Portal', function (): void {
+        bootstrapRoutingFixture();
+        makeCustomerEnvironment('delta');
+
+        $this->getJson('http://authn.local/delta/account/_ping')
+            ->assertOk()
+            ->assertJson(['environment_slug' => 'delta']);
+    });
+});

--- a/tests/Feature/Services/Keys/SigningKeyGeneratorTest.php
+++ b/tests/Feature/Services/Keys/SigningKeyGeneratorTest.php
@@ -21,7 +21,8 @@ function makeProductionEnvironment(): Environment
     return Environment::create([
         'project_id' => $project->id,
         'kind' => Environment::KIND_PRODUCTION,
-        'frontend_api_host' => 'test.authn.local',
+        'slug' => 'test-'.bin2hex(random_bytes(3)),
+        'frontend_api_host' => 'test-'.bin2hex(random_bytes(3)).'.authn.local',
     ]);
 }
 

--- a/tests/Feature/Services/Tenancy/BootstrapServiceTest.php
+++ b/tests/Feature/Services/Tenancy/BootstrapServiceTest.php
@@ -32,6 +32,15 @@ function bootstrapWith(array $overrides = []): array
     return $result;
 }
 
+beforeEach(function (): void {
+    config([
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.bapi_host' => 'api.authn.local',
+        'authn.dashboard_host' => 'dashboard.authn.local',
+    ]);
+});
+
 it('provisions the _admin project, environment, workspace org, operator, signing key, and api keys', function (): void {
     $result = bootstrapWith();
 
@@ -43,7 +52,9 @@ it('provisions the _admin project, environment, workspace org, operator, signing
 
     expect($result['environment']->id)->toStartWith('env_');
     expect($result['environment']->kind)->toBe('production');
-    expect($result['environment']->frontend_api_host)->toBe('authn.local');
+    expect($result['environment']->slug)->toBe('_admin');
+    // Subdomain mode (the default for the test suite) prefixes the env slug.
+    expect($result['environment']->frontend_api_host)->toBe('_admin.authn.local');
 
     /** @var Organization $workspace */
     $workspace = $result['workspace'];
@@ -138,4 +149,16 @@ it('exposes Project->is_admin_project for the seeded _admin row', function (): v
     $admin = Project::where('slug', Project::SYSTEM_SLUG)->firstOrFail();
 
     expect($admin->is_admin_project)->toBeTrue();
+});
+
+it('uses the bare app host as the FAPI host in path mode', function (): void {
+    config([
+        'authn.routing_mode' => 'path',
+        'authn.app_host' => 'authn.local',
+    ]);
+
+    $result = bootstrapWith();
+
+    expect($result['environment']->slug)->toBe('_admin');
+    expect($result['environment']->frontend_api_host)->toBe('authn.local');
 });

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('that true is true', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Unit/Support/UrlTest.php
+++ b/tests/Unit/Support/UrlTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Support\Url;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+function envFixture(): Environment
+{
+    return new Environment([
+        'project_id' => 'prj_01HKX9SY9V7H7TF8C8K7J9X4ZB',
+        'kind' => 'production',
+        'slug' => 'acme',
+        'frontend_api_host' => 'acme.authn.local',
+    ]);
+}
+
+beforeEach(function (): void {
+    config([
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.app_port_suffix' => '',
+    ]);
+});
+
+describe('subdomain mode', function (): void {
+    beforeEach(function (): void {
+        config([
+            'authn.routing_mode' => 'subdomain',
+            'authn.bapi_host' => 'api.authn.local',
+            'authn.dashboard_host' => 'dashboard.authn.local',
+        ]);
+    });
+
+    it('builds BAPI URLs against api.{app_host}', function (): void {
+        expect(Url::bapi('/v1/users'))->toBe('https://api.authn.local/v1/users');
+        expect(Url::bapi(''))->toBe('https://api.authn.local');
+    });
+
+    it('builds Dashboard URLs against dashboard.{app_host}', function (): void {
+        expect(Url::dashboard('/users'))->toBe('https://dashboard.authn.local/users');
+    });
+
+    it('builds FAPI URLs against the env frontend_api_host', function (): void {
+        expect(Url::fapi(envFixture(), '/v1/client'))->toBe('https://acme.authn.local/v1/client');
+    });
+
+    it('builds Account Portal URLs at the env host root', function (): void {
+        expect(Url::accountPortal(envFixture(), '/sign-in'))->toBe('https://acme.authn.local/sign-in');
+    });
+});
+
+describe('path mode', function (): void {
+    beforeEach(function (): void {
+        config([
+            'authn.routing_mode' => 'path',
+            'authn.bapi_host' => 'authn.local',
+            'authn.dashboard_host' => 'authn.local',
+        ]);
+    });
+
+    it('builds BAPI URLs under /api', function (): void {
+        expect(Url::bapi('/v1/users'))->toBe('https://authn.local/api/v1/users');
+    });
+
+    it('builds Dashboard URLs under /dashboard', function (): void {
+        expect(Url::dashboard('/users'))->toBe('https://authn.local/dashboard/users');
+    });
+
+    it('builds FAPI URLs under /{env_slug}', function (): void {
+        expect(Url::fapi(envFixture(), '/v1/client'))->toBe('https://authn.local/acme/v1/client');
+    });
+
+    it('builds Account Portal URLs under /{env_slug}/account', function (): void {
+        expect(Url::accountPortal(envFixture(), '/sign-in'))->toBe('https://authn.local/acme/account/sign-in');
+    });
+});


### PR DESCRIPTION
## Summary

Wires the three URL surfaces to dispatch by host (subdomain mode, default for hosted authn.sh) or by path prefix (path mode, recommended self-host default). Selectable via \`AUTHN_ROUTING_MODE\`.

- **\`config/authn.php\`** — \`routing_mode\`, \`app_host\`, derived \`bapi_host\` / \`dashboard_host\`, plus a \`reserved_env_slugs\` blocklist (\`api\`, \`dashboard\`, \`docs\`, \`www\`, \`horizon\`, …). \`_admin\` is NOT reserved — it's the legitimate slug of the system project's environment.
- **Migration** — adds the unique routing-time \`slug\` column to environments and drops the unique on \`frontend_api_host\` (path mode shares one host across every env).
- **Routing dispatch** — \`bootstrap/app.php\` registers BAPI / Dashboard / FAPI route groups with mode-aware host or prefix bindings. BAPI + Dashboard register first so their bindings win against the FAPI catch-all.
- **\`ResolveProjectFromHost\`** middleware extracts the slug, looks up the Environment, binds it + Project as singletons. 404s with \`environment_not_found\` on unknown / reserved labels.
- **\`AuthenticateBapiKey\`** (skeleton; AU-13 fleshes it out) verifies \`Authorization: Bearer sk_…\` against \`api_keys.hashed_secret\`, debounces \`last_used_at\` writes to ≤ 1/min via Cache::add.
- **\`App\\Support\\Url\`** — generates routing-mode-aware URLs for all four surfaces.
- **Routes + placeholder controllers** — \`routes/{bapi,dashboard,fapi}.php\` each expose a \`/_ping\` endpoint that returns the surface name + resolved env id. Real handlers land in AU-8/9/10/13/17.
- **Tests** — 25 new Pest tests across both routing modes (RoutingDispatchTest, UrlTest, AuthenticateBapiKeyTest) + extended BootstrapServiceTest. Removes the placeholder Laravel ExampleTests.

Total suite: 65 / 65 green.

Closes #3.

## Test plan

- [x] \`php artisan test\` — 65/65 green locally.
- [x] \`vendor/bin/pint --test\` — clean.
- [x] \`php artisan route:list\` shows: \`api.{host}/v1/_ping\`, \`dashboard.{host}/_ping\`, \`{env_slug}.{host}/v1/_ping\`, \`{env_slug}.{host}/account/_ping\` (subdomain mode).
- [x] AuthenticateBapiKey debounce holds across two rapid requests.
- [x] BootstrapService produces \`_admin.authn.local\` in subdomain mode and \`authn.local\` in path mode.
- [ ] CI green on the merge commit (verify after push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)