### PR TITLE
FAPI sign-in flow: state machine + 4 strategies + ticket exchange (AU-9)

### DIFF
--- a/app/Auth/ErrorCodes.php
+++ b/app/Auth/ErrorCodes.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth;
+
+/**
+ * Centralized vocabulary for FAPI sign-in / sign-up error codes.
+ *
+ * Codes are stable strings that SDKs match on; never parse the
+ * `message` field. Keep this list in lockstep with the openapi spec
+ * so generated clients have an exhaustive enum.
+ */
+final class ErrorCodes
+{
+    // Form / parameter errors
+    public const FORM_PARAM_NIL = 'form_param_nil';
+
+    public const FORM_PARAM_FORMAT_INVALID = 'form_param_format_invalid';
+
+    public const FORM_IDENTIFIER_NOT_FOUND = 'form_identifier_not_found';
+
+    public const FORM_IDENTIFIER_EXISTS = 'form_identifier_exists';
+
+    // Password
+    public const FORM_PASSWORD_INCORRECT = 'form_password_incorrect';
+
+    public const FORM_PASSWORD_PWNED = 'form_password_pwned';
+
+    public const FORM_PASSWORD_VALIDATION_FAILED = 'form_password_validation_failed';
+
+    // Verification
+    public const FORM_CODE_INCORRECT = 'form_code_incorrect';
+
+    public const VERIFICATION_EXPIRED = 'verification_expired';
+
+    public const VERIFICATION_FAILED = 'verification_failed';
+
+    public const VERIFICATION_ALREADY_VERIFIED = 'verification_already_verified';
+
+    // Tickets / one-shot tokens
+    public const TICKET_INVALID = 'ticket_invalid';
+
+    public const TICKET_EXPIRED = 'ticket_expired';
+
+    // Session / user state
+    public const IDENTIFIER_ALREADY_SIGNED_IN = 'identifier_already_signed_in';
+
+    public const USER_LOCKED = 'user_locked';
+
+    public const USER_BANNED = 'user_banned';
+
+    public const SESSION_REVOKED = 'session_revoked';
+
+    // Captcha (full enforcement in AU-18)
+    public const CAPTCHA_INVALID = 'captcha_invalid';
+
+    // v0.1 stop signs for features that land later
+    public const TRANSFER_NOT_SUPPORTED_IN_V0_1 = 'transfer_not_supported_in_v0_1';
+
+    public const MFA_NOT_ENABLED_IN_V0_1 = 'mfa_not_enabled_in_v0_1';
+
+    public const STRATEGY_NOT_SUPPORTED_IN_V0_1 = 'strategy_not_supported_in_v0_1';
+
+    public const PREPARE_NOT_REQUIRED = 'prepare_not_required';
+
+    public const NEEDS_NEW_PASSWORD = 'needs_new_password';
+
+    public const NOT_IN_NEEDS_NEW_PASSWORD_STATE = 'not_in_needs_new_password_state';
+
+    public const SIGN_IN_NOT_FOUND = 'sign_in_not_found';
+
+    public const SIGN_IN_ABANDONED = 'sign_in_abandoned';
+
+    public const SIGN_IN_ALREADY_COMPLETE = 'sign_in_already_complete';
+}

--- a/app/Auth/Strategies/EmailCodeStrategy.php
+++ b/app/Auth/Strategies/EmailCodeStrategy.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Auth\ErrorCodes;
+use App\Jobs\Mail\SendVerificationEmail;
+use App\Models\EmailAddress;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Models\VerificationCode;
+use App\Services\Verification\VerificationManager;
+
+/**
+ * Email-OTP first-factor for sign-in.
+ *
+ * prepare:
+ *   - Resolves the EmailAddress by identifier (or by emailAddressId from
+ *     the SDK).
+ *   - Starts a Verification (strategy=email_code, TTL 10min).
+ *   - Mints a 6-digit code, persists its sha256, dispatches
+ *     SendVerificationEmail.
+ *   - Updates `attempt->first_factor_verification_id`.
+ *
+ * attempt:
+ *   - Reads the in-flight Verification.
+ *   - Calls VerificationManager::attempt with the user-supplied code.
+ *   - On success, returns the User; status flow handled by the
+ *     controller.
+ */
+final class EmailCodeStrategy implements Strategy
+{
+    public const PURPOSE = VerificationCode::PURPOSE_EMAIL_CODE;
+
+    public const TTL_SECONDS = 600;
+
+    public function __construct(private readonly VerificationManager $verifications) {}
+
+    public function name(): string
+    {
+        return Verification::STRATEGY_EMAIL_CODE;
+    }
+
+    public function requiresPrepare(): bool
+    {
+        return true;
+    }
+
+    public function prepare(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $emailAddress = $this->resolveEmailAddress($attempt, $params);
+        if ($emailAddress === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'No email address matches this identifier.', 422);
+        }
+
+        $verification = $this->verifications->start(
+            $emailAddress,
+            Verification::STRATEGY_EMAIL_CODE,
+            self::TTL_SECONDS,
+        );
+        $code = $this->verifications->mintNumericCode($verification, self::PURPOSE, self::TTL_SECONDS);
+
+        SendVerificationEmail::dispatch(
+            $attempt->environment_id,
+            $emailAddress->email_address,
+            $code,
+            self::PURPOSE,
+        );
+
+        $attempt->forceFill(['first_factor_verification_id' => $verification->id])->save();
+
+        return StrategyResult::ok($attempt);
+    }
+
+    public function attempt(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $code = $params['code'] ?? null;
+        if (! is_string($code) || $code === '') {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'code is required.');
+        }
+
+        $verification = Verification::query()
+            ->withoutGlobalScopes()
+            ->where('id', (string) $attempt->first_factor_verification_id)
+            ->first();
+        if ($verification === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, 'No verification is in progress for this attempt.', 422);
+        }
+
+        $ok = $this->verifications->attempt($verification, $code);
+        if (! $ok) {
+            $code = $verification->fresh()->status === Verification::STATUS_FAILED
+                ? ErrorCodes::VERIFICATION_FAILED
+                : ($verification->fresh()->status === Verification::STATUS_EXPIRED
+                    ? ErrorCodes::VERIFICATION_EXPIRED
+                    : ErrorCodes::FORM_CODE_INCORRECT);
+
+            return StrategyResult::fail($attempt, $code, 'Incorrect code.');
+        }
+
+        // Map verifiable -> User via EmailAddress.
+        $email = EmailAddress::query()->withoutGlobalScopes()->where('id', $verification->verifiable_id)->first();
+        $user = $email ? User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first() : null;
+
+        if ($user === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'User not found.', 422);
+        }
+
+        if ($user->banned) {
+            return StrategyResult::fail($attempt, ErrorCodes::USER_BANNED, 'This user is banned.', 403);
+        }
+        if ($user->locked && $user->lockout_expires_at?->isFuture()) {
+            return StrategyResult::fail($attempt, ErrorCodes::USER_LOCKED, 'This user is temporarily locked.', 403);
+        }
+
+        return StrategyResult::ok($attempt, $user);
+    }
+
+    private function resolveEmailAddress(SignInAttempt $attempt, array $params): ?EmailAddress
+    {
+        $emailAddressId = $params['email_address_id'] ?? null;
+        if (is_string($emailAddressId) && $emailAddressId !== '') {
+            return EmailAddress::query()
+                ->withoutGlobalScopes()
+                ->where('id', $emailAddressId)
+                ->where('environment_id', $attempt->environment_id)
+                ->first();
+        }
+
+        return EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower((string) $attempt->identifier))
+            ->first();
+    }
+}

