### PR TITLE
CORS + Origin enforcement middleware (FAPI)

### DIFF
--- a/app/Http/Middleware/EnforceFapiOrigin.php
+++ b/app/Http/Middleware/EnforceFapiOrigin.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\Environment;
+use App\Support\AllowedOrigins;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Origin-header enforcement for state-changing FAPI requests.
+ *
+ * GET / HEAD / OPTIONS skip — read-only methods don't need CSRF
+ * mitigation, and OPTIONS is the preflight FapiCors short-circuits.
+ *
+ * Bearer-token requests (mobile / native paths) skip too — they're
+ * authenticated by the token, not a cookie, so a forged Origin can't
+ * ride a logged-in session.
+ *
+ * Otherwise the Origin (or Referer host as a fallback) MUST appear in
+ * `Environment.allowed_origins`. Mismatched / missing → 403
+ * `origin_invalid` with the offending origin and the configured allow
+ * list in `meta` so an operator can copy-paste the value into the
+ * dashboard.
+ *
+ * Public bootstrap endpoints (`/v1/environment`, `/v1/client`,
+ * `/.well-known/*`) opt out via route-level `withoutMiddleware`.
+ */
+final class EnforceFapiOrigin
+{
+    private const SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS'];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (in_array(strtoupper($request->getMethod()), self::SAFE_METHODS, true)) {
+            return $next($request);
+        }
+
+        if ($this->hasBearerToken($request)) {
+            return $next($request);
+        }
+
+        $env = app()->bound(Environment::class) ? app(Environment::class) : null;
+        if ($env === null) {
+            return $this->forbid('environment_not_resolved', 'No environment is bound for this request.');
+        }
+
+        $origin = $request->headers->get('Origin');
+        if (! is_string($origin) || $origin === '') {
+            $referer = $request->headers->get('Referer');
+            if (is_string($referer) && $referer !== '') {
+                $parts = parse_url($referer);
+                if (! empty($parts['scheme']) && ! empty($parts['host'])) {
+                    $origin = $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
+                }
+            }
+        }
+
+        if (! is_string($origin) || $origin === '') {
+            return $this->forbid('origin_invalid', 'Request must include an Origin header.', null, $env);
+        }
+
+        if (! AllowedOrigins::matches($env, $origin)) {
+            return $this->forbid('origin_invalid', 'Request origin is not in the allowed origins list.', $origin, $env);
+        }
+
+        return $next($request);
+    }
+
+    private function hasBearerToken(Request $request): bool
+    {
+        $header = $request->headers->get('Authorization');
+        if (! is_string($header)) {
+            return false;
+        }
+
+        return (bool) preg_match('/^Bearer\s+\S+$/i', $header);
+    }
+
+    private function forbid(string $code, string $message, ?string $origin = null, ?Environment $env = null): Response
+    {
+        $meta = [];
+        if ($origin !== null) {
+            $meta['origin'] = $origin;
+        }
+        if ($env !== null) {
+            $meta['allowed'] = is_array($env->allowed_origins) ? $env->allowed_origins : [];
+        }
+
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message.' Add this origin in your dashboard under Configure → Domains → Allowed origins, or use a server-to-server credential.',
+                'meta' => $meta,
+            ]],
+            'trace_id' => null,
+        ], 403);
+    }
+}

