### PR TITLE
FAPI: GET /v1/environment + GET /v1/client + handshake

### DIFF
--- a/app/Http/Controllers/Fapi/ClientController.php
+++ b/app/Http/Controllers/Fapi/ClientController.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Http\Resources\ClientResource;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Session;
+use App\Services\Client\ClientResolver;
+use App\Services\Sessions\HandshakeToken;
+use App\Services\Sessions\SessionLifecycle;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
+
+/**
+ * Five endpoints for the `Client` resource:
+ *
+ *   GET    /v1/client            — return the device's snapshot, minting
+ *                                  a fresh row when no cookie matches
+ *                                  (idempotent first-touch)
+ *   PUT    /v1/client            — explicit fresh-client mint (used by
+ *                                  the SDK on first boot when it knows
+ *                                  there is no prior cookie)
+ *   DELETE /v1/client            — sign out everything on this device
+ *                                  and clear the cookie
+ *   GET    /v1/client/handshake  — exchange an SSR handshake token for
+ *                                  a __client cookie
+ *
+ * The `__session` cookie is the SDK's responsibility (it reads it to know
+ * when to refresh); we only set / clear `__client` here.
+ */
+final class ClientController
+{
+    public function __construct(
+        private readonly ClientResolver $resolver,
+        private readonly SessionLifecycle $sessions,
+    ) {}
+
+    public function show(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $cookie = $request->cookie('__client');
+        $client = $this->resolver->fromCookie(is_string($cookie) ? $cookie : null, $env);
+
+        $createdHere = false;
+        if ($client === null) {
+            $client = Client::query()->withoutGlobalScopes()->create([
+                'environment_id' => $env->id,
+                'last_active_at' => now(),
+            ]);
+            $createdHere = true;
+        }
+
+        $response = response()
+            ->json(ClientResource::from($client))
+            ->header('Cache-Control', 'no-store');
+
+        if ($createdHere || $cookie === null) {
+            $response = $response->withCookie($this->buildCookie($client));
+        }
+
+        return $response;
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        $client = Client::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'last_active_at' => now(),
+        ]);
+
+        return response()
+            ->json(ClientResource::from($client))
+            ->header('Cache-Control', 'no-store')
+            ->withCookie($this->buildCookie($client));
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $cookie = $request->cookie('__client');
+        $client = $this->resolver->fromCookie(is_string($cookie) ? $cookie : null, $env);
+
+        if ($client !== null) {
+            $client->sessions()
+                ->whereIn('status', Session::LIVE_STATUSES)
+                ->each(fn (Session $session) => $this->sessions->end($session));
+        }
+
+        return response()
+            ->json([
+                'deleted' => true,
+                'client' => null,
+            ])
+            ->header('Cache-Control', 'no-store')
+            ->withCookie(Cookie::forget('__client'));
+    }
+
+    public function handshake(Request $request, HandshakeToken $tokens): JsonResponse
+    {
+        $env = app(Environment::class);
+        $token = $request->input('handshake_token') ?? $request->query('handshake_token');
+
+        if (! is_string($token) || $token === '') {
+            return $this->error(400, 'handshake_token_missing', 'A handshake_token is required.');
+        }
+
+        $client = $tokens->verify($token, $env);
+        if ($client === null) {
+            return $this->error(401, 'handshake_token_invalid', 'Handshake token is invalid, expired, or already redeemed.');
+        }
+
+        return response()
+            ->json(ClientResource::from($client))
+            ->header('Cache-Control', 'no-store')
+            ->withCookie($this->buildCookie($client));
+    }
+
+    /**
+     * Build the `__client` cookie. HttpOnly, SameSite=Lax, Secure when
+     * the request itself is over HTTPS — the latter mirrors PLAN §6.3.
+     * Lifetime: 1 year sliding (Laravel's Cookie::make takes minutes).
+     */
+    private function buildCookie(Client $client): \Symfony\Component\HttpFoundation\Cookie
+    {
+        $value = $this->resolver->mintCookieValue($client);
+
+        return Cookie::make(
+            name: '__client',
+            value: $value,
+            minutes: 60 * 24 * 365,
+            path: '/',
+            domain: null,
+            secure: request()->secure(),
+            httpOnly: true,
+            raw: false,
+            sameSite: 'lax',
+        );
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Controllers/Fapi/EnvironmentController.php
+++ b/app/Http/Controllers/Fapi/EnvironmentController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Http\Resources\EnvironmentResource;
+use App\Models\Environment;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * `GET /v1/environment` — public, no auth.
+ *
+ * Cached at the application layer keyed by `(env_id,
+ * environment.updated_at)` so config-page edits invalidate
+ * automatically; falls through after a 60-second safety TTL anyway.
+ *
+ * Response carries `Cache-Control: public, max-age=60` so CDNs can
+ * also do their share — no Set-Cookie ever set on this endpoint.
+ */
+final class EnvironmentController
+{
+    public function show(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        $cacheKey = sprintf('fapi:environment:%s:%s', $env->id, $env->updated_at?->getTimestamp() ?? 0);
+        $payload = Cache::remember($cacheKey, 60, fn () => EnvironmentResource::from($env));
+
+        return response()
+            ->json($payload)
+            ->header('Cache-Control', 'public, max-age=60');
+    }
+}

--- a/app/Http/Resources/ClientResource.php
+++ b/app/Http/Resources/ClientResource.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Client;
+use App\Models\Session;
+
+/**
+ * The Client snapshot returned to the SDK. Mirrors PLAN §8.2.
+ *
+ * v0.1: only `sessions` is populated — `sign_in` and `sign_up` arrive
+ * with AU-9 / AU-10 once those state machines land.
+ */
+final class ClientResource
+{
+    public static function from(?Client $client): array
+    {
+        if ($client === null) {
+            return [
+                'object' => 'client',
+                'id' => null,
+                'sessions' => [],
+                'sign_in' => null,
+                'sign_up' => null,
+                'last_active_session_id' => null,
+                'created_at' => null,
+                'updated_at' => null,
+            ];
+        }
+
+        $sessions = $client->sessions()
+            ->whereIn('status', Session::LIVE_STATUSES)
+            ->latest('last_active_at')
+            ->get()
+            ->map(fn (Session $session) => self::sessionShape($session))
+            ->all();
+
+        return [
+            'object' => 'client',
+            'id' => $client->id,
+            'sessions' => $sessions,
+            'sign_in' => null,                      // populated in AU-9
+            'sign_up' => null,                      // populated in AU-10
+            'last_active_session_id' => $client->last_active_session_id,
+            'created_at' => $client->created_at?->getTimestampMs(),
+            'updated_at' => $client->updated_at?->getTimestampMs(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function sessionShape(Session $session): array
+    {
+        return [
+            'object' => 'session',
+            'id' => $session->id,
+            'status' => $session->status,
+            'last_active_at' => $session->last_active_at?->getTimestampMs(),
+            'expire_at' => $session->expire_at->getTimestampMs(),
+            'abandon_at' => $session->abandon_at?->getTimestampMs(),
+            'last_active_organization_id' => $session->last_active_organization_id,
+            'actor' => $session->actor,
+            'user_id' => $session->user_id,
+        ];
+    }
+}

--- a/app/Http/Resources/EnvironmentResource.php
+++ b/app/Http/Resources/EnvironmentResource.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Environment;
+
+/**
+ * The public-facing shape returned by `GET /v1/environment`. The SDK
+ * loads this once at boot to learn which strategies are enabled, what
+ * branding to apply, where to redirect on success, etc.
+ *
+ * Strict about what it exposes: secret keys (captcha.secret_key,
+ * private signing material) never leak. The full surface (org settings,
+ * commerce settings, oauth_providers, full localization catalog) lights
+ * up across v0.2 → v0.7 — v0.1 returns stubs for the categories that
+ * aren't wired yet so the SDK shape is stable from day one.
+ */
+final class EnvironmentResource
+{
+    public static function from(Environment $environment): array
+    {
+        $appearance = is_array($environment->appearance) ? $environment->appearance : [];
+        $sessions = is_array($appearance['sessions'] ?? null) ? $appearance['sessions'] : [];
+        $localization = is_array($environment->localization) ? $environment->localization : [];
+
+        return [
+            'object' => 'environment',
+            'id' => $environment->id,
+
+            'auth_config' => [
+                // v0.1 supports identifier-based sign-in via email only.
+                'identifiers' => ['email_address'],
+                'first_factors' => ['password', 'email_code', 'reset_password_email_code', 'ticket'],
+                'second_factors' => [],
+                'sign_up_modes' => ['public'],
+            ],
+
+            'display_config' => [
+                'application_name' => $appearance['application_name'] ?? config('app.name'),
+                'branded' => (bool) ($appearance['branded'] ?? false),
+                'support_email' => $appearance['support_email'] ?? null,
+                'brand_color' => $appearance['brand_color'] ?? null,
+                'logo_url' => $appearance['logo_url'] ?? null,
+                'favicon_url' => $appearance['favicon_url'] ?? null,
+            ],
+
+            'user_settings' => [
+                // Per-attribute settings (full PLAN §13.2 shape) lands in AU-13;
+                // v0.1 returns the implicit default: email + password required,
+                // no other identifiers.
+                'attributes' => [
+                    'email_address' => [
+                        'enabled' => true,
+                        'required' => true,
+                        'used_for_first_factor' => true,
+                        'used_for_second_factor' => false,
+                        'verifications' => ['email_code'],
+                        'verify_at_sign_up' => true,
+                    ],
+                    'password' => [
+                        'enabled' => true,
+                        'required' => true,
+                        'used_for_first_factor' => true,
+                        'used_for_second_factor' => false,
+                        'verifications' => [],
+                        'verify_at_sign_up' => false,
+                    ],
+                    'first_name' => [
+                        'enabled' => true,
+                        'required' => false,
+                        'used_for_first_factor' => false,
+                        'used_for_second_factor' => false,
+                        'verifications' => [],
+                        'verify_at_sign_up' => false,
+                    ],
+                    'last_name' => [
+                        'enabled' => true,
+                        'required' => false,
+                        'used_for_first_factor' => false,
+                        'used_for_second_factor' => false,
+                        'verifications' => [],
+                        'verify_at_sign_up' => false,
+                    ],
+                ],
+            ],
+
+            // v0.2 lights this up.
+            'organization_settings' => [
+                'enabled' => false,
+            ],
+
+            // Out of scope for v0.1 — billing entities are deferred.
+            'commerce_settings' => [
+                'enabled' => false,
+            ],
+
+            // Bot protection (AU-18 wires the actual provider call). Public
+            // half only — secret_key never leaves the server.
+            'captcha' => [
+                'provider' => $appearance['captcha']['provider'] ?? null,
+                'widget_type' => $appearance['captcha']['widget_type'] ?? null,
+                'public_key' => $appearance['captcha']['public_key'] ?? null,
+            ],
+
+            'localization' => [
+                'default_locale' => $localization['default_locale'] ?? 'en-US',
+                'supported_locales' => $localization['supported_locales'] ?? ['en-US'],
+                'fallback_locale' => $localization['fallback_locale'] ?? 'en-US',
+                // override_etag is bumped whenever overrides change so the SDK
+                // can cache the catalog endpoint per-version. Implementation
+                // lands when the localization editor ships.
+                'override_etag' => $localization['override_etag'] ?? null,
+            ],
+
+            // v0.4 lights this up with preset + custom OIDC/OAuth2 providers.
+            'oauth_providers' => [],
+
+            'paths' => $appearance['paths'] ?? [],
+
+            'sessions' => [
+                // The bare minimum the SDK needs at boot to know its refresh
+                // cadence. Full per-env config (multi_session, inactivity
+                // timeout, …) lands in AU-13.
+                'session_token_lifetime_seconds' => $sessions['lifetime_seconds'] ?? 60,
+                'multi_session' => (bool) ($sessions['multi_session'] ?? true),
+            ],
+
+            'created_at' => $environment->created_at?->getTimestampMs(),
+            'updated_at' => $environment->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/app/Services/Sessions/HandshakeToken.php
+++ b/app/Services/Sessions/HandshakeToken.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Sessions;
+
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\SigningKey;
+use App\Support\Url;
+use Illuminate\Support\Facades\Cache;
+use Lcobucci\Clock\SystemClock;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Token\Parser;
+use Lcobucci\JWT\Token\Plain;
+use Lcobucci\JWT\Validation\Constraint\IssuedBy;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Lcobucci\JWT\Validation\Constraint\StrictValidAt;
+use Lcobucci\JWT\Validation\Validator;
+
+/**
+ * One-shot handshake-token issuance + verification.
+ *
+ * SSR frameworks (Next.js, Nuxt, Remix) hit `GET /v1/client/handshake?
+ * handshake_token=…` after a server-side render to swap a server-issued
+ * token for a `__client` cookie they couldn't set themselves. The token
+ * is signed with the env's active SigningKey, single-use (jti tracked
+ * in the cache for the TTL window), 60s default lifetime.
+ *
+ * v0.1 ships the verify side — the issuance helper that BAPI calls when
+ * an SSR adapter requests a handshake lands later. Tests mint tokens
+ * inline.
+ */
+final class HandshakeToken
+{
+    public const TTL_SECONDS = 60;
+
+    /** Cache prefix for the single-use jti guard. */
+    private const JTI_CACHE_PREFIX = 'handshake:jti:';
+
+    /**
+     * Mint a handshake token bound to a specific Client.
+     */
+    public function issue(Environment $environment, Client $client): string
+    {
+        $signingKey = $environment->signingKeys()
+            ->where('status', SigningKey::STATUS_ACTIVE)
+            ->latest('activated_at')
+            ->firstOrFail();
+
+        $now = now();
+        $expiresAt = $now->copy()->addSeconds(self::TTL_SECONDS);
+
+        $config = Configuration::forAsymmetricSigner(
+            new Sha256,
+            InMemory::plainText($signingKey->privatePem()),
+            InMemory::plainText('public-not-needed-for-signing'),
+        );
+
+        $token = $config->builder()
+            ->withHeader('kid', $signingKey->id)
+            ->issuedBy(Url::fapi($environment, ''))
+            ->relatedTo($client->id)
+            ->identifiedBy($this->mintJti())
+            ->issuedAt($now->toDateTimeImmutable())
+            ->canOnlyBeUsedAfter($now->toDateTimeImmutable())
+            ->expiresAt($expiresAt->toDateTimeImmutable())
+            ->withClaim('purpose', 'handshake')
+            ->getToken($config->signer(), $config->signingKey());
+
+        return $token->toString();
+    }
+
+    /**
+     * Verify a handshake token. Returns the resolved Client on success
+     * or null on any failure mode (bad signature, expired, replayed,
+     * cross-environment, missing client row).
+     */
+    public function verify(string $jwt, Environment $environment): ?Client
+    {
+        try {
+            $token = (new Parser(new JoseEncoder))->parse($jwt);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (! $token instanceof Plain) {
+            return null;
+        }
+
+        $kid = (string) ($token->headers()->get('kid') ?? '');
+        if ($kid === '') {
+            return null;
+        }
+
+        $signingKey = $environment->signingKeys()
+            ->where('id', $kid)
+            ->whereIn('status', [
+                SigningKey::STATUS_ACTIVE,
+                SigningKey::STATUS_RETIRING,
+                SigningKey::STATUS_PENDING,
+            ])
+            ->first();
+        if ($signingKey === null) {
+            return null;
+        }
+
+        $publicResource = openssl_pkey_get_private($signingKey->privatePem());
+        $publicPem = openssl_pkey_get_details($publicResource)['key'];
+
+        $config = Configuration::forAsymmetricSigner(
+            new Sha256,
+            InMemory::plainText('private-not-needed-for-verification'),
+            InMemory::plainText($publicPem),
+        );
+
+        try {
+            (new Validator)->assert(
+                $token,
+                new SignedWith($config->signer(), $config->verificationKey()),
+                new IssuedBy(Url::fapi($environment, '')),
+                new StrictValidAt(SystemClock::fromSystemTimezone()),
+            );
+        } catch (\Throwable) {
+            return null;
+        }
+
+        $jti = $token->claims()->get('jti');
+        if (! is_string($jti) || $jti === '') {
+            return null;
+        }
+        $cacheKey = self::JTI_CACHE_PREFIX.$environment->id.':'.$jti;
+        if (! Cache::add($cacheKey, 1, self::TTL_SECONDS)) {
+            return null; // replay
+        }
+
+        $purpose = $token->claims()->get('purpose');
+        if ($purpose !== 'handshake') {
+            return null;
+        }
+
+        $clientId = $token->claims()->get('sub');
+        if (! is_string($clientId)) {
+            return null;
+        }
+
+        return Client::query()
+            ->withoutGlobalScopes()
+            ->where('id', $clientId)
+            ->where('environment_id', $environment->id)
+            ->first();
+    }
+
+    private function mintJti(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(16)), '+/', '-_'), '=');
+    }
+}

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Fapi\ClientController;
+use App\Http\Controllers\Fapi\EnvironmentController;
 use App\Http\Controllers\Fapi\PingController;
 use App\Http\Controllers\Fapi\SessionTokenController;
 use App\Http\Controllers\WellKnown\JwksController;
@@ -27,9 +29,16 @@ Route::get('/.well-known/openid-configuration', OpenIdConfigurationController::c
 Route::prefix('v1')->group(function (): void {
     Route::get('/_ping', PingController::class)->name('fapi.ping');
 
+    // Public bootstrap endpoints — no Client cookie required. `show` mints
+    // one on the fly when none is supplied.
+    Route::get('/environment', [EnvironmentController::class, 'show'])->name('fapi.environment');
+    Route::get('/client', [ClientController::class, 'show'])->name('fapi.client.show');
+    Route::put('/client', [ClientController::class, 'store'])->name('fapi.client.store');
+    Route::delete('/client', [ClientController::class, 'destroy'])->name('fapi.client.destroy');
+    Route::match(['get', 'post'], '/client/handshake', [ClientController::class, 'handshake'])->name('fapi.client.handshake');
+
     // Routes that require an existing Client (resolved from the __client
-    // cookie). The `GET /v1/client` endpoint that mints one on first
-    // contact is intentionally NOT inside this group — it lands in AU-8.
+    // cookie via ResolveClientFromCookie).
     Route::middleware(ResolveClientFromCookie::class)->group(function (): void {
         Route::post('/client/sessions/{sid}/tokens', SessionTokenController::class)->name('fapi.session_token');
         Route::post('/client/sessions/{sid}/tokens/{template}', SessionTokenController::class)->name('fapi.session_token.template');

--- a/tests/Feature/Http/ClientEndpointTest.php
+++ b/tests/Feature/Http/ClientEndpointTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Session;
+use App\Models\User;
+use App\Services\Client\ClientResolver;
+use App\Services\Keys\SigningKeyGenerator;
+use App\Services\Sessions\HandshakeToken;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+uses(RefreshDatabase::class);
+
+function reloadFapiRoutesForClientTest(): void
+{
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+
+    $appHost = (string) config('authn.app_host');
+    $fapi = Route::middleware('fapi');
+    if ((string) config('authn.routing_mode') === 'subdomain') {
+        $fapi->domain('{env_slug}.'.$appHost);
+    } else {
+        $fapi->prefix('{env_slug}');
+    }
+    $fapi->group(base_path('routes/fapi.php'));
+}
+
+function clientBoot(): array
+{
+    config([
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.app_port_suffix' => '',
+        'authn.bapi_host' => 'api.authn.local',
+        'authn.dashboard_host' => 'dashboard.authn.local',
+    ]);
+    reloadFapiRoutesForClientTest();
+
+    $project = Project::create(['name' => 'P', 'slug' => 'p']);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'acme',
+        'frontend_api_host' => 'acme.authn.local',
+    ]);
+    (new SigningKeyGenerator)->generate($env);
+
+    return ['env' => $env];
+}
+
+it('mints a fresh client + sets the cookie when no __client cookie is present', function (): void {
+    clientBoot();
+
+    $response = $this->withCredentials()
+        ->withHeader('Host', 'acme.authn.local')
+        ->getJson('https://acme.authn.local/v1/client');
+
+    $response->assertOk()
+        ->assertJsonPath('object', 'client')
+        ->assertJsonPath('sessions', [])
+        ->assertJsonPath('sign_in', null)
+        ->assertJsonPath('sign_up', null);
+
+    $cookieValues = collect($response->headers->getCookies())->keyBy(fn ($c) => $c->getName());
+    expect($cookieValues->has('__client'))->toBeTrue();
+
+    expect(Client::query()->withoutGlobalScopes()->count())->toBe(1);
+});
+
+it('returns the existing client when a valid cookie is supplied', function (): void {
+    $f = clientBoot();
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $cookie = app(ClientResolver::class)->mintCookieValue($client);
+
+    $response = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeader('Host', 'acme.authn.local')
+        ->getJson('https://acme.authn.local/v1/client');
+
+    $response->assertOk()->assertJsonPath('id', $client->id);
+    expect(Client::query()->withoutGlobalScopes()->count())->toBe(1);
+});
+
+it('mints a fresh client when the cookie is tampered (does not throw)', function (): void {
+    $f = clientBoot();
+
+    $response = $this->withCredentials()
+        ->withUnencryptedCookie('__client', 'forged.invalid')
+        ->withHeader('Host', 'acme.authn.local')
+        ->getJson('https://acme.authn.local/v1/client');
+
+    $response->assertOk();
+    expect(Client::query()->withoutGlobalScopes()->count())->toBe(1);
+});
+
+it('PUT /v1/client always mints a fresh row', function (): void {
+    $f = clientBoot();
+    Client::create(['environment_id' => $f['env']->id]);
+
+    $response = $this->withCredentials()
+        ->withHeader('Host', 'acme.authn.local')
+        ->putJson('https://acme.authn.local/v1/client');
+
+    $response->assertOk();
+    expect(Client::query()->withoutGlobalScopes()->count())->toBe(2);
+});
+
+it('DELETE /v1/client ends every active session and clears the cookie', function (): void {
+    $f = clientBoot();
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $user = User::create(['environment_id' => $f['env']->id]);
+    Session::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'user_id' => $user->id,
+    ]);
+
+    $cookie = app(ClientResolver::class)->mintCookieValue($client);
+
+    $response = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeader('Host', 'acme.authn.local')
+        ->deleteJson('https://acme.authn.local/v1/client');
+
+    $response->assertOk()->assertJson(['deleted' => true, 'client' => null]);
+    expect(Session::query()->withoutGlobalScopes()->where('client_id', $client->id)->first()->status)->toBe('ended');
+
+    $cleared = collect($response->headers->getCookies())
+        ->first(fn ($c) => $c->getName() === '__client');
+    // Cookie::forget produces an empty/null value with an expiry in the past.
+    expect($cleared)->not->toBeNull();
+    expect((string) $cleared->getValue())->toBe('');
+    expect($cleared->getExpiresTime())->toBeLessThan(now()->getTimestamp());
+});
+
+it('handshake redeems a valid token and sets the cookie', function (): void {
+    $f = clientBoot();
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $token = app(HandshakeToken::class)->issue($f['env'], $client);
+
+    $response = $this->withCredentials()
+        ->withHeader('Host', 'acme.authn.local')
+        ->getJson('https://acme.authn.local/v1/client/handshake?handshake_token='.urlencode($token));
+
+    $response->assertOk()->assertJsonPath('id', $client->id);
+    $cookies = collect($response->headers->getCookies())->keyBy(fn ($c) => $c->getName());
+    expect($cookies->has('__client'))->toBeTrue();
+});
+
+it('handshake refuses replay (single-use jti)', function (): void {
+    $f = clientBoot();
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $token = app(HandshakeToken::class)->issue($f['env'], $client);
+
+    $url = 'https://acme.authn.local/v1/client/handshake?handshake_token='.urlencode($token);
+
+    $this->withCredentials()->withHeader('Host', 'acme.authn.local')->getJson($url)->assertOk();
+
+    $this->withCredentials()->withHeader('Host', 'acme.authn.local')->getJson($url)
+        ->assertUnauthorized()
+        ->assertJsonPath('errors.0.code', 'handshake_token_invalid');
+});
+
+it('handshake refuses a malformed token', function (): void {
+    clientBoot();
+
+    $this->withCredentials()->withHeader('Host', 'acme.authn.local')
+        ->getJson('https://acme.authn.local/v1/client/handshake?handshake_token=not-a-jwt')
+        ->assertUnauthorized()
+        ->assertJsonPath('errors.0.code', 'handshake_token_invalid');
+});
+
+it('handshake refuses a token issued for a different env', function (): void {
+    $f = clientBoot();
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $token = app(HandshakeToken::class)->issue($f['env'], $client);
+
+    $project2 = Project::create(['name' => 'Other', 'slug' => 'other']);
+    $other = Environment::create([
+        'project_id' => $project2->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'other',
+        'frontend_api_host' => 'other.authn.local',
+    ]);
+    (new SigningKeyGenerator)->generate($other);
+
+    $this->withCredentials()->withHeader('Host', 'other.authn.local')
+        ->getJson('https://other.authn.local/v1/client/handshake?handshake_token='.urlencode($token))
+        ->assertUnauthorized();
+});
+
+it('handshake refuses a request with no token', function (): void {
+    clientBoot();
+
+    $this->withCredentials()->withHeader('Host', 'acme.authn.local')
+        ->getJson('https://acme.authn.local/v1/client/handshake')
+        ->assertStatus(400)
+        ->assertJsonPath('errors.0.code', 'handshake_token_missing');
+});

--- a/tests/Feature/Http/EnvironmentEndpointTest.php
+++ b/tests/Feature/Http/EnvironmentEndpointTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+uses(RefreshDatabase::class);
+
+function reloadFapiRoutesForEnvTest(): void
+{
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+
+    $appHost = (string) config('authn.app_host');
+    $fapi = Route::middleware('fapi');
+    if ((string) config('authn.routing_mode') === 'subdomain') {
+        $fapi->domain('{env_slug}.'.$appHost);
+    } else {
+        $fapi->prefix('{env_slug}');
+    }
+    $fapi->group(base_path('routes/fapi.php'));
+}
+
+function envBoot(): Environment
+{
+    config([
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.app_port_suffix' => '',
+        'authn.bapi_host' => 'api.authn.local',
+        'authn.dashboard_host' => 'dashboard.authn.local',
+    ]);
+    reloadFapiRoutesForEnvTest();
+
+    $project = Project::create(['name' => 'P', 'slug' => 'p']);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'acme',
+        'frontend_api_host' => 'acme.authn.local',
+    ]);
+}
+
+it('returns the canonical environment shape', function (): void {
+    envBoot();
+    $response = $this->withHeader('Host', 'acme.authn.local')
+        ->getJson('https://acme.authn.local/v1/environment');
+
+    $response->assertOk();
+    $response->assertJsonPath('object', 'environment');
+    $response->assertJsonPath('auth_config.first_factors', ['password', 'email_code', 'reset_password_email_code', 'ticket']);
+    $response->assertJsonPath('auth_config.identifiers', ['email_address']);
+    $response->assertJsonPath('user_settings.attributes.email_address.required', true);
+    $response->assertJsonPath('user_settings.attributes.password.required', true);
+    $response->assertJsonPath('organization_settings.enabled', false);
+    $response->assertJsonPath('commerce_settings.enabled', false);
+    $response->assertJsonPath('localization.default_locale', 'en-US');
+    $response->assertJsonPath('oauth_providers', []);
+    $response->assertJsonPath('sessions.session_token_lifetime_seconds', 60);
+});
+
+it('responds with the public Cache-Control header', function (): void {
+    envBoot();
+    $response = $this->withHeader('Host', 'acme.authn.local')
+        ->getJson('https://acme.authn.local/v1/environment');
+
+    expect($response->headers->get('Cache-Control'))->toContain('public');
+    expect($response->headers->get('Cache-Control'))->toContain('max-age=60');
+});
+
+it('never returns secret captcha or signing material', function (): void {
+    $env = envBoot();
+    $env->forceFill([
+        'appearance' => [
+            'captcha' => [
+                'provider' => 'turnstile',
+                'widget_type' => 'invisible',
+                'public_key' => 'public-key',
+                'secret_key' => 'should-never-leak',
+            ],
+        ],
+    ])->save();
+
+    $response = $this->withHeader('Host', 'acme.authn.local')
+        ->getJson('https://acme.authn.local/v1/environment');
+
+    expect($response->getContent())->not->toContain('should-never-leak');
+    $response->assertJsonPath('captcha.public_key', 'public-key');
+});
+
+it('reflects appearance edits after the env is touched', function (): void {
+    $env = envBoot();
+    $first = $this->withHeader('Host', 'acme.authn.local')
+        ->getJson('https://acme.authn.local/v1/environment');
+    expect($first->json('display_config.brand_color'))->toBeNull();
+
+    $env->forceFill([
+        'appearance' => ['brand_color' => '#ff0066'],
+        'updated_at' => now()->addSeconds(2),
+    ])->save();
+    $env->refresh();
+    // updated_at must change for the cache-key to invalidate.
+    expect($env->updated_at->getTimestamp())->toBeGreaterThan(0);
+
+    $second = $this->withHeader('Host', 'acme.authn.local')
+        ->getJson('https://acme.authn.local/v1/environment');
+    expect($second->json('display_config.brand_color'))->toBe('#ff0066');
+});


### PR DESCRIPTION
## Summary

The bootstrap surface every browser SDK touches on first load. Public, no auth required. \`GET /v1/client\` mints a fresh row when no cookie matches so the SDK never has to call PUT first.

- **\`EnvironmentResource\`** — public-facing shape with stable v0.1 stubs for the v0.2 / v0.4 / v0.7 surfaces. Captcha \`secret_key\` never leaks.
- **\`ClientResource\`** — Client snapshot with live sessions, sign_in/sign_up null in v0.1.
- **\`HandshakeToken\`** service — issues + verifies one-shot SSR handshake JWTs (60s TTL, single-use jti via cache, signed with env's active key).
- **\`EnvironmentController::show\`** — app-layer cache keyed by \`(env_id, environment.updated_at)\` with 60s TTL; \`Cache-Control: public, max-age=60\`.
- **\`ClientController\`** — show / store / destroy / handshake. \`__client\` cookie HttpOnly + SameSite=Lax + Secure; lifetime 1y sliding.
- **Routes** — \`GET /v1/environment\`, \`GET /v1/client\`, \`PUT /v1/client\`, \`DELETE /v1/client\`, \`GET|POST /v1/client/handshake\`.

Total suite: 150 / 150 green.

Closes #8.

## Test plan

- [x] \`php artisan test\` — 150/150 green locally.
- [x] \`vendor/bin/pint --test\` — clean.
- [x] No captcha secret in /v1/environment payload.
- [x] /v1/client mints on no cookie, returns existing on valid cookie, mints on tampered cookie.
- [x] DELETE /v1/client ends live sessions and clears the cookie (empty value + past expiry).
- [x] handshake redeems once, replay returns 401, cross-env returns 401.
- [ ] CI green on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)