--- a/app/Auth/Strategies/PasswordStrategy.php
+++ b/app/Auth/Strategies/PasswordStrategy.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Auth\ErrorCodes;
+use App\Models\EmailAddress;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+
+final class PasswordStrategy implements Strategy
+{
+    public function name(): string
+    {
+        return Verification::STRATEGY_PASSWORD;
+    }
+
+    public function requiresPrepare(): bool
+    {
+        return false;
+    }
+
+    public function prepare(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        return StrategyResult::fail($attempt, ErrorCodes::PREPARE_NOT_REQUIRED, 'Password strategy does not need a prepare step.', 422);
+    }
+
+    public function attempt(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $password = $params['password'] ?? null;
+        if (! is_string($password) || $password === '') {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'password is required.');
+        }
+
+        $identifier = (string) $attempt->identifier;
+        $user = $this->resolveUserByEmail($identifier, $attempt->environment_id);
+
+        // Same error code regardless of whether the user exists or the
+        // password is wrong, so we don't leak user existence. (The
+        // timing-attack mitigation that runs Hash::check on a decoy when
+        // the user doesn't exist will land alongside HIBP + brute-force
+        // lockout in AU-18.)
+        if ($user === null || ! $user->checkPassword($password)) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_PASSWORD_INCORRECT, 'Password is incorrect. Try again, or use another method.', 422);
+        }
+
+        if ($user->banned) {
+            return StrategyResult::fail($attempt, ErrorCodes::USER_BANNED, 'This user is banned.', 403);
+        }
+        if ($user->locked && $user->lockout_expires_at?->isFuture()) {
+            return StrategyResult::fail($attempt, ErrorCodes::USER_LOCKED, 'This user is temporarily locked.', 403);
+        }
+
+        return StrategyResult::ok($attempt, $user);
+    }
+
+    private function resolveUserByEmail(string $identifier, string $environmentId): ?User
+    {
+        $row = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $environmentId)
+            ->where('email_address', strtolower($identifier))
+            ->first();
+
+        if ($row === null) {
+            return null;
+        }
+
+        return User::query()
+            ->withoutGlobalScopes()
+            ->where('id', $row->user_id)
+            ->first();
+    }
+}

--- a/app/Auth/Strategies/ResetPasswordEmailCodeStrategy.php
+++ b/app/Auth/Strategies/ResetPasswordEmailCodeStrategy.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Auth\ErrorCodes;
+use App\Jobs\Mail\SendVerificationEmail;
+use App\Models\EmailAddress;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Models\VerificationCode;
+use App\Services\Verification\VerificationManager;
+
+/**
+ * Forgot-password flow: same email-OTP plumbing as EmailCodeStrategy
+ * but routed through the `reset_password_code` template (AU-14 wires
+ * the template). On successful attempt the SignInController flips
+ * `attempt->status` to `needs_new_password`; the SDK then calls
+ * `POST /v1/client/sign_ins/{id}/reset_password`.
+ */
+final class ResetPasswordEmailCodeStrategy implements Strategy
+{
+    public const PURPOSE = VerificationCode::PURPOSE_RESET_PASSWORD_EMAIL_CODE;
+
+    public const TTL_SECONDS = 600;
+
+    public function __construct(private readonly VerificationManager $verifications) {}
+
+    public function name(): string
+    {
+        return Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE;
+    }
+
+    public function requiresPrepare(): bool
+    {
+        return true;
+    }
+
+    public function prepare(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $emailAddress = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower((string) $attempt->identifier))
+            ->first();
+
+        if ($emailAddress === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'No email address matches this identifier.', 422);
+        }
+
+        $verification = $this->verifications->start(
+            $emailAddress,
+            Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE,
+            self::TTL_SECONDS,
+        );
+        $code = $this->verifications->mintNumericCode($verification, self::PURPOSE, self::TTL_SECONDS);
+
+        SendVerificationEmail::dispatch(
+            $attempt->environment_id,
+            $emailAddress->email_address,
+            $code,
+            self::PURPOSE,
+        );
+
+        $attempt->forceFill(['first_factor_verification_id' => $verification->id])->save();
+
+        return StrategyResult::ok($attempt);
+    }
+
+    public function attempt(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $code = $params['code'] ?? null;
+        if (! is_string($code) || $code === '') {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'code is required.');
+        }
+
+        $verification = Verification::query()
+            ->withoutGlobalScopes()
+            ->where('id', (string) $attempt->first_factor_verification_id)
+            ->first();
+        if ($verification === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, 'No verification is in progress for this attempt.', 422);
+        }
+
+        $ok = $this->verifications->attempt($verification, $code);
+        if (! $ok) {
+            $errorCode = $verification->fresh()->status === Verification::STATUS_FAILED
+                ? ErrorCodes::VERIFICATION_FAILED
+                : ($verification->fresh()->status === Verification::STATUS_EXPIRED
+                    ? ErrorCodes::VERIFICATION_EXPIRED
+                    : ErrorCodes::FORM_CODE_INCORRECT);
+
+            return StrategyResult::fail($attempt, $errorCode, 'Incorrect code.');
+        }
+
+        $email = EmailAddress::query()->withoutGlobalScopes()->where('id', $verification->verifiable_id)->first();
+        $user = $email ? User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first() : null;
+
+        if ($user === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'User not found.', 422);
+        }
+
+        return StrategyResult::ok($attempt, $user);
+    }
+}

--- a/app/Auth/Strategies/Strategy.php
+++ b/app/Auth/Strategies/Strategy.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Models\SignInAttempt;
+
+/**
+ * Each first-factor strategy implements this. The controller routes
+ * `prepare_first_factor` and `attempt_first_factor` calls to the right
+ * implementation via App\Auth\StrategyResolver.
+ */
+interface Strategy
+{
+    public function name(): string;
+
+    /**
+     * Long-form description of whether this strategy needs a prepare
+     * step. password / ticket are one-shot — they answer false here
+     * and the controller returns prepare_not_required.
+     */
+    public function requiresPrepare(): bool;
+
+    /**
+     * Issue any out-of-band material (email code, magic link). Called
+     * by `POST /v1/client/sign_ins/{id}/prepare_first_factor`.
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function prepare(SignInAttempt $attempt, array $params): StrategyResult;
+
+    /**
+     * Validate the user's response. Called by `attempt_first_factor`.
+     * Updates `attempt->status` per the lifecycle (PLAN §9.1):
+     *   correct → complete (or needs_new_password for reset)
+     *   wrong   → still in needs_first_factor; verification.attempts incremented
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function attempt(SignInAttempt $attempt, array $params): StrategyResult;
+}

--- a/app/Auth/Strategies/StrategyResult.php
+++ b/app/Auth/Strategies/StrategyResult.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Models\SignInAttempt;
+use App\Models\User;
+
+/**
+ * Common result shape returned by every Strategy method. The controller
+ * doesn't need to know about strategy internals — it inspects `success`,
+ * `errorCode`, `errorMessage`, then renders the SignInAttempt with any
+ * resulting Verification or User attached.
+ */
+final class StrategyResult
+{
+    private function __construct(
+        public readonly bool $success,
+        public readonly SignInAttempt $attempt,
+        public readonly ?User $user = null,
+        public readonly ?string $errorCode = null,
+        public readonly ?string $errorMessage = null,
+        public readonly int $httpStatus = 200,
+    ) {}
+
+    public static function ok(SignInAttempt $attempt, ?User $user = null): self
+    {
+        return new self(true, $attempt, $user);
+    }
+
+    public static function fail(SignInAttempt $attempt, string $code, string $message, int $httpStatus = 422): self
+    {
+        return new self(false, $attempt, null, $code, $message, $httpStatus);
+    }
+}

--- a/app/Auth/Strategies/TicketStrategy.php
+++ b/app/Auth/Strategies/TicketStrategy.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Auth\ErrorCodes;
+use App\Models\EmailAddress;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Services\Tickets\TicketVerifier;
+
+/**
+ * Redeems an `__authn_ticket` JWT (PLAN §9.7 / §9.8).
+ *
+ * Single-use: the verifier guards replay via the jti cache.
+ *
+ * Sub claim shape per purpose:
+ *   - invitation / organization_invitation: sub = email address
+ *   - sign_in_token / actor_token: sub = user_id
+ *   - waitlist_invite: sub = email address
+ *
+ * v0.1 supports the email-and-user paths for sign-in (sign_in_token,
+ * invitation that resolves to an existing user). Other purposes are
+ * relevant to sign-up (AU-10) — we let the controller transfer them
+ * over by returning an `unknown_purpose_for_sign_in` failure here.
+ */
+final class TicketStrategy implements Strategy
+{
+    public function __construct(private readonly TicketVerifier $verifier) {}
+
+    public function name(): string
+    {
+        return Verification::STRATEGY_TICKET;
+    }
+
+    public function requiresPrepare(): bool
+    {
+        return false;
+    }
+
+    public function prepare(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        return StrategyResult::fail($attempt, ErrorCodes::PREPARE_NOT_REQUIRED, 'Ticket strategy does not need a prepare step.', 422);
+    }
+
+    public function attempt(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $ticket = $params['ticket'] ?? null;
+        if (! is_string($ticket) || $ticket === '') {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'ticket is required.');
+        }
+
+        $claims = $this->verifier->verify($ticket, $attempt->environment);
+        if ($claims === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::TICKET_INVALID, 'Ticket is invalid, expired, or already redeemed.', 401);
+        }
+
+        $purpose = $claims['purpose'] ?? null;
+        $sub = $claims['sub'] ?? null;
+        if (! is_string($purpose) || ! is_string($sub)) {
+            return StrategyResult::fail($attempt, ErrorCodes::TICKET_INVALID, 'Ticket is missing required claims.', 422);
+        }
+
+        $user = match ($purpose) {
+            'sign_in_token', 'actor_token' => $this->resolveUserById($sub, $attempt->environment_id),
+            'invitation', 'organization_invitation', 'waitlist_invite' => $this->resolveUserByEmail($sub, $attempt->environment_id),
+            default => null,
+        };
+
+        if ($user === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'No user matches this ticket.', 422);
+        }
+
+        if ($user->banned) {
+            return StrategyResult::fail($attempt, ErrorCodes::USER_BANNED, 'This user is banned.', 403);
+        }
+        if ($user->locked && $user->lockout_expires_at?->isFuture()) {
+            return StrategyResult::fail($attempt, ErrorCodes::USER_LOCKED, 'This user is temporarily locked.', 403);
+        }
+
+        // Stamp the identifier so the rest of the controller has it.
+        if ($attempt->identifier === null) {
+            $primary = $user->primary_email_address_id
+                ? EmailAddress::query()->withoutGlobalScopes()->where('id', $user->primary_email_address_id)->first()
+                : null;
+            if ($primary !== null) {
+                $attempt->forceFill(['identifier' => $primary->email_address])->save();
+            }
+        }
+
+        return StrategyResult::ok($attempt, $user);
+    }
+
+    private function resolveUserById(string $userId, string $environmentId): ?User
+    {
+        return User::query()
+            ->withoutGlobalScopes()
+            ->where('id', $userId)
+            ->where('environment_id', $environmentId)
+            ->first();
+    }
+
+    private function resolveUserByEmail(string $email, string $environmentId): ?User
+    {
+        $row = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $environmentId)
+            ->where('email_address', strtolower($email))
+            ->first();
+
+        return $row ? User::query()->withoutGlobalScopes()->where('id', $row->user_id)->first() : null;
+    }
+}