--- a/app/Http/Middleware/FapiCors.php
+++ b/app/Http/Middleware/FapiCors.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\Environment;
+use App\Support\AllowedOrigins;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Cross-Origin Resource Sharing for FAPI.
+ *
+ * Echoes the request `Origin` only when it appears in the env's
+ * `allowed_origins` list. OPTIONS preflights short-circuit return 204
+ * with the headers attached so the browser will let the actual request
+ * proceed. Requests with no Origin (server-to-server callers, native
+ * apps) pass through with no CORS response headers — they don't need
+ * them.
+ */
+final class FapiCors
+{
+    private const ALLOW_HEADERS = 'Content-Type, Authorization, X-Requested-With, Authn-*';
+
+    private const ALLOW_METHODS = 'GET, POST, PUT, PATCH, DELETE, OPTIONS';
+
+    private const MAX_AGE = 86400;
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $origin = $request->headers->get('Origin');
+        $env = app()->bound(Environment::class) ? app(Environment::class) : null;
+        $allowed = $env !== null && is_string($origin) && $origin !== ''
+            && AllowedOrigins::matches($env, $origin);
+
+        if (strtoupper($request->getMethod()) === 'OPTIONS') {
+            $response = response('', 204);
+            if ($allowed) {
+                $this->attachCors($response, $origin);
+            }
+
+            return $response;
+        }
+
+        $response = $next($request);
+        if ($allowed) {
+            $this->attachCors($response, $origin);
+            $response->headers->set('Vary', trim(($response->headers->get('Vary') ?? '').', Origin', ', '));
+        }
+
+        return $response;
+    }
+
+    private function attachCors(Response $response, string $origin): void
+    {
+        $response->headers->set('Access-Control-Allow-Origin', $origin);
+        $response->headers->set('Access-Control-Allow-Credentials', 'true');
+        $response->headers->set('Access-Control-Allow-Headers', self::ALLOW_HEADERS);
+        $response->headers->set('Access-Control-Allow-Methods', self::ALLOW_METHODS);
+        $response->headers->set('Access-Control-Max-Age', (string) self::MAX_AGE);
+    }
+}