--- a/app/Auth/StrategyResolver.php
+++ b/app/Auth/StrategyResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth;
+
+use App\Auth\Strategies\EmailCodeStrategy;
+use App\Auth\Strategies\PasswordStrategy;
+use App\Auth\Strategies\ResetPasswordEmailCodeStrategy;
+use App\Auth\Strategies\Strategy;
+use App\Auth\Strategies\TicketStrategy;
+use App\Models\Verification;
+use InvalidArgumentException;
+
+/**
+ * Maps strategy names from the wire (per PLAN §9.3) to their concrete
+ * Strategy implementations. Anything not in the v0.1 whitelist throws.
+ */
+final class StrategyResolver
+{
+    public function __construct(
+        private readonly PasswordStrategy $password,
+        private readonly EmailCodeStrategy $emailCode,
+        private readonly ResetPasswordEmailCodeStrategy $resetPasswordEmailCode,
+        private readonly TicketStrategy $ticket,
+    ) {}
+
+    public function resolve(string $name): Strategy
+    {
+        return match ($name) {
+            Verification::STRATEGY_PASSWORD => $this->password,
+            Verification::STRATEGY_EMAIL_CODE => $this->emailCode,
+            Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE => $this->resetPasswordEmailCode,
+            Verification::STRATEGY_TICKET => $this->ticket,
+            default => throw new InvalidArgumentException("Strategy {$name} is not enabled in v0.1."),
+        };
+    }
+}

--- a/app/Http/Controllers/Fapi/SignInController.php
+++ b/app/Http/Controllers/Fapi/SignInController.php
@@ -1,0 +1,401 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Auth\ErrorCodes;
+use App\Auth\StrategyResolver;
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\SignInResource;
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\Session;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Services\Client\ClientResolver;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Cookie;
+
+/**
+ * FAPI sign-in state-machine controller.
+ *
+ * Endpoints:
+ *   POST   /v1/client/sign_ins
+ *   GET    /v1/client/sign_ins/{id}
+ *   POST   /v1/client/sign_ins/{id}/prepare_first_factor
+ *   POST   /v1/client/sign_ins/{id}/attempt_first_factor
+ *   POST   /v1/client/sign_ins/{id}/prepare_second_factor   (404 in v0.1)
+ *   POST   /v1/client/sign_ins/{id}/attempt_second_factor   (404 in v0.1)
+ *   POST   /v1/client/sign_ins/{id}/reset_password
+ *
+ * v0.1 strategies: password, email_code, reset_password_email_code, ticket.
+ * Captcha trio is captured but not enforced (AU-18). MFA, OAuth, SAML,
+ * passkey strategies are out of scope for v0.1.
+ */
+final class SignInController
+{
+    public function __construct(private readonly StrategyResolver $strategies) {}
+
+    public function store(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $createdClient = false;
+        $client = $this->resolveOrCreateClient($request, $env, $createdClient);
+
+        if ($request->boolean('transfer')) {
+            return $this->error(422, ErrorCodes::TRANSFER_NOT_SUPPORTED_IN_V0_1, 'transfer flow lands in a later milestone.', $client);
+        }
+
+        $strategy = $request->input('strategy');
+        if ($strategy !== null && ! in_array($strategy, [
+            Verification::STRATEGY_PASSWORD,
+            Verification::STRATEGY_EMAIL_CODE,
+            Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE,
+            Verification::STRATEGY_TICKET,
+        ], true)) {
+            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategy} is not enabled in v0.1.", $client);
+        }
+
+        return DB::transaction(function () use ($request, $env, $client, $strategy, $createdClient): JsonResponse {
+            // Idempotency: if the Client already has a non-terminal attempt, return it.
+            $existing = $client->current_sign_in_attempt_id !== null
+                ? SignInAttempt::query()->withoutGlobalScopes()->where('id', $client->current_sign_in_attempt_id)->first()
+                : null;
+            if ($existing !== null && ! in_array($existing->status, [SignInAttempt::STATUS_COMPLETE, SignInAttempt::STATUS_ABANDONED], true) && ! $existing->isAbandoned()) {
+                return $this->envelope($client, $existing, 200, null, $createdClient);
+            }
+
+            $attempt = SignInAttempt::create([
+                'environment_id' => $env->id,
+                'client_id' => $client->id,
+                'identifier' => $request->input('identifier'),
+                'captcha_token' => $request->input('captcha_token'),
+                'captcha_widget_type' => $request->input('captcha_widget_type'),
+                'captcha_error' => $request->input('captcha_error'),
+            ]);
+
+            $client->forceFill(['current_sign_in_attempt_id' => $attempt->id])->saveQuietly();
+
+            // Inline-strategy short-circuits: when the create call carries a
+            // strategy + the credential, run it immediately so the SDK gets
+            // the terminal status in one round trip.
+            if ($strategy === Verification::STRATEGY_TICKET) {
+                return $this->runStrategy($attempt, $strategy, ['ticket' => $request->input('ticket')], $client, terminalAdvance: true, attachClientCookie: $createdClient);
+            }
+
+            if ($strategy === Verification::STRATEGY_PASSWORD && is_string($request->input('password'))) {
+                if (! is_string($attempt->identifier)) {
+                    return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'identifier is required when strategy=password.', $client);
+                }
+                $attempt->status = SignInAttempt::STATUS_NEEDS_FIRST_FACTOR;
+                $attempt->save();
+
+                return $this->runStrategy($attempt, $strategy, ['password' => $request->input('password')], $client, terminalAdvance: true, attachClientCookie: $createdClient);
+            }
+
+            if (is_string($attempt->identifier)) {
+                $attempt->status = SignInAttempt::STATUS_NEEDS_FIRST_FACTOR;
+                $attempt->save();
+            }
+
+            return $this->envelope($client, $attempt->fresh(), 200, null, $createdClient);
+        });
+    }
+
+    public function show(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $client = app(Client::class);
+        $attempt = SignInAttempt::query()
+            ->withoutGlobalScopes()
+            ->where('id', $sid)
+            ->where('client_id', $client->id)
+            ->first();
+        if ($attempt === null) {
+            return $this->error(404, ErrorCodes::SIGN_IN_NOT_FOUND, 'Sign-in attempt not found on this device.', $client);
+        }
+
+        return $this->envelope($client, $attempt);
+    }
+
+    public function prepareFirstFactor(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $client = app(Client::class);
+        $attempt = $this->loadAttempt($sid, $client);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        $strategyName = (string) $request->input('strategy', '');
+        if ($strategyName === '') {
+            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', $client);
+        }
+
+        try {
+            $strategy = $this->strategies->resolve($strategyName);
+        } catch (InvalidArgumentException) {
+            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategyName} is not enabled in v0.1.", $client);
+        }
+
+        if (! $strategy->requiresPrepare()) {
+            return $this->error(422, ErrorCodes::PREPARE_NOT_REQUIRED, "{$strategyName} does not need a prepare step.", $client);
+        }
+
+        $result = $strategy->prepare($attempt, [
+            'email_address_id' => $request->input('email_address_id'),
+            'redirect_url' => $request->input('redirect_url'),
+        ]);
+
+        if (! $result->success) {
+            return $this->error($result->httpStatus, $result->errorCode ?? ErrorCodes::VERIFICATION_FAILED, $result->errorMessage ?? '', $client, $result->attempt);
+        }
+
+        return $this->envelope($client, $result->attempt->fresh());
+    }
+
+    public function attemptFirstFactor(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $client = app(Client::class);
+        $attempt = $this->loadAttempt($sid, $client);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        $strategyName = (string) $request->input('strategy', '');
+        if ($strategyName === '') {
+            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', $client);
+        }
+
+        try {
+            $strategy = $this->strategies->resolve($strategyName);
+        } catch (InvalidArgumentException) {
+            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategyName} is not enabled in v0.1.", $client);
+        }
+
+        return $this->runStrategy($attempt, $strategyName, [
+            'password' => $request->input('password'),
+            'code' => $request->input('code'),
+            'ticket' => $request->input('ticket'),
+        ], $client, terminalAdvance: true);
+    }
+
+    public function prepareSecondFactor(Request $request): JsonResponse
+    {
+        return $this->error(404, ErrorCodes::MFA_NOT_ENABLED_IN_V0_1, 'Two-step verification lands in v0.3.');
+    }
+
+    public function attemptSecondFactor(Request $request): JsonResponse
+    {
+        return $this->error(404, ErrorCodes::MFA_NOT_ENABLED_IN_V0_1, 'Two-step verification lands in v0.3.');
+    }
+
+    public function resetPassword(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $client = app(Client::class);
+        $attempt = $this->loadAttempt($sid, $client);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        if ($attempt->status !== SignInAttempt::STATUS_NEEDS_NEW_PASSWORD) {
+            return $this->error(422, ErrorCodes::NOT_IN_NEEDS_NEW_PASSWORD_STATE, 'Sign-in is not awaiting a new password.', $client, $attempt);
+        }
+
+        $password = $request->input('password');
+        if (! is_string($password) || $password === '') {
+            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'password is required.', $client, $attempt);
+        }
+        if (strlen($password) < 8) {
+            return $this->error(422, ErrorCodes::FORM_PASSWORD_VALIDATION_FAILED, 'Password must be at least 8 characters.', $client, $attempt);
+        }
+
+        $verification = Verification::query()->withoutGlobalScopes()->where('id', (string) $attempt->first_factor_verification_id)->first();
+        $email = $verification ? EmailAddress::query()->withoutGlobalScopes()->where('id', $verification->verifiable_id)->first() : null;
+        $user = $email ? User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first() : null;
+        if ($user === null) {
+            return $this->error(422, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'User not found.', $client, $attempt);
+        }
+
+        // (HIBP breach check is a stub for v0.1; AU-18 wires the real call.)
+        $user->setPassword($password);
+        $user->save();
+
+        if ($request->boolean('sign_out_of_other_sessions')) {
+            $user->sessions()->whereIn('status', Session::LIVE_STATUSES)->each(function (Session $existing): void {
+                $existing->forceFill(['status' => Session::STATUS_REVOKED])->save();
+            });
+        }
+
+        $session = $this->createSession($attempt, $user);
+
+        return $this->envelope($client, $attempt->fresh(), 200, $session);
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    private function runStrategy(
+        SignInAttempt $attempt,
+        string $strategyName,
+        array $params,
+        Client $client,
+        bool $terminalAdvance,
+        bool $attachClientCookie = false,
+    ): JsonResponse {
+        $strategy = $this->strategies->resolve($strategyName);
+        $result = $strategy->attempt($attempt, $params);
+
+        if (! $result->success) {
+            return $this->error($result->httpStatus, $result->errorCode ?? ErrorCodes::VERIFICATION_FAILED, $result->errorMessage ?? '', $client, $result->attempt);
+        }
+
+        $attempt = $result->attempt;
+        $user = $result->user;
+
+        if (! $terminalAdvance) {
+            return $this->envelope($client, $attempt->fresh(), 200, null, $attachClientCookie);
+        }
+
+        // Reset-password strategy: hand-off to the new-password endpoint.
+        if ($strategyName === Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE) {
+            $attempt->status = SignInAttempt::STATUS_NEEDS_NEW_PASSWORD;
+            $attempt->save();
+
+            return $this->envelope($client, $attempt->fresh(), 200, null, $attachClientCookie);
+        }
+
+        // Otherwise create a Session and complete.
+        $session = $this->createSession($attempt, $user);
+
+        return $this->envelope($client, $attempt->fresh(), 200, $session, $attachClientCookie);
+    }
+
+    private function createSession(SignInAttempt $attempt, User $user): Session
+    {
+        $session = Session::create([
+            'environment_id' => $attempt->environment_id,
+            'client_id' => $attempt->client_id,
+            'user_id' => $user->id,
+            'status' => Session::STATUS_ACTIVE,
+        ]);
+
+        $attempt->forceFill([
+            'created_session_id' => $session->id,
+            'status' => SignInAttempt::STATUS_COMPLETE,
+        ])->save();
+
+        // Bump the Client's last_active_session_id.
+        Client::query()
+            ->withoutGlobalScopes()
+            ->where('id', $attempt->client_id)
+            ->update(['last_active_session_id' => $session->id, 'last_active_at' => now()]);
+
+        // Stamp the user as recently signed in.
+        $user->forceFill(['last_sign_in_at' => now(), 'last_active_at' => now()])->saveQuietly();
+
+        return $session;
+    }
+
+    private function loadAttempt(string $sid, Client $client): SignInAttempt|JsonResponse
+    {
+        $attempt = SignInAttempt::query()
+            ->withoutGlobalScopes()
+            ->where('id', $sid)
+            ->where('client_id', $client->id)
+            ->first();
+        if ($attempt === null) {
+            return $this->error(404, ErrorCodes::SIGN_IN_NOT_FOUND, 'Sign-in attempt not found on this device.', $client);
+        }
+        if ($attempt->isAbandoned()) {
+            return $this->error(422, ErrorCodes::SIGN_IN_ABANDONED, 'This sign-in attempt has been abandoned.', $client, $attempt);
+        }
+        if ($attempt->status === SignInAttempt::STATUS_COMPLETE) {
+            return $this->error(422, ErrorCodes::SIGN_IN_ALREADY_COMPLETE, 'This sign-in attempt is already complete.', $client, $attempt);
+        }
+
+        return $attempt;
+    }
+
+    private function resolveOrCreateClient(Request $request, Environment $env, bool &$created = false): Client
+    {
+        $cookie = $request->cookie('__client');
+        if (is_string($cookie)) {
+            $client = app(ClientResolver::class)->fromCookie($cookie, $env);
+            if ($client !== null) {
+                return $client;
+            }
+        }
+
+        $created = true;
+
+        return Client::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'last_active_at' => now(),
+        ]);
+    }
+
+    private function envelope(
+        Client $client,
+        ?SignInAttempt $attempt,
+        int $status = 200,
+        ?Session $newSession = null,
+        bool $attachClientCookie = false,
+    ): JsonResponse {
+        $response = response()->json([
+            'response' => SignInResource::from($attempt),
+            'client' => ClientResource::from($client->fresh()),
+        ], $status)->header('Cache-Control', 'no-store');
+
+        if ($attachClientCookie) {
+            $response = $response->withCookie($this->buildClientCookie($client));
+        }
+
+        return $response;
+    }
+
+    private function buildClientCookie(Client $client): Cookie
+    {
+        $value = app(ClientResolver::class)->mintCookieValue($client);
+
+        return \Illuminate\Support\Facades\Cookie::make(
+            name: '__client',
+            value: $value,
+            minutes: 60 * 24 * 365,
+            path: '/',
+            domain: null,
+            secure: request()->secure(),
+            httpOnly: true,
+            raw: false,
+            sameSite: 'lax',
+        );
+    }
+
+    private function error(int $status, string $code, string $message, ?Client $client = null, ?SignInAttempt $attempt = null): JsonResponse
+    {
+        $body = [
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ];
+        if ($client !== null) {
+            $body['client'] = ClientResource::from($client->fresh());
+        }
+        if ($attempt !== null) {
+            $body['response'] = SignInResource::from($attempt->fresh());
+        }
+
+        return response()->json($body, $status)->header('Cache-Control', 'no-store');
+    }
+}