--- a/app/Support/AllowedOrigins.php
+++ b/app/Support/AllowedOrigins.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Models\Environment;
+
+/**
+ * Compares an `Origin` (or `Referer`) header against an environment's
+ * `allowed_origins` list. Used by both FapiCors (to decide which origin
+ * to echo on the response) and EnforceFapiOrigin (to decide whether to
+ * 403 a state-changing request).
+ *
+ * Rules — same logic for both middlewares:
+ *
+ *   1. Exact match by default (scheme + host + port).
+ *   2. Default ports are stripped on both sides before compare so
+ *      `https://app.example.com` and `https://app.example.com:443`
+ *      match regardless of which one was registered.
+ *   3. In development environments only, the registered list may carry
+ *      `http://localhost:*` or `http://127.0.0.1:*` patterns to match
+ *      any port (PLAN §6.5).
+ */
+final class AllowedOrigins
+{
+    public static function matches(Environment $environment, string $origin): bool
+    {
+        $normalizedOrigin = self::normalize($origin);
+        if ($normalizedOrigin === null) {
+            return false;
+        }
+
+        $allowed = is_array($environment->allowed_origins) ? $environment->allowed_origins : [];
+        $devMode = $environment->kind === Environment::KIND_DEVELOPMENT;
+
+        foreach ($allowed as $entry) {
+            if (! is_string($entry)) {
+                continue;
+            }
+            if ($devMode && self::matchesDevPattern($entry, $normalizedOrigin)) {
+                return true;
+            }
+            if (self::normalize($entry) === $normalizedOrigin) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Strip default ports and lowercase the host so two equivalent forms
+     * compare equal. Returns null on a malformed origin.
+     */
+    public static function normalize(string $origin): ?string
+    {
+        $parts = parse_url($origin);
+        if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+            return null;
+        }
+        $scheme = strtolower($parts['scheme']);
+        $host = strtolower($parts['host']);
+        $port = $parts['port'] ?? null;
+        if ($port !== null && self::isDefaultPort($scheme, $port)) {
+            $port = null;
+        }
+
+        return $scheme.'://'.$host.($port !== null ? ':'.$port : '');
+    }
+
+    /**
+     * Match a wildcard pattern from the allow list (e.g. `http://localhost:*`).
+     * Only valid in development environments. Pattern grammar:
+     *   <scheme>://<host>[:<port>|:*]
+     */
+    private static function matchesDevPattern(string $pattern, string $normalizedOrigin): bool
+    {
+        // The `#` in the negated character class would terminate a `#`-delimited
+        // regex prematurely; using `~` as the delimiter avoids escaping inline.
+        if (! preg_match('~^(https?)://([^:/?\#]+)(?::(\d+|\*))?$~i', $pattern, $m)) {
+            return false;
+        }
+        $scheme = strtolower($m[1]);
+        $host = strtolower($m[2]);
+        $portSpec = $m[3] ?? null;
+
+        if (! preg_match('~^(https?)://([^:/?\#]+)(?::(\d+))?$~i', $normalizedOrigin, $om)) {
+            return false;
+        }
+        if (strtolower($om[1]) !== $scheme) {
+            return false;
+        }
+        if (strtolower($om[2]) !== $host) {
+            return false;
+        }
+        if ($portSpec === '*') {
+            return true;
+        }
+        $originPort = $om[3] ?? null;
+
+        return $portSpec === $originPort;
+    }
+
+    private static function isDefaultPort(string $scheme, int|string $port): bool
+    {
+        $port = (int) $port;
+
+        return ($scheme === 'http' && $port === 80) || ($scheme === 'https' && $port === 443);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Middleware\AuthenticateBapiKey;
+use App\Http\Middleware\EnforceFapiOrigin;
+use App\Http\Middleware\FapiCors;
 use App\Http\Middleware\ResolveProjectFromHost;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -67,6 +69,8 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->group('fapi', [
             ResolveProjectFromHost::class,
+            FapiCors::class,
+            EnforceFapiOrigin::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Fapi\PingController;
 use App\Http\Controllers\Fapi\SessionTokenController;
 use App\Http\Controllers\WellKnown\JwksController;
 use App\Http\Controllers\WellKnown\OpenIdConfigurationController;
+use App\Http\Middleware\EnforceFapiOrigin;
 use App\Http\Middleware\ResolveClientFromCookie;
 use Illuminate\Support\Facades\Route;
 
@@ -23,19 +24,29 @@ use Illuminate\Support\Facades\Route;
 */
 
 // JWKS + OIDC discovery — sit at the FAPI host root, no /v1 prefix.
-Route::get('/.well-known/jwks.json', JwksController::class)->name('fapi.jwks');
-Route::get('/.well-known/openid-configuration', OpenIdConfigurationController::class)->name('fapi.openid_configuration');
+// These are public bootstrap endpoints, so they opt out of Origin
+// enforcement (they don't carry credentials anyway).
+Route::withoutMiddleware([EnforceFapiOrigin::class])->group(function (): void {
+    Route::get('/.well-known/jwks.json', JwksController::class)->name('fapi.jwks');
+    Route::get('/.well-known/openid-configuration', OpenIdConfigurationController::class)->name('fapi.openid_configuration');
+});
 
 Route::prefix('v1')->group(function (): void {
     Route::get('/_ping', PingController::class)->name('fapi.ping');
 
     // Public bootstrap endpoints — no Client cookie required. `show` mints
-    // one on the fly when none is supplied.
-    Route::get('/environment', [EnvironmentController::class, 'show'])->name('fapi.environment');
-    Route::get('/client', [ClientController::class, 'show'])->name('fapi.client.show');
-    Route::put('/client', [ClientController::class, 'store'])->name('fapi.client.store');
-    Route::delete('/client', [ClientController::class, 'destroy'])->name('fapi.client.destroy');
-    Route::match(['get', 'post'], '/client/handshake', [ClientController::class, 'handshake'])->name('fapi.client.handshake');
+    // one on the fly when none is supplied. These also opt out of Origin
+    // enforcement: GET /environment and GET /client are read-only (Origin
+    // check skips automatically); PUT /client is the very first call, so
+    // the SDK can't yet have a session worth protecting; handshake is
+    // authenticated by the JWT it carries.
+    Route::withoutMiddleware([EnforceFapiOrigin::class])->group(function (): void {
+        Route::get('/environment', [EnvironmentController::class, 'show'])->name('fapi.environment');
+        Route::get('/client', [ClientController::class, 'show'])->name('fapi.client.show');
+        Route::put('/client', [ClientController::class, 'store'])->name('fapi.client.store');
+        Route::delete('/client', [ClientController::class, 'destroy'])->name('fapi.client.destroy');
+        Route::match(['get', 'post'], '/client/handshake', [ClientController::class, 'handshake'])->name('fapi.client.handshake');
+    });
 
     // Routes that require an existing Client (resolved from the __client
     // cookie via ResolveClientFromCookie).
@@ -48,3 +59,11 @@ Route::prefix('v1')->group(function (): void {
 Route::prefix('account')->group(function (): void {
     Route::get('/_ping', PingController::class)->name('account_portal.ping');
 });
+
+// Catch-all OPTIONS preflight handler. The FapiCors middleware
+// short-circuits the response with 204 + the right CORS headers
+// when the Origin is in the env's allowlist; otherwise returns 204
+// with no CORS headers (the browser then blocks the actual request).
+Route::withoutMiddleware([EnforceFapiOrigin::class])
+    ->options('{any}', fn () => response('', 204))
+    ->where('any', '.*');

--- a/tests/Feature/Http/CorsAndOriginTest.php
+++ b/tests/Feature/Http/CorsAndOriginTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Session;
+use App\Models\User;
+use App\Services\Client\ClientResolver;
+use App\Services\Keys\SigningKeyGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+uses(RefreshDatabase::class);
+
+function reloadFapiRoutesForCors(): void
+{
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+
+    $appHost = (string) config('authn.app_host');
+    $fapi = Route::middleware('fapi');
+    if ((string) config('authn.routing_mode') === 'subdomain') {
+        $fapi->domain('{env_slug}.'.$appHost);
+    } else {
+        $fapi->prefix('{env_slug}');
+    }
+    $fapi->group(base_path('routes/fapi.php'));
+}
+
+function corsBoot(array $allowedOrigins = ['https://app.example.com'], string $kind = Environment::KIND_PRODUCTION): array
+{
+    config([
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.app_port_suffix' => '',
+        'authn.bapi_host' => 'api.authn.local',
+        'authn.dashboard_host' => 'dashboard.authn.local',
+    ]);
+    reloadFapiRoutesForCors();
+
+    $project = Project::create(['name' => 'P', 'slug' => 'p']);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => $kind,
+        'slug' => 'acme',
+        'frontend_api_host' => 'acme.authn.local',
+        'allowed_origins' => $allowedOrigins,
+    ]);
+    (new SigningKeyGenerator)->generate($env);
+    $user = User::create(['environment_id' => $env->id]);
+    $client = Client::create(['environment_id' => $env->id]);
+    $session = Session::create([
+        'environment_id' => $env->id,
+        'client_id' => $client->id,
+        'user_id' => $user->id,
+    ]);
+
+    return ['env' => $env, 'client' => $client, 'session' => $session];
+}
+
+/* ------------------------------------------------------------------ CORS preflight */
+
+it('OPTIONS preflight from an allowed origin returns 204 with CORS headers', function (): void {
+    corsBoot();
+
+    $response = $this->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Origin' => 'https://app.example.com',
+        'Access-Control-Request-Method' => 'POST',
+    ])->json('OPTIONS', 'https://acme.authn.local/v1/client');
+
+    expect($response->getStatusCode())->toBe(204);
+    expect($response->headers->get('Access-Control-Allow-Origin'))->toBe('https://app.example.com');
+    expect($response->headers->get('Access-Control-Allow-Credentials'))->toBe('true');
+    expect($response->headers->get('Access-Control-Allow-Methods'))->toContain('POST');
+    expect($response->headers->get('Access-Control-Allow-Headers'))->toContain('Authorization');
+    expect($response->headers->get('Access-Control-Max-Age'))->toBe('86400');
+});
+
+it('OPTIONS preflight from a disallowed origin returns 204 but NO CORS headers', function (): void {
+    corsBoot();
+
+    $response = $this->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Origin' => 'https://attacker.example',
+    ])->json('OPTIONS', 'https://acme.authn.local/v1/client');
+
+    expect($response->getStatusCode())->toBe(204);
+    expect($response->headers->get('Access-Control-Allow-Origin'))->toBeNull();
+});
+
+it('responses to allowed-origin requests carry CORS headers and Vary: Origin', function (): void {
+    $f = corsBoot();
+
+    $response = $this->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Origin' => 'https://app.example.com',
+    ])->getJson('https://acme.authn.local/v1/environment');
+
+    $response->assertOk();
+    expect($response->headers->get('Access-Control-Allow-Origin'))->toBe('https://app.example.com');
+    expect($response->headers->get('Vary'))->toContain('Origin');
+});
+
+/* ------------------------------------------------------------------ Origin enforcement */
+
+it('state-changing requests from an allowed origin are accepted', function (): void {
+    $f = corsBoot();
+    $cookie = app(ClientResolver::class)->mintCookieValue($f['client']);
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+        ])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens")
+        ->assertOk();
+});
+
+it('state-changing requests from a disallowed origin are rejected with origin_invalid', function (): void {
+    $f = corsBoot();
+    $cookie = app(ClientResolver::class)->mintCookieValue($f['client']);
+
+    $response = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://attacker.example',
+        ])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens");
+
+    $response->assertForbidden()
+        ->assertJsonPath('errors.0.code', 'origin_invalid')
+        ->assertJsonPath('errors.0.meta.origin', 'https://attacker.example')
+        ->assertJsonPath('errors.0.meta.allowed', ['https://app.example.com']);
+});
+
+it('state-changing requests with no Origin and no Bearer token are rejected', function (): void {
+    $f = corsBoot();
+    $cookie = app(ClientResolver::class)->mintCookieValue($f['client']);
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeader('Host', 'acme.authn.local')
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens")
+        ->assertForbidden()
+        ->assertJsonPath('errors.0.code', 'origin_invalid');
+});
+
+it('state-changing requests with a Bearer token bypass the Origin check', function (): void {
+    $f = corsBoot();
+    $cookie = app(ClientResolver::class)->mintCookieValue($f['client']);
+
+    // Bearer token is sufficient — Origin missing is OK on the bearer path.
+    // ResolveClientFromCookie still requires the cookie for the session lookup
+    // route, so we keep the cookie too.
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Authorization' => 'Bearer device_token_placeholder',
+        ])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens")
+        ->assertOk();
+});
+
+it('falls back to Referer host when Origin is absent', function (): void {
+    $f = corsBoot();
+    $cookie = app(ClientResolver::class)->mintCookieValue($f['client']);
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Referer' => 'https://app.example.com/some/path',
+        ])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens")
+        ->assertOk();
+});
+
+it('GET /v1/environment is publicly accessible from any origin', function (): void {
+    corsBoot(allowedOrigins: []);
+
+    $this->withHeaders(['Host' => 'acme.authn.local', 'Origin' => 'https://anywhere.example'])
+        ->getJson('https://acme.authn.local/v1/environment')
+        ->assertOk();
+});
+
+it('GET /v1/client is publicly accessible from any origin', function (): void {
+    corsBoot(allowedOrigins: []);
+
+    $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->getJson('https://acme.authn.local/v1/client')
+        ->assertOk();
+});
+
+it('default ports are normalised on both sides', function (): void {
+    $f = corsBoot(['https://app.example.com:443']);
+    $cookie = app(ClientResolver::class)->mintCookieValue($f['client']);
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',  // no explicit port
+        ])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens")
+        ->assertOk();
+});
+
+it('honours wildcard localhost patterns in development envs', function (): void {
+    $f = corsBoot(['http://localhost:*'], Environment::KIND_DEVELOPMENT);
+    $cookie = app(ClientResolver::class)->mintCookieValue($f['client']);
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'http://localhost:5173',
+        ])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens")
+        ->assertOk();
+});
+
+it('does NOT honour wildcard localhost patterns in production envs', function (): void {
+    $f = corsBoot(['http://localhost:*'], Environment::KIND_PRODUCTION);
+    $cookie = app(ClientResolver::class)->mintCookieValue($f['client']);
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'http://localhost:5173',
+        ])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens")
+        ->assertForbidden()
+        ->assertJsonPath('errors.0.code', 'origin_invalid');
+});

--- a/tests/Feature/Http/SessionTokenEndpointTest.php
+++ b/tests/Feature/Http/SessionTokenEndpointTest.php
@@ -49,6 +49,7 @@ function bootEnv(): array
         'kind' => Environment::KIND_PRODUCTION,
         'slug' => 'acme',
         'frontend_api_host' => 'acme.authn.local',
+        'allowed_origins' => ['https://app.example.com'],
     ]);
     (new SigningKeyGenerator)->generate($env);
     $user = User::create(['environment_id' => $env->id]);
@@ -68,7 +69,7 @@ it('mints a __session JWT when the cookie matches the device', function (): void
 
     $response = $this->withUnencryptedCookie('__client', $cookie)
         ->withCredentials()
-        ->withHeader('Host', 'acme.authn.local')
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => 'https://app.example.com'])
         ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens");
 
     $response->assertOk()->assertJsonStructure(['jwt', 'expires_at', 'kid']);
@@ -81,7 +82,7 @@ it('mints a __session JWT when the cookie matches the device', function (): void
 it('rejects the request with 401 when the __client cookie is missing', function (): void {
     $f = bootEnv();
 
-    $this->withHeader('Host', 'acme.authn.local')
+    $this->withHeaders(['Host' => 'acme.authn.local', 'Origin' => 'https://app.example.com'])
         ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens")
         ->assertUnauthorized()
         ->assertJsonPath('errors.0.code', 'client_not_found');
@@ -94,7 +95,7 @@ it('returns 404 when the session belongs to a different client', function (): vo
 
     $this->withUnencryptedCookie('__client', $cookie)
         ->withCredentials()
-        ->withHeader('Host', 'acme.authn.local')
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => 'https://app.example.com'])
         ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens")
         ->assertNotFound()
         ->assertJsonPath('errors.0.code', 'session_not_found');
@@ -109,7 +110,7 @@ it('returns 401 session_revoked for a session in a non-live status', function ()
 
     $this->withUnencryptedCookie('__client', $cookie)
         ->withCredentials()
-        ->withHeader('Host', 'acme.authn.local')
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => 'https://app.example.com'])
         ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens")
         ->assertUnauthorized()
         ->assertJsonPath('errors.0.code', 'session_revoked');
@@ -121,7 +122,7 @@ it('returns 404 template_not_found for any non-default template', function (): v
 
     $this->withUnencryptedCookie('__client', $cookie)
         ->withCredentials()
-        ->withHeader('Host', 'acme.authn.local')
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => 'https://app.example.com'])
         ->postJson("https://acme.authn.local/v1/client/sessions/{$f['session']->id}/tokens/supabase")
         ->assertNotFound()
         ->assertJsonPath('errors.0.code', 'template_not_found');