--- a/app/Http/Resources/ClientResource.php
+++ b/app/Http/Resources/ClientResource.php
@@ -6,6 +6,7 @@ namespace App\Http\Resources;
 
 use App\Models\Client;
 use App\Models\Session;
+use App\Models\SignInAttempt;
 
 /**
  * The Client snapshot returned to the SDK. Mirrors PLAN §8.2.
@@ -37,11 +38,22 @@ final class ClientResource
             ->map(fn (Session $session) => self::sessionShape($session))
             ->all();
 
+        $signIn = null;
+        if ($client->current_sign_in_attempt_id !== null) {
+            $attempt = SignInAttempt::query()
+                ->withoutGlobalScopes()
+                ->where('id', $client->current_sign_in_attempt_id)
+                ->first();
+            if ($attempt !== null && ! in_array($attempt->status, [SignInAttempt::STATUS_COMPLETE, SignInAttempt::STATUS_ABANDONED], true)) {
+                $signIn = SignInResource::from($attempt);
+            }
+        }
+
         return [
             'object' => 'client',
             'id' => $client->id,
             'sessions' => $sessions,
-            'sign_in' => null,                      // populated in AU-9
+            'sign_in' => $signIn,
             'sign_up' => null,                      // populated in AU-10
             'last_active_session_id' => $client->last_active_session_id,
             'created_at' => $client->created_at?->getTimestampMs(),

--- a/app/Http/Resources/SignInResource.php
+++ b/app/Http/Resources/SignInResource.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\EmailAddress;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+
+/**
+ * Mirrors PLAN §3.2's SignIn shape — what FAPI returns for any
+ * sign-in state-machine endpoint. Surfaces just enough of the user
+ * to render an avatar / name preview without revealing private data
+ * before authentication completes.
+ */
+final class SignInResource
+{
+    public static function from(?SignInAttempt $attempt): ?array
+    {
+        if ($attempt === null) {
+            return null;
+        }
+
+        return [
+            'object' => 'sign_in_attempt',
+            'id' => $attempt->id,
+            'status' => $attempt->status,
+            'identifier' => $attempt->identifier,
+            'supported_identifiers' => ['email_address'],
+            'supported_first_factors' => self::supportedFirstFactors($attempt),
+            'supported_second_factors' => [],
+            'first_factor_verification' => self::verificationShape(
+                $attempt->first_factor_verification_id !== null
+                    ? Verification::query()->withoutGlobalScopes()->where('id', $attempt->first_factor_verification_id)->first()
+                    : null
+            ),
+            'second_factor_verification' => null,
+            'user_data' => self::userDataPreview($attempt),
+            'created_session_id' => $attempt->created_session_id,
+            'abandon_at' => $attempt->abandon_at->getTimestampMs(),
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private static function supportedFirstFactors(SignInAttempt $attempt): array
+    {
+        if ($attempt->identifier === null) {
+            return [];
+        }
+
+        $email = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower($attempt->identifier))
+            ->first();
+        if ($email === null) {
+            return [];
+        }
+
+        $user = User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first();
+        if ($user === null) {
+            return [];
+        }
+
+        $factors = [];
+        if ($user->password_hash !== null) {
+            $factors[] = ['strategy' => Verification::STRATEGY_PASSWORD];
+        }
+        $factors[] = [
+            'strategy' => Verification::STRATEGY_EMAIL_CODE,
+            'email_address_id' => $email->id,
+            'safe_identifier' => self::redactEmail($email->email_address),
+        ];
+        $factors[] = [
+            'strategy' => Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE,
+            'email_address_id' => $email->id,
+            'safe_identifier' => self::redactEmail($email->email_address),
+        ];
+
+        return $factors;
+    }
+
+    private static function verificationShape(?Verification $verification): ?array
+    {
+        if ($verification === null) {
+            return null;
+        }
+
+        return [
+            'object' => 'verification',
+            'status' => $verification->status,
+            'strategy' => $verification->strategy,
+            'attempts' => $verification->attempts,
+            'expire_at' => $verification->expire_at->getTimestampMs(),
+            'external_verification_redirect_url' => $verification->external_verification_redirect_url,
+            'nonce' => $verification->nonce,
+            'error' => $verification->error_code !== null ? [
+                'code' => $verification->error_code,
+                'message' => $verification->error_message,
+            ] : null,
+        ];
+    }
+
+    private static function userDataPreview(SignInAttempt $attempt): ?array
+    {
+        if ($attempt->identifier === null) {
+            return null;
+        }
+
+        $email = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower($attempt->identifier))
+            ->first();
+        if ($email === null) {
+            return null;
+        }
+        $user = User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first();
+        if ($user === null) {
+            return null;
+        }
+
+        return [
+            'first_name' => $user->first_name,
+            'last_name' => $user->last_name,
+            'image_url' => $user->image_url,
+            'has_image' => (bool) $user->has_image,
+        ];
+    }
+
+    private static function redactEmail(string $email): string
+    {
+        if (! str_contains($email, '@')) {
+            return $email;
+        }
+        [$local, $domain] = explode('@', $email, 2);
+        $first = $local !== '' ? $local[0] : '';
+
+        return $first.str_repeat('*', max(1, strlen($local) - 1)).'@'.$domain;
+    }
+}

--- a/app/Jobs/Mail/SendVerificationEmail.php
+++ b/app/Jobs/Mail/SendVerificationEmail.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Queue job that renders the `verification_code` email template and
+ * dispatches it via the env's mail driver.
+ *
+ * v0.1 placeholder — AU-14 lights up MJML rendering + driver
+ * abstraction. For now the job just logs the payload so the sign-in /
+ * sign-up flows can be tested end-to-end.
+ */
+final class SendVerificationEmail implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly string $environmentId,
+        public readonly string $emailAddress,
+        public readonly string $code,
+        public readonly string $purpose,
+    ) {
+        $this->onQueue('mail');
+    }
+
+    public function handle(): void
+    {
+        Log::info('SendVerificationEmail (AU-14 stub)', [
+            'environment_id' => $this->environmentId,
+            'to' => $this->emailAddress,
+            'purpose' => $this->purpose,
+            'code_length' => strlen($this->code),
+        ]);
+    }
+}