@@ -130,7 +131,7 @@ it('returns 404 template_not_found for any non-default template', function (): v
 it('serves JWKS at /.well-known/jwks.json with cache headers', function (): void {
     $f = bootEnv();
 
-    $response = $this->withHeader('Host', 'acme.authn.local')
+    $response = $this->withHeaders(['Host' => 'acme.authn.local', 'Origin' => 'https://app.example.com'])
         ->getJson('https://acme.authn.local/.well-known/jwks.json');
 
     $response->assertOk();
@@ -143,7 +144,7 @@ it('serves JWKS at /.well-known/jwks.json with cache headers', function (): void
 it('serves OIDC discovery at /.well-known/openid-configuration', function (): void {
     $f = bootEnv();
 
-    $response = $this->withHeader('Host', 'acme.authn.local')
+    $response = $this->withHeaders(['Host' => 'acme.authn.local', 'Origin' => 'https://app.example.com'])
         ->getJson('https://acme.authn.local/.well-known/openid-configuration');
 
     $response->assertOk()->assertJson([

--- a/tests/Unit/Support/AllowedOriginsTest.php
+++ b/tests/Unit/Support/AllowedOriginsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Support\AllowedOrigins;
+
+function envWith(array $allowed, string $kind = Environment::KIND_PRODUCTION): Environment
+{
+    return new Environment([
+        'project_id' => 'prj_01HKX9SY9V7H7TF8C8K7J9X4ZB',
+        'kind' => $kind,
+        'slug' => 'env',
+        'frontend_api_host' => 'env.authn.local',
+        'allowed_origins' => $allowed,
+    ]);
+}
+
+it('matches an exact entry', function (): void {
+    $env = envWith(['https://app.example.com']);
+    expect(AllowedOrigins::matches($env, 'https://app.example.com'))->toBeTrue();
+});
+
+it('strips default ports on both sides', function (): void {
+    $env = envWith(['https://app.example.com']);
+    expect(AllowedOrigins::matches($env, 'https://app.example.com:443'))->toBeTrue();
+
+    $env2 = envWith(['https://app.example.com:443']);
+    expect(AllowedOrigins::matches($env2, 'https://app.example.com'))->toBeTrue();
+
+    $env3 = envWith(['http://localhost:80']);
+    expect(AllowedOrigins::matches($env3, 'http://localhost'))->toBeTrue();
+});
+
+it('refuses non-default ports that do not match', function (): void {
+    $env = envWith(['https://app.example.com']);
+    expect(AllowedOrigins::matches($env, 'https://app.example.com:8443'))->toBeFalse();
+});
+
+it('lowercases the host when comparing', function (): void {
+    $env = envWith(['https://APP.example.com']);
+    expect(AllowedOrigins::matches($env, 'https://app.example.com'))->toBeTrue();
+});
+
+it('refuses an empty / malformed origin', function (): void {
+    $env = envWith(['https://app.example.com']);
+    expect(AllowedOrigins::matches($env, ''))->toBeFalse();
+    expect(AllowedOrigins::matches($env, 'not-a-url'))->toBeFalse();
+});
+
+it('refuses an origin not in the list', function (): void {
+    $env = envWith(['https://app.example.com']);
+    expect(AllowedOrigins::matches($env, 'https://attacker.example'))->toBeFalse();
+});
+
+it('honours port wildcard patterns only in development envs', function (): void {
+    $devEnv = envWith(['http://localhost:*'], Environment::KIND_DEVELOPMENT);
+    expect(AllowedOrigins::matches($devEnv, 'http://localhost:5173'))->toBeTrue();
+    expect(AllowedOrigins::matches($devEnv, 'http://localhost:3000'))->toBeTrue();
+
+    $prodEnv = envWith(['http://localhost:*'], Environment::KIND_PRODUCTION);
+    expect(AllowedOrigins::matches($prodEnv, 'http://localhost:5173'))->toBeFalse();
+});
+
+it('matches 127.0.0.1 wildcard pattern in development envs', function (): void {
+    $env = envWith(['http://127.0.0.1:*'], Environment::KIND_DEVELOPMENT);
+    expect(AllowedOrigins::matches($env, 'http://127.0.0.1:8000'))->toBeTrue();
+    expect(AllowedOrigins::matches($env, 'http://127.0.0.1'))->toBeTrue(); // no port
+});
+
+it('handles an empty allow list', function (): void {
+    $env = envWith([]);
+    expect(AllowedOrigins::matches($env, 'https://app.example.com'))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

Two FAPI middlewares + a shared comparator. Public bootstrap endpoints opt out via \`withoutMiddleware\`.

- **\`AllowedOrigins\`** comparator — exact match by default, default-ports stripped on both sides, case-insensitive host, dev-only wildcard port patterns (\`http://localhost:*\`, \`http://127.0.0.1:*\`).
- **\`FapiCors\`** — short-circuits OPTIONS preflights with 204 + CORS headers when the Origin is allowed (204 with NO headers otherwise — browser blocks the actual request). Adds CORS headers + \`Vary: Origin\` to non-OPTIONS responses.
- **\`EnforceFapiOrigin\`** — gates state-changing methods. Skips on safe methods + OPTIONS + Bearer-token requests. Reads Origin (or Referer host fallback) and demands a match. 403 \`origin_invalid\` with \`meta.origin\` + \`meta.allowed\` on mismatch.
- **Public bootstrap endpoints** (\`/v1/environment\`, \`/v1/client\`, \`/.well-known/*\`, \`/v1/client/handshake\`) opt out via \`withoutMiddleware([EnforceFapiOrigin::class])\`.
- **Catch-all OPTIONS handler** in \`routes/fapi.php\` so preflights for any FAPI URL get 204.
- **Pre-existing tests** updated: env fixture now includes \`allowed_origins\`; every state-changing request sends an Origin header.

Total suite: 172 / 172 green.

Closes #7.

## Test plan

- [x] \`php artisan test\` — 172/172 green locally.
- [x] \`vendor/bin/pint --test\` — clean.
- [x] OPTIONS preflight from allowed origin → 204 + CORS headers; from disallowed → 204 without.
- [x] State-changing request from disallowed origin → 403 origin_invalid with meta.origin + meta.allowed.
- [x] Bearer-token requests bypass Origin check; Referer fallback works.
- [x] GET /v1/environment and GET /v1/client publicly accessible.
- [x] Default-port normalisation matches \`https://x\` to \`https://x:443\`.
- [x] Dev wildcard localhost matches only in development envs.
- [ ] CI green on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)