--- a/app/Services/Tickets/TicketIssuer.php
+++ b/app/Services/Tickets/TicketIssuer.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Tickets;
+
+use App\Models\Environment;
+use App\Models\SigningKey;
+use App\Support\Url;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+
+/**
+ * Mints `__authn_ticket` JWTs for invitation / sign-in-token / actor-token
+ * URL flows (PLAN §9.7).
+ *
+ * Tokens carry:
+ *   aud = "ticket"
+ *   iss = the env's FAPI URL
+ *   sub = the redemption subject (email for invitations, user_id for
+ *         sign-in tokens)
+ *   sid = the source resource id (`inv_…`, `sit_…`, `act_…`)
+ *   purpose = `invitation | organization_invitation | sign_in_token |
+ *             actor_token | waitlist_invite`
+ *   metadata = public_metadata copied from the source
+ *   redirect_url = post-redemption landing
+ *
+ * Single-use semantics live in the verifier (jti tracked in the cache for
+ * the lifetime of the token).
+ */
+final class TicketIssuer
+{
+    /**
+     * @param  array<string, mixed>  $claims  extras like sub, sid, purpose, metadata, redirect_url.
+     */
+    public function issue(Environment $environment, int $ttlSeconds, array $claims): string
+    {
+        $signingKey = $environment->signingKeys()
+            ->where('status', SigningKey::STATUS_ACTIVE)
+            ->latest('activated_at')
+            ->firstOrFail();
+
+        $config = Configuration::forAsymmetricSigner(
+            new Sha256,
+            InMemory::plainText($signingKey->privatePem()),
+            InMemory::plainText('public-not-needed-for-signing'),
+        );
+
+        $now = now();
+        $expiresAt = $now->copy()->addSeconds($ttlSeconds);
+
+        $builder = $config->builder()
+            ->withHeader('kid', $signingKey->id)
+            ->issuedBy(Url::fapi($environment, ''))
+            ->permittedFor('ticket')
+            ->identifiedBy($this->mintJti())
+            ->issuedAt($now->toDateTimeImmutable())
+            ->canOnlyBeUsedAfter($now->toDateTimeImmutable())
+            ->expiresAt($expiresAt->toDateTimeImmutable());
+
+        if (isset($claims['sub']) && is_string($claims['sub'])) {
+            $builder = $builder->relatedTo($claims['sub']);
+        }
+        foreach (['sid', 'purpose', 'metadata', 'redirect_url'] as $name) {
+            if (array_key_exists($name, $claims)) {
+                $builder = $builder->withClaim($name, $claims[$name]);
+            }
+        }
+
+        return $builder->getToken($config->signer(), $config->signingKey())->toString();
+    }
+
+    private function mintJti(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(16)), '+/', '-_'), '=');
+    }
+}

--- a/app/Services/Tickets/TicketVerifier.php
+++ b/app/Services/Tickets/TicketVerifier.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Tickets;
+
+use App\Models\Environment;
+use App\Models\SigningKey;
+use App\Support\Url;
+use Illuminate\Support\Facades\Cache;
+use Lcobucci\Clock\SystemClock;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Token\Parser;
+use Lcobucci\JWT\Token\Plain;
+use Lcobucci\JWT\Validation\Constraint\IssuedBy;
+use Lcobucci\JWT\Validation\Constraint\PermittedFor;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Lcobucci\JWT\Validation\Constraint\StrictValidAt;
+use Lcobucci\JWT\Validation\Validator;
+
+/**
+ * Verifies + redeems `__authn_ticket` JWTs (PLAN §9.7 / §9.8).
+ *
+ * Responsibilities:
+ *   - Parse the JWT and locate its kid in the env's published key set.
+ *   - Validate signature, issuer (FAPI URL), audience ("ticket"), clock.
+ *   - Single-use guard: the jti is cached at redemption time; replays
+ *     return null.
+ *   - Returns the decoded claims map on success or null on any failure.
+ *
+ * The "purpose" claim discriminates which downstream flow handles
+ * the ticket (invitation, sign_in_token, …) — that policy lives in
+ * the controllers, not here.
+ */
+final class TicketVerifier
+{
+    private const JTI_CACHE_PREFIX = 'ticket:jti:';
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function verify(string $jwt, Environment $environment): ?array
+    {
+        try {
+            $token = (new Parser(new JoseEncoder))->parse($jwt);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (! $token instanceof Plain) {
+            return null;
+        }
+
+        $kid = (string) ($token->headers()->get('kid') ?? '');
+        if ($kid === '') {
+            return null;
+        }
+
+        $signingKey = $environment->signingKeys()
+            ->where('id', $kid)
+            ->whereIn('status', [
+                SigningKey::STATUS_ACTIVE,
+                SigningKey::STATUS_RETIRING,
+                SigningKey::STATUS_PENDING,
+            ])
+            ->first();
+        if ($signingKey === null) {
+            return null;
+        }
+
+        $publicResource = openssl_pkey_get_private($signingKey->privatePem());
+        $publicPem = openssl_pkey_get_details($publicResource)['key'];
+
+        try {
+            (new Validator)->assert(
+                $token,
+                new SignedWith(new Sha256, InMemory::plainText($publicPem)),
+                new IssuedBy(Url::fapi($environment, '')),
+                new PermittedFor('ticket'),
+                new StrictValidAt(SystemClock::fromSystemTimezone()),
+            );
+        } catch (\Throwable) {
+            return null;
+        }
+
+        $jti = $token->claims()->get('jti');
+        if (! is_string($jti) || $jti === '') {
+            return null;
+        }
+
+        $expiresAt = $token->claims()->get('exp');
+        $ttl = $expiresAt instanceof \DateTimeInterface
+            ? max(60, $expiresAt->getTimestamp() - now()->getTimestamp() + 60)
+            : 60 * 60;
+
+        $cacheKey = self::JTI_CACHE_PREFIX.$environment->id.':'.$jti;
+        if (! Cache::add($cacheKey, 1, $ttl)) {
+            return null; // replay
+        }
+
+        return $token->claims()->all();
+    }
+}

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Fapi\ClientController;
 use App\Http\Controllers\Fapi\EnvironmentController;
 use App\Http\Controllers\Fapi\PingController;
 use App\Http\Controllers\Fapi\SessionTokenController;
+use App\Http\Controllers\Fapi\SignInController;
 use App\Http\Controllers\WellKnown\JwksController;
 use App\Http\Controllers\WellKnown\OpenIdConfigurationController;
 use App\Http\Middleware\EnforceFapiOrigin;
@@ -48,9 +49,17 @@ Route::prefix('v1')->group(function (): void {
         Route::match(['get', 'post'], '/client/handshake', [ClientController::class, 'handshake'])->name('fapi.client.handshake');
     });
 
-    // Routes that require an existing Client (resolved from the __client
-    // cookie via ResolveClientFromCookie).
+    // Sign-in: POST creates the attempt (and, if needed, the Client). The
+    // remaining endpoints require an existing Client cookie.
+    Route::post('/client/sign_ins', [SignInController::class, 'store'])->name('fapi.sign_in.store');
     Route::middleware(ResolveClientFromCookie::class)->group(function (): void {
+        Route::get('/client/sign_ins/{sid}', [SignInController::class, 'show'])->name('fapi.sign_in.show');
+        Route::post('/client/sign_ins/{sid}/prepare_first_factor', [SignInController::class, 'prepareFirstFactor'])->name('fapi.sign_in.prepare_first_factor');
+        Route::post('/client/sign_ins/{sid}/attempt_first_factor', [SignInController::class, 'attemptFirstFactor'])->name('fapi.sign_in.attempt_first_factor');
+        Route::post('/client/sign_ins/{sid}/prepare_second_factor', [SignInController::class, 'prepareSecondFactor'])->name('fapi.sign_in.prepare_second_factor');
+        Route::post('/client/sign_ins/{sid}/attempt_second_factor', [SignInController::class, 'attemptSecondFactor'])->name('fapi.sign_in.attempt_second_factor');
+        Route::post('/client/sign_ins/{sid}/reset_password', [SignInController::class, 'resetPassword'])->name('fapi.sign_in.reset_password');
+
         Route::post('/client/sessions/{sid}/tokens', SessionTokenController::class)->name('fapi.session_token');
         Route::post('/client/sessions/{sid}/tokens/{template}', SessionTokenController::class)->name('fapi.session_token.template');
     });

--- a/tests/Feature/Http/SignIn/EmailCodeTest.php
+++ b/tests/Feature/Http/SignIn/EmailCodeTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Verification;
+use App\Models\VerificationCode;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Http\SignIn\SignInTestSupport;
+
+uses(RefreshDatabase::class);
+
+it('runs the prepare → attempt → complete email-code path end-to-end', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    // Pre-create the Client + cookie so we don't have to round-trip the
+    // Set-Cookie header through the test harness's cookie jar.
+    $bs = SignInTestSupport::clientWithCookie($f['env']);
+    $cookie = $bs['cookie'];
+    $cookieName = '__client';
+
+    // 1. POST /sign_ins (identifier-only)
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie($cookieName, $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'identifier' => 'alice@example.com',
+        ]);
+    $create->assertOk()->assertJsonPath('response.status', 'needs_first_factor');
+    $sid = $create->json('response.id');
+
+    // 2. POST /prepare_first_factor strategy=email_code
+    $this->withCredentials()
+        ->withUnencryptedCookie($cookieName, $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/prepare_first_factor", [
+            'strategy' => 'email_code',
+        ])
+        ->assertOk();
+
+    // 3. Pull the cleartext code from the verification_codes table by re-hashing
+    //    the candidate sent in step 4.
+    $verification = Verification::query()->withoutGlobalScopes()->latest('id')->first();
+    expect($verification)->not->toBeNull();
+    $codeRow = VerificationCode::query()->where('verification_id', $verification->id)->latest('id')->first();
+    expect($codeRow)->not->toBeNull();
+
+    // The cleartext is gone — but for the purpose of the test we mint a new
+    // code via the manager and stamp it on the row so we know the secret.
+    $known = '424242';
+    $codeRow->forceFill(['code_hash' => hash('sha256', $known)])->save();
+
+    // 4. POST /attempt_first_factor with the right code → complete
+    $attempt = $this->withCredentials()
+        ->withUnencryptedCookie($cookieName, $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/attempt_first_factor", [
+            'strategy' => 'email_code',
+            'code' => $known,
+        ]);
+
+    $attempt->assertOk()->assertJsonPath('response.status', 'complete');
+    expect($attempt->json('response.created_session_id'))->toStartWith('sess_');
+});
+
+it('flips the verification to failed after 5 wrong codes', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    SignInTestSupport::makeUser($f['env']);
+    $bs = SignInTestSupport::clientWithCookie($f['env']);
+    $cookie = $bs['cookie'];
+
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'identifier' => 'alice@example.com',
+        ]);
+    $sid = $create->json('response.id');
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/prepare_first_factor", ['strategy' => 'email_code'])
+        ->assertOk();
+
+    for ($i = 0; $i < 5; $i++) {
+        $r = $this->withCredentials()
+            ->withUnencryptedCookie('__client', $cookie)
+            ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+            ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/attempt_first_factor", [
+                'strategy' => 'email_code',
+                'code' => '000000',
+            ]);
+        $r->assertStatus(422);
+    }
+
+    $verification = Verification::query()->withoutGlobalScopes()->latest('id')->first();
+    expect($verification->status)->toBe('failed');
+});

--- a/tests/Feature/Http/SignIn/PasswordTest.php
+++ b/tests/Feature/Http/SignIn/PasswordTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Session;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Http\SignIn\SignInTestSupport;
+
+uses(RefreshDatabase::class);
+
+it('completes a sign-in when identifier + strategy=password + password are supplied in one call', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    SignInTestSupport::makeUser($f['env']);
+
+    $response = $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'identifier' => 'alice@example.com',
+            'strategy' => 'password',
+            'password' => 'super-secret-password',
+        ]);
+
+    $response->assertOk()
+        ->assertJsonPath('response.status', 'complete')
+        ->assertJsonPath('response.identifier', 'alice@example.com');
+
+    $sessionId = $response->json('response.created_session_id');
+    expect($sessionId)->toStartWith('sess_');
+    expect(Session::query()->withoutGlobalScopes()->where('id', $sessionId)->where('status', 'active')->exists())->toBeTrue();
+});
+
+it('returns form_password_incorrect on a wrong password', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    SignInTestSupport::makeUser($f['env']);
+
+    $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'identifier' => 'alice@example.com',
+            'strategy' => 'password',
+            'password' => 'wrong-password',
+        ])
+        ->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'form_password_incorrect');
+});
+
+it('returns form_password_incorrect for an unknown identifier (no user-existence leak)', function (): void {
+    $f = SignInTestSupport::bootEnv();
+
+    $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'identifier' => 'ghost@example.com',
+            'strategy' => 'password',
+            'password' => 'whatever',
+        ])
+        ->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'form_password_incorrect');
+});
+
+it('refuses sign-in for a banned user', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    $bundle['user']->forceFill(['banned' => true])->saveQuietly();
+
+    $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'identifier' => 'alice@example.com',
+            'strategy' => 'password',
+            'password' => 'super-secret-password',
+        ])
+        ->assertStatus(403)
+        ->assertJsonPath('errors.0.code', 'user_banned');
+});
+
+it('refuses sign-in for a locked user with a future lockout_expires_at', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    $bundle['user']->forceFill([
+        'locked' => true,
+        'lockout_expires_at' => now()->addHour(),
+    ])->saveQuietly();
+
+    $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'identifier' => 'alice@example.com',
+            'strategy' => 'password',
+            'password' => 'super-secret-password',
+        ])
+        ->assertStatus(403)
+        ->assertJsonPath('errors.0.code', 'user_locked');
+});
+
+it('returns supported_first_factors on identifier-only create', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    SignInTestSupport::makeUser($f['env']);
+
+    $response = $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'identifier' => 'alice@example.com',
+        ]);
+
+    $response->assertOk()
+        ->assertJsonPath('response.status', 'needs_first_factor');
+
+    $strategies = collect($response->json('response.supported_first_factors'))->pluck('strategy');
+    expect($strategies->contains('password'))->toBeTrue();
+    expect($strategies->contains('email_code'))->toBeTrue();
+    expect($strategies->contains('reset_password_email_code'))->toBeTrue();
+});

--- a/tests/Feature/Http/SignIn/ResetPasswordTest.php
+++ b/tests/Feature/Http/SignIn/ResetPasswordTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Session;
+use App\Models\User;
+use App\Models\Verification;
+use App\Models\VerificationCode;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\Feature\Http\SignIn\SignInTestSupport;
+
+uses(RefreshDatabase::class);
+
+it('runs the reset_password_email_code → reset_password → complete path end-to-end', function (): void {
+    Bus::fake();
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    $bs = SignInTestSupport::clientWithCookie($f['env']);
+    $cookie = $bs['cookie'];
+
+    // 1. Open the attempt with strategy=reset_password_email_code (no prepare needed
+    //    yet — just stash the strategy intent).
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'identifier' => 'alice@example.com',
+        ]);
+    $sid = $create->json('response.id');
+
+    // 2. Prepare the reset code.
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/prepare_first_factor", [
+            'strategy' => 'reset_password_email_code',
+        ])
+        ->assertOk();
+
+    $verification = Verification::query()->withoutGlobalScopes()->latest('id')->first();
+    $codeRow = VerificationCode::query()->where('verification_id', $verification->id)->latest('id')->first();
+    $known = '424242';
+    $codeRow->forceFill(['code_hash' => hash('sha256', $known)])->save();
+
+    // 3. Attempt with the right code → status flips to needs_new_password.
+    $attempt = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/attempt_first_factor", [
+            'strategy' => 'reset_password_email_code',
+            'code' => $known,
+        ]);
+    $attempt->assertOk()->assertJsonPath('response.status', 'needs_new_password');
+
+    // 4. Submit a new password → complete + Session minted.
+    $reset = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/reset_password", [
+            'password' => 'brand-new-password-9000',
+        ]);
+    $reset->assertOk()->assertJsonPath('response.status', 'complete');
+
+    // 5. The new password works.
+    $user = User::query()->withoutGlobalScopes()->where('id', $bundle['user']->id)->first();
+    expect($user->checkPassword('brand-new-password-9000'))->toBeTrue();
+    expect($user->checkPassword('super-secret-password'))->toBeFalse();
+});
+
+it('refuses /reset_password unless the attempt is in needs_new_password state', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    SignInTestSupport::makeUser($f['env']);
+    $bs = SignInTestSupport::clientWithCookie($f['env']);
+    $cookie = $bs['cookie'];
+
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'identifier' => 'alice@example.com',
+        ]);
+    $sid = $create->json('response.id');
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/reset_password", [
+            'password' => 'whatever',
+        ])
+        ->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'not_in_needs_new_password_state');
+});

--- a/tests/Feature/Http/SignIn/SignInTestSupport.php
+++ b/tests/Feature/Http/SignIn/SignInTestSupport.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\SignIn;
+
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\User;
+use App\Services\Client\ClientResolver;
+use App\Services\Keys\SigningKeyGenerator;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * Shared fixtures for the SignIn HTTP tests. Uses a per-call random
+ * suffix so multiple `signInBoot()` calls in the same test don't trip
+ * the env_slug unique constraint.
+ */
+final class SignInTestSupport
+{
+    public static function reloadRoutes(): void
+    {
+        $router = app('router');
+        $router->setRoutes(new RouteCollection);
+
+        $appHost = (string) config('authn.app_host');
+        $fapi = Route::middleware('fapi');
+        if ((string) config('authn.routing_mode') === 'subdomain') {
+            $fapi->domain('{env_slug}.'.$appHost);
+        } else {
+            $fapi->prefix('{env_slug}');
+        }
+        $fapi->group(base_path('routes/fapi.php'));
+    }
+
+    public static function bootEnv(string $allowedOrigin = 'https://app.example.com'): array
+    {
+        config([
+            'authn.routing_mode' => 'subdomain',
+            'authn.app_host' => 'authn.local',
+            'authn.app_scheme' => 'https',
+            'authn.app_port_suffix' => '',
+            'authn.bapi_host' => 'api.authn.local',
+            'authn.dashboard_host' => 'dashboard.authn.local',
+        ]);
+        self::reloadRoutes();
+
+        $project = Project::create(['name' => 'P', 'slug' => 'p']);
+        $env = Environment::create([
+            'project_id' => $project->id,
+            'kind' => Environment::KIND_PRODUCTION,
+            'slug' => 'acme',
+            'frontend_api_host' => 'acme.authn.local',
+            'allowed_origins' => [$allowedOrigin],
+        ]);
+        (new SigningKeyGenerator)->generate($env);
+
+        return ['env' => $env, 'origin' => $allowedOrigin];
+    }
+
+    public static function makeUser(Environment $env, string $email = 'alice@example.com', ?string $password = 'super-secret-password'): array
+    {
+        $user = new User(['environment_id' => $env->id, 'first_name' => 'Alice', 'last_name' => 'Smith']);
+        if ($password !== null) {
+            $user->setPassword($password);
+        }
+        $user->save();
+
+        $emailRow = EmailAddress::create([
+            'environment_id' => $env->id,
+            'user_id' => $user->id,
+            'email_address' => $email,
+            'verified_at' => now(),
+            'is_primary' => true,
+        ]);
+
+        return ['user' => $user->fresh(), 'email' => $emailRow];
+    }
+
+    public static function clientWithCookie(Environment $env): array
+    {
+        $client = Client::create(['environment_id' => $env->id]);
+        $cookie = app(ClientResolver::class)->mintCookieValue($client);
+
+        return ['client' => $client, 'cookie' => $cookie];
+    }
+}

--- a/tests/Feature/Http/SignIn/TicketTest.php
+++ b/tests/Feature/Http/SignIn/TicketTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Tickets\TicketIssuer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Http\SignIn\SignInTestSupport;
+
+uses(RefreshDatabase::class);
+
+it('redeems a sign_in_token ticket and lands on complete', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+
+    $ticket = app(TicketIssuer::class)->issue($f['env'], 1800, [
+        'sub' => $bundle['user']->id,
+        'sid' => 'sit_01HKX9SY9V7H7TF8C8K7J9X4ZB',
+        'purpose' => 'sign_in_token',
+    ]);
+
+    $response = $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'strategy' => 'ticket',
+            'ticket' => $ticket,
+        ]);
+
+    $response->assertOk()->assertJsonPath('response.status', 'complete');
+    expect($response->json('response.created_session_id'))->toStartWith('sess_');
+});
+
+it('refuses a replayed ticket (single-use jti)', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+
+    $ticket = app(TicketIssuer::class)->issue($f['env'], 1800, [
+        'sub' => $bundle['user']->id,
+        'sid' => 'sit_01HKX9SY9V7H7TF8C8K7J9X4ZC',
+        'purpose' => 'sign_in_token',
+    ]);
+
+    // First redemption succeeds.
+    $first = $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'strategy' => 'ticket',
+            'ticket' => $ticket,
+        ]);
+    $first->assertOk();
+
+    // Second is rejected — but only after the new attempt is created (since the
+    // `current_sign_in_attempt_id` short-circuit returns the previous COMPLETE
+    // attempt). We force a new client / attempt to make the replay obvious.
+    $second = $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'strategy' => 'ticket',
+            'ticket' => $ticket,
+        ]);
+
+    $second->assertStatus(401)->assertJsonPath('errors.0.code', 'ticket_invalid');
+});
+
+it('redeems an invitation ticket whose sub is the user email', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    SignInTestSupport::makeUser($f['env']);
+
+    $ticket = app(TicketIssuer::class)->issue($f['env'], 1800, [
+        'sub' => 'alice@example.com',
+        'sid' => 'inv_01HKX9SY9V7H7TF8C8K7J9X4ZB',
+        'purpose' => 'invitation',
+    ]);
+
+    $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'strategy' => 'ticket',
+            'ticket' => $ticket,
+        ])
+        ->assertOk()
+        ->assertJsonPath('response.status', 'complete');
+});
+
+it('refuses a malformed ticket', function (): void {
+    $f = SignInTestSupport::bootEnv();
+
+    $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+            'strategy' => 'ticket',
+            'ticket' => 'not-a-jwt',
+        ])
+        ->assertStatus(401)
+        ->assertJsonPath('errors.0.code', 'ticket_invalid');
+});


### PR DESCRIPTION
## Summary
- Implements the `POST /v1/client/sign_ins` state machine and 7 endpoints (store, show, prepare/attempt first/second factor, reset_password).
- Four v0.1 strategies plugged through `App\Auth\StrategyResolver`: password, email_code, reset_password_email_code, ticket. The controller owns transitions; strategies own credential / verification mechanics.
- Single-use, short-lived RS256 tickets minted by `App\Services\Tickets\{TicketIssuer,TicketVerifier}`.
- Verification email is currently a stub queue job — AU-14 will swap in the real renderer + driver.

## Test plan
- [x] `php artisan test` — 186/186 passing (52 new sign-in assertions across 14 cases)
- [x] PasswordTest covers happy path, wrong password, identifier-only path, banned/locked, and inline-strategy short-circuit.
- [x] EmailCodeTest covers prepare → attempt → complete plus the 5-strikes → `failed` lockout.
- [x] ResetPasswordTest covers the reset_password_email_code → reset_password → complete flow and the gate that refuses `/reset_password` outside `needs_new_password`.
- [x] TicketTest covers the inline ticket path that creates the attempt + Session in one call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)