### PR TITLE
FAPI sign-up flow: identifier + email verification + ticket (AU-10)

### DIFF
--- a/app/Auth/ErrorCodes.php
+++ b/app/Auth/ErrorCodes.php
@@ -73,4 +73,24 @@ final class ErrorCodes
     public const SIGN_IN_ABANDONED = 'sign_in_abandoned';
 
     public const SIGN_IN_ALREADY_COMPLETE = 'sign_in_already_complete';
+
+    // Sign-up
+
+    public const FORM_PARAM_UNKNOWN = 'form_param_unknown';
+
+    public const FORM_IDENTIFIER_NOT_ALLOWED = 'form_identifier_not_allowed';
+
+    public const FORM_IDENTIFIER_DISPOSABLE = 'form_identifier_disposable';
+
+    public const LEGAL_ACCEPTED_REQUIRED = 'legal_accepted_required';
+
+    public const SIGN_UP_NOT_FOUND = 'sign_up_not_found';
+
+    public const SIGN_UP_ABANDONED = 'sign_up_abandoned';
+
+    public const SIGN_UP_ALREADY_COMPLETE = 'sign_up_already_complete';
+
+    public const NO_VERIFICATION_IN_PROGRESS = 'no_verification_in_progress';
+
+    public const SIGN_UP_NOT_READY = 'sign_up_not_ready';
 }

--- a/app/Auth/SignUp/IdentifierNormalizer.php
+++ b/app/Auth/SignUp/IdentifierNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\SignUp;
+
+/**
+ * Email normalisation per the per-env user_settings flags (PLAN §13.2):
+ *
+ *   - block_email_subaddresses             (default false) — strip `+tag`
+ *   - ignore_dots_for_gmail_addresses      (default true)  — `f.o.o@gmail.com`
+ *                                                            == `foo@gmail.com`
+ *
+ * Used both at sign-up time (collision detection) and at sign-in /
+ * /v1/me/email_addresses CRUD time so the same canonical form is what we
+ * uniqueness-check against.
+ */
+final class IdentifierNormalizer
+{
+    private const GMAIL_HOSTS = ['gmail.com', 'googlemail.com'];
+
+    /**
+     * Returns the canonical form used for uniqueness checks. The original
+     * (un-normalised) form is what we store on the EmailAddress row when the
+     * env permits it; the canonical form is what we look up against.
+     *
+     * @param  array<string, mixed>  $userSettings  the env's user_settings blob
+     */
+    public function canonicalize(string $email, array $userSettings = []): string
+    {
+        $email = strtolower(trim($email));
+        if (! str_contains($email, '@')) {
+            return $email;
+        }
+
+        [$local, $domain] = explode('@', $email, 2);
+
+        if ($this->flag($userSettings, 'block_email_subaddresses', false) && str_contains($local, '+')) {
+            $local = explode('+', $local, 2)[0];
+        }
+
+        if ($this->flag($userSettings, 'ignore_dots_for_gmail_addresses', true)
+            && in_array($domain, self::GMAIL_HOSTS, true)
+        ) {
+            $local = str_replace('.', '', $local);
+        }
+
+        return $local.'@'.$domain;
+    }
+
+    private function flag(array $userSettings, string $key, bool $default): bool
+    {
+        if (! array_key_exists($key, $userSettings)) {
+            return $default;
+        }
+
+        return (bool) $userSettings[$key];
+    }
+}

--- a/app/Auth/SignUp/IdentifierRestrictions.php
+++ b/app/Auth/SignUp/IdentifierRestrictions.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\SignUp;
+
+use App\Models\AllowlistIdentifier;
+use App\Models\BlocklistIdentifier;
+use App\Models\Environment;
+
+/**
+ * Resolves whether a given email is allowed to sign up against an env.
+ *
+ * Order:
+ *   1. block_disposable_email_domains (uses a small bundled list — full
+ *      catalogue lands in AU-18)
+ *   2. blocklist_identifiers (any match → reject)
+ *   3. signup_mode = restricted → must match an allowlist row
+ */
+final class IdentifierRestrictions
+{
+    /**
+     * Tiny seed list. AU-18 swaps in the full disposable-domain catalogue.
+     */
+    private const DISPOSABLE_DOMAINS = [
+        'mailinator.com',
+        'tempmail.com',
+        'guerrillamail.com',
+        '10minutemail.com',
+        'throwawaymail.com',
+        'yopmail.com',
+        'trashmail.com',
+        'getnada.com',
+        'sharklasers.com',
+    ];
+
+    public const REASON_DISPOSABLE = 'form_identifier_disposable';
+
+    public const REASON_NOT_ALLOWED = 'form_identifier_not_allowed';
+
+    public function check(Environment $environment, string $email): ?string
+    {
+        $email = strtolower($email);
+        if (! str_contains($email, '@')) {
+            return null;
+        }
+        [, $domain] = explode('@', $email, 2);
+
+        $userSettings = is_array($environment->user_settings) ? $environment->user_settings : [];
+        if (($userSettings['block_disposable_email_domains'] ?? false) === true
+            && in_array($domain, self::DISPOSABLE_DOMAINS, true)
+        ) {
+            return self::REASON_DISPOSABLE;
+        }
+
+        $blocked = BlocklistIdentifier::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $environment->id)
+            ->where(function ($q) use ($email, $domain): void {
+                $q->where(function ($qq) use ($email): void {
+                    $qq->where('identifier_type', BlocklistIdentifier::TYPE_EMAIL_ADDRESS)
+                        ->where('identifier', $email);
+                })->orWhere(function ($qq) use ($domain): void {
+                    $qq->where('identifier_type', BlocklistIdentifier::TYPE_EMAIL_DOMAIN)
+                        ->whereIn('identifier', [$domain, '@'.$domain]);
+                });
+            })
+            ->exists();
+        if ($blocked) {
+            return self::REASON_NOT_ALLOWED;
+        }
+
+        if ($environment->signup_mode === Environment::SIGNUP_MODE_RESTRICTED) {
+            $allowed = AllowlistIdentifier::query()
+                ->withoutGlobalScopes()
+                ->where('environment_id', $environment->id)
+                ->where(function ($q) use ($email, $domain): void {
+                    $q->where(function ($qq) use ($email): void {
+                        $qq->where('identifier_type', AllowlistIdentifier::TYPE_EMAIL_ADDRESS)
+                            ->where('identifier', $email);
+                    })->orWhere(function ($qq) use ($domain): void {
+                        $qq->where('identifier_type', AllowlistIdentifier::TYPE_EMAIL_DOMAIN)
+                            ->whereIn('identifier', [$domain, '@'.$domain]);
+                    });
+                })
+                ->exists();
+            if (! $allowed) {
+                return self::REASON_NOT_ALLOWED;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Auth/SignUp/StageRequirements.php
+++ b/app/Auth/SignUp/StageRequirements.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\SignUp;
+
+use App\Models\Environment;
+
+/**
+ * Validates a sign-up payload against the env's `user_settings.attributes`
+ * matrix. Returns:
+ *
+ *   - rejected[]        — fields the body provided that the env has disabled
+ *                         (controller maps to 422 form_param_unknown)
+ *   - missing_fields[]  — required fields not yet supplied
+ *   - unverified_fields[] — required-and-verifiable fields with no proof yet
+ *
+ * Default attribute matrix matches what EnvironmentResource publishes when no
+ * per-env override exists (email + password required; first/last_name optional;
+ * everything else disabled). Env overrides are merged on top.
+ */
+final class StageRequirements
+{
+    public const KNOWN_ATTRIBUTES = [
+        'email_address',
+        'username',
+        'first_name',
+        'last_name',
+        'password',
+    ];
+
+    private const DEFAULTS = [
+        'email_address' => [
+            'enabled' => true,
+            'required' => true,
+            'verifications' => ['email_code'],
+            'verify_at_sign_up' => true,
+        ],
+        'password' => [
+            'enabled' => true,
+            'required' => true,
+            'verifications' => [],
+            'verify_at_sign_up' => false,
+        ],
+        'username' => [
+            'enabled' => false,
+            'required' => false,
+            'verifications' => [],
+            'verify_at_sign_up' => false,
+        ],
+        'first_name' => [
+            'enabled' => true,
+            'required' => false,
+            'verifications' => [],
+            'verify_at_sign_up' => false,
+        ],
+        'last_name' => [
+            'enabled' => true,
+            'required' => false,
+            'verifications' => [],
+            'verify_at_sign_up' => false,
+        ],
+    ];
+
+    /**
+     * @param  array<string, mixed>  $supplied  attribute => value (already-staged fields included)
+     * @param  array<string, mixed>  $alreadyVerified  attribute => bool (e.g. ['email_address' => true] when a verification ran)
+     * @return array{rejected: list<string>, missing_fields: list<string>, unverified_fields: list<string>, matrix: array<string, array<string, mixed>>}
+     */
+    public function evaluate(Environment $environment, array $supplied, array $alreadyVerified = []): array
+    {
+        $matrix = $this->matrix($environment);
+
+        $rejected = [];
+        $missing = [];
+        $unverified = [];
+
+        foreach (self::KNOWN_ATTRIBUTES as $attr) {
+            $cfg = $matrix[$attr] ?? self::DEFAULTS[$attr];
+            $value = $supplied[$attr] ?? null;
+            $hasValue = is_string($value) && $value !== '';
+
+            if (! ($cfg['enabled'] ?? false)) {
+                if ($hasValue) {
+                    $rejected[] = $attr;
+                }
+
+                continue;
+            }
+
+            if (($cfg['required'] ?? false) && ! $hasValue) {
+                $missing[] = $attr;
+
+                continue;
+            }
+
+            if (($cfg['verify_at_sign_up'] ?? false) && $hasValue && empty($alreadyVerified[$attr])) {
+                $unverified[] = $attr;
+            }
+        }
+
+        return [
+            'rejected' => $rejected,
+            'missing_fields' => $missing,
+            'unverified_fields' => $unverified,
+            'matrix' => $matrix,
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function matrix(Environment $environment): array
+    {
+        $userSettings = is_array($environment->user_settings) ? $environment->user_settings : [];
+        $overrides = is_array($userSettings['attributes'] ?? null) ? $userSettings['attributes'] : [];
+        $matrix = self::DEFAULTS;
+        foreach ($overrides as $attr => $cfg) {
+            if (! is_array($cfg)) {
+                continue;
+            }
+            $matrix[$attr] = array_merge($matrix[$attr] ?? [], $cfg);
+        }
+
+        return $matrix;
+    }
+}

--- a/app/Auth/SignUp/TicketRedeemer.php
+++ b/app/Auth/SignUp/TicketRedeemer.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\SignUp;
+
+use App\Models\Environment;
+use App\Models\Invitation;
+use App\Services\Tickets\TicketVerifier;
+
+/**
+ * Single-call redemption of an invitation `ticket` JWT against an env.
+ * Returns either:
+ *   ['ok' => true,  'invitation' => Invitation, 'email' => string, 'metadata' => array, 'redirect_url' => ?string]
+ *   ['ok' => false, 'reason' => string]   (reason is a stable error code)
+ *
+ * Reasons:
+ *   - ticket_invalid   — JWT failed signature / clock / replay / missing claims
+ *   - ticket_expired   — invitation row past its expires_at (or status != pending)
+ *
+ * The verifier already hardcodes the single-use jti guard, so a replay of the
+ * same ticket returns ticket_invalid.
+ */
+final class TicketRedeemer
+{
+    public const REASON_INVALID = 'ticket_invalid';
+
+    public const REASON_EXPIRED = 'ticket_expired';
+
+    public function __construct(private readonly TicketVerifier $verifier) {}
+
+    /**
+     * @return array{ok: bool, reason?: string, invitation?: Invitation, email?: string, metadata?: array<string, mixed>, redirect_url?: ?string}
+     */
+    public function redeem(Environment $environment, string $jwt): array
+    {
+        $claims = $this->verifier->verify($jwt, $environment);
+        if ($claims === null) {
+            return ['ok' => false, 'reason' => self::REASON_INVALID];
+        }
+
+        if (($claims['purpose'] ?? null) !== 'invitation') {
+            return ['ok' => false, 'reason' => self::REASON_INVALID];
+        }
+
+        $invitationId = $claims['sid'] ?? null;
+        if (! is_string($invitationId) || $invitationId === '') {
+            return ['ok' => false, 'reason' => self::REASON_INVALID];
+        }
+
+        $invitation = Invitation::query()
+            ->withoutGlobalScopes()
+            ->where('id', $invitationId)
+            ->where('environment_id', $environment->id)
+            ->first();
+        if ($invitation === null) {
+            return ['ok' => false, 'reason' => self::REASON_INVALID];
+        }
+        if (! $invitation->isRedeemable()) {
+            return ['ok' => false, 'reason' => self::REASON_EXPIRED];
+        }
+
+        $sub = $claims['sub'] ?? null;
+        $email = is_string($sub) ? strtolower($sub) : strtolower($invitation->email_address);
+        $metadata = is_array($claims['metadata'] ?? null) ? $claims['metadata'] : [];
+        $redirect = is_string($claims['redirect_url'] ?? null) ? $claims['redirect_url'] : null;
+
+        return [
+            'ok' => true,
+            'invitation' => $invitation,
+            'email' => $email,
+            'metadata' => $metadata,
+            'redirect_url' => $redirect,
+        ];
+    }
+}

--- a/app/Http/Controllers/Fapi/SignUpController.php
+++ b/app/Http/Controllers/Fapi/SignUpController.php
@@ -1,0 +1,551 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Auth\ErrorCodes;
+use App\Auth\SignUp\IdentifierNormalizer;
+use App\Auth\SignUp\IdentifierRestrictions;
+use App\Auth\SignUp\StageRequirements;
+use App\Auth\SignUp\TicketRedeemer;
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\SignUpResource;
+use App\Jobs\Mail\SendVerificationEmail;
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\Invitation;
+use App\Models\Session;
+use App\Models\SignUpAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Models\VerificationCode;
+use App\Services\Client\ClientResolver;
+use App\Services\Verification\VerificationManager;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Symfony\Component\HttpFoundation\Cookie;
+
+/**
+ * FAPI sign-up state-machine controller.
+ *
+ * Endpoints (PLAN §3.3 / §9.4):
+ *   POST   /v1/client/sign_ups
+ *   GET    /v1/client/sign_ups/{id}
+ *   PATCH  /v1/client/sign_ups/{id}
+ *   POST   /v1/client/sign_ups/{id}/prepare_verification
+ *   POST   /v1/client/sign_ups/{id}/attempt_verification
+ *
+ * v0.1 strategies for verification: email_code (and ticket at create-time).
+ * email_link, OAuth transfer, organization-creation, phone are all v0.2+.
+ */
+final class SignUpController
+{
+    private const EMAIL_VERIFICATION_TTL = 600;
+
+    public function __construct(
+        private readonly StageRequirements $stage,
+        private readonly IdentifierRestrictions $restrictions,
+        private readonly IdentifierNormalizer $normalizer,
+        private readonly TicketRedeemer $ticketRedeemer,
+        private readonly VerificationManager $verifications,
+    ) {}
+
+    public function store(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $createdClient = false;
+        $client = $this->resolveOrCreateClient($request, $env, $createdClient);
+
+        if ($request->boolean('transfer')) {
+            return $this->error(422, ErrorCodes::TRANSFER_NOT_SUPPORTED_IN_V0_1, 'transfer flow lands in a later milestone.', $client);
+        }
+
+        return DB::transaction(function () use ($request, $env, $client, $createdClient): JsonResponse {
+            $existing = $client->current_sign_up_attempt_id !== null
+                ? SignUpAttempt::query()->withoutGlobalScopes()->where('id', $client->current_sign_up_attempt_id)->first()
+                : null;
+            if ($existing !== null && ! in_array($existing->status, [SignUpAttempt::STATUS_COMPLETE, SignUpAttempt::STATUS_ABANDONED], true)) {
+                return $this->envelope($client, $existing, 200, null, $createdClient);
+            }
+
+            $ticket = $request->input('ticket');
+            if (is_string($ticket) && $ticket !== '') {
+                return $this->createFromTicket($request, $env, $client, $ticket, $createdClient);
+            }
+
+            return $this->createInteractive($request, $env, $client, $createdClient);
+        });
+    }
+
+    public function show(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $client = app(Client::class);
+        $attempt = $this->loadAttempt($sid, $client);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        return $this->envelope($client, $attempt);
+    }
+
+    public function patch(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $client = app(Client::class);
+        $attempt = $this->loadAttempt($sid, $client);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        $env = app(Environment::class);
+        $supplied = $this->collectSupplied($request, $attempt);
+        $eval = $this->stage->evaluate($env, $supplied, $this->verifiedFlags($attempt));
+
+        if (! empty($eval['rejected'])) {
+            return $this->error(422, ErrorCodes::FORM_PARAM_UNKNOWN, 'One or more fields are not enabled for sign-up: '.implode(', ', $eval['rejected']), $client, $attempt);
+        }
+
+        $reasonOrAccept = $this->applyIdentifierGuards($env, $supplied['email_address'] ?? $attempt->email_address);
+        if ($reasonOrAccept !== null) {
+            return $this->error(422, $reasonOrAccept, 'Email is not allowed for sign-up.', $client, $attempt);
+        }
+
+        $this->stageOnto($attempt, $supplied, $eval);
+        $attempt->save();
+
+        return $this->envelope($client, $attempt->fresh());
+    }
+
+    public function prepareVerification(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $client = app(Client::class);
+        $attempt = $this->loadAttempt($sid, $client);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        $strategy = (string) $request->input('strategy', '');
+        if ($strategy === '') {
+            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', $client, $attempt);
+        }
+        if ($strategy === Verification::STRATEGY_EMAIL_LINK) {
+            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, 'email_link sign-up lands in v0.2.', $client, $attempt);
+        }
+        if ($strategy !== Verification::STRATEGY_EMAIL_CODE) {
+            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategy} is not enabled in v0.1.", $client, $attempt);
+        }
+
+        if (! is_string($attempt->email_address) || $attempt->email_address === '') {
+            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'email_address is required before preparing email verification.', $client, $attempt);
+        }
+
+        // For sign-up the email isn't yet on an EmailAddress row — start the
+        // Verification on the SignUpAttempt itself so the morph is consistent
+        // (the staged email lives on the attempt).
+        $verification = $this->verifications->start($attempt, Verification::STRATEGY_EMAIL_CODE, self::EMAIL_VERIFICATION_TTL);
+        $code = $this->verifications->mintNumericCode($verification, VerificationCode::PURPOSE_EMAIL_CODE, self::EMAIL_VERIFICATION_TTL);
+
+        SendVerificationEmail::dispatch(
+            $attempt->environment_id,
+            $attempt->email_address,
+            $code,
+            VerificationCode::PURPOSE_EMAIL_CODE,
+        );
+
+        $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
+        $verifications['email_address'] = $verification->id;
+        $attempt->verifications = $verifications;
+        $attempt->save();
+
+        return $this->envelope($client, $attempt->fresh());
+    }
+
+    public function attemptVerification(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $client = app(Client::class);
+        $attempt = $this->loadAttempt($sid, $client);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        $strategy = (string) $request->input('strategy', '');
+        if ($strategy !== Verification::STRATEGY_EMAIL_CODE) {
+            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategy} is not enabled in v0.1.", $client, $attempt);
+        }
+        $code = $request->input('code');
+        if (! is_string($code) || $code === '') {
+            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'code is required.', $client, $attempt);
+        }
+
+        $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
+        $vid = $verifications['email_address'] ?? null;
+        if (! is_string($vid)) {
+            return $this->error(422, ErrorCodes::NO_VERIFICATION_IN_PROGRESS, 'No email verification has been prepared.', $client, $attempt);
+        }
+        $verification = Verification::query()->withoutGlobalScopes()->where('id', $vid)->first();
+        if ($verification === null) {
+            return $this->error(422, ErrorCodes::NO_VERIFICATION_IN_PROGRESS, 'No email verification has been prepared.', $client, $attempt);
+        }
+
+        $ok = $this->verifications->attempt($verification, $code);
+        if (! $ok) {
+            $fresh = $verification->fresh();
+            $errCode = $fresh->status === Verification::STATUS_FAILED
+                ? ErrorCodes::VERIFICATION_FAILED
+                : ($fresh->status === Verification::STATUS_EXPIRED
+                    ? ErrorCodes::VERIFICATION_EXPIRED
+                    : ErrorCodes::FORM_CODE_INCORRECT);
+
+            return $this->error(422, $errCode, 'Incorrect code.', $client, $attempt);
+        }
+
+        $env = app(Environment::class);
+
+        return $this->finalizeIfReady($env, $client, $attempt, ['email_address' => true]);
+    }
+
+    /* -------------------- create branches -------------------- */
+
+    private function createInteractive(Request $request, Environment $env, Client $client, bool $createdClient): JsonResponse
+    {
+        $supplied = $this->collectSupplied($request, null);
+        $eval = $this->stage->evaluate($env, $supplied);
+
+        if (! empty($eval['rejected'])) {
+            return $this->error(422, ErrorCodes::FORM_PARAM_UNKNOWN, 'One or more fields are not enabled for sign-up: '.implode(', ', $eval['rejected']), $client);
+        }
+
+        $userSettings = is_array($env->user_settings) ? $env->user_settings : [];
+        if (($userSettings['require_legal_accepted'] ?? false) === true && ! $request->boolean('legal_accepted')) {
+            return $this->error(422, ErrorCodes::LEGAL_ACCEPTED_REQUIRED, 'You must accept the legal terms to sign up.', $client);
+        }
+
+        if (isset($supplied['email_address'])) {
+            $reason = $this->applyIdentifierGuards($env, $supplied['email_address']);
+            if ($reason !== null) {
+                return $this->error(422, $reason, 'Email is not allowed for sign-up.', $client);
+            }
+            $canonical = $this->normalizer->canonicalize($supplied['email_address'], $userSettings);
+            if ($this->emailAlreadyTaken($env, $canonical)) {
+                return $this->error(422, ErrorCodes::FORM_IDENTIFIER_EXISTS, 'That email is already in use.', $client);
+            }
+            $supplied['email_address'] = $canonical;
+        }
+
+        $attempt = SignUpAttempt::create(['environment_id' => $env->id, 'client_id' => $client->id]);
+        $this->stageOnto($attempt, $supplied, $eval);
+        $attempt->save();
+
+        $client->forceFill(['current_sign_up_attempt_id' => $attempt->id])->saveQuietly();
+
+        return $this->finalizeIfReady($env, $client, $attempt, [], $createdClient);
+    }
+
+    private function createFromTicket(Request $request, Environment $env, Client $client, string $ticket, bool $createdClient): JsonResponse
+    {
+        $result = $this->ticketRedeemer->redeem($env, $ticket);
+        if (! $result['ok']) {
+            $code = $result['reason'] === TicketRedeemer::REASON_EXPIRED
+                ? ErrorCodes::TICKET_EXPIRED
+                : ErrorCodes::TICKET_INVALID;
+
+            return $this->error(422, $code, 'This invitation cannot be redeemed.', $client);
+        }
+
+        /** @var Invitation $invitation */
+        $invitation = $result['invitation'];
+        $email = $result['email'];
+        $userSettings = is_array($env->user_settings) ? $env->user_settings : [];
+        $canonical = $this->normalizer->canonicalize($email, $userSettings);
+        if ($this->emailAlreadyTaken($env, $canonical)) {
+            return $this->error(422, ErrorCodes::FORM_IDENTIFIER_EXISTS, 'That email is already in use.', $client);
+        }
+
+        $supplied = $this->collectSupplied($request, null);
+        $supplied['email_address'] = $canonical;
+
+        $eval = $this->stage->evaluate($env, $supplied, ['email_address' => true]);
+        if (! empty($eval['rejected'])) {
+            return $this->error(422, ErrorCodes::FORM_PARAM_UNKNOWN, 'One or more fields are not enabled for sign-up: '.implode(', ', $eval['rejected']), $client);
+        }
+
+        $attempt = SignUpAttempt::create(['environment_id' => $env->id, 'client_id' => $client->id]);
+        $this->stageOnto($attempt, $supplied, $eval);
+        $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
+        $verifications['email_address'] = '__ticket__';
+        $attempt->verifications = $verifications;
+        if (! empty($result['metadata'])) {
+            $attempt->public_metadata = array_merge(is_array($attempt->public_metadata) ? $attempt->public_metadata : [], $result['metadata']);
+        }
+        $attempt->save();
+
+        $client->forceFill(['current_sign_up_attempt_id' => $attempt->id])->saveQuietly();
+
+        return $this->finalizeIfReady($env, $client, $attempt, ['email_address' => true], $createdClient, $invitation);
+    }
+
+    /* -------------------- finalize -------------------- */
+
+    private function finalizeIfReady(
+        Environment $env,
+        Client $client,
+        SignUpAttempt $attempt,
+        array $extraVerified = [],
+        bool $attachClientCookie = false,
+        ?Invitation $redeemingInvitation = null,
+    ): JsonResponse {
+        $verifiedFlags = array_merge($this->verifiedFlags($attempt), $extraVerified);
+        $supplied = [
+            'email_address' => $attempt->email_address,
+            'username' => $attempt->username,
+            'first_name' => $attempt->first_name,
+            'last_name' => $attempt->last_name,
+            'password' => $attempt->password_hash !== null ? '__present__' : null,
+        ];
+        $eval = $this->stage->evaluate($env, $supplied, $verifiedFlags);
+
+        $attempt->missing_fields = $eval['missing_fields'];
+        $attempt->unverified_fields = $eval['unverified_fields'];
+
+        if (! empty($eval['missing_fields']) || ! empty($eval['unverified_fields'])) {
+            $attempt->save();
+
+            return $this->envelope($client, $attempt->fresh(), 200, null, $attachClientCookie);
+        }
+
+        // Promote: create User + EmailAddress + Session.
+        return DB::transaction(function () use ($env, $client, $attempt, $attachClientCookie, $redeemingInvitation): JsonResponse {
+            $user = User::query()->withoutGlobalScopes()->create([
+                'environment_id' => $env->id,
+                'first_name' => $attempt->first_name,
+                'last_name' => $attempt->last_name,
+                'username' => $attempt->username,
+                'password_hash' => $attempt->password_hash,
+                'password_changed_at' => $attempt->password_hash !== null ? now() : null,
+                'public_metadata' => is_array($attempt->public_metadata) ? $attempt->public_metadata : [],
+                'unsafe_metadata' => is_array($attempt->unsafe_metadata) ? $attempt->unsafe_metadata : [],
+            ]);
+
+            $email = EmailAddress::query()->withoutGlobalScopes()->create([
+                'environment_id' => $env->id,
+                'user_id' => $user->id,
+                'email_address' => (string) $attempt->email_address,
+                'verified_at' => now(),
+                'is_primary' => true,
+            ]);
+
+            $user->forceFill(['primary_email_address_id' => $email->id])->saveQuietly();
+
+            $session = Session::create([
+                'environment_id' => $env->id,
+                'client_id' => $client->id,
+                'user_id' => $user->id,
+                'status' => Session::STATUS_ACTIVE,
+            ]);
+
+            $attempt->forceFill([
+                'created_user_id' => $user->id,
+                'created_session_id' => $session->id,
+                'status' => SignUpAttempt::STATUS_COMPLETE,
+                'missing_fields' => [],
+                'unverified_fields' => [],
+            ])->save();
+
+            Client::query()
+                ->withoutGlobalScopes()
+                ->where('id', $client->id)
+                ->update(['last_active_session_id' => $session->id, 'last_active_at' => now()]);
+
+            if ($redeemingInvitation !== null) {
+                $redeemingInvitation->forceFill([
+                    'status' => Invitation::STATUS_ACCEPTED,
+                    'redeemed_by_user_id' => $user->id,
+                    'accepted_at' => now(),
+                ])->save();
+            }
+
+            return $this->envelope($client, $attempt->fresh(), 200, $session, $attachClientCookie);
+        });
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    /**
+     * @return array<string, ?string>
+     */
+    private function collectSupplied(Request $request, ?SignUpAttempt $attempt): array
+    {
+        return [
+            'email_address' => $request->input('email_address', $attempt?->email_address),
+            'username' => $request->input('username', $attempt?->username),
+            'first_name' => $request->input('first_name', $attempt?->first_name),
+            'last_name' => $request->input('last_name', $attempt?->last_name),
+            'password' => $request->input('password', $attempt?->password_hash !== null ? '__present__' : null),
+        ];
+    }
+
+    private function stageOnto(SignUpAttempt $attempt, array $supplied, array $eval): void
+    {
+        if (isset($supplied['email_address']) && is_string($supplied['email_address'])) {
+            $attempt->email_address = strtolower($supplied['email_address']);
+        }
+        foreach (['username', 'first_name', 'last_name'] as $f) {
+            if (isset($supplied[$f]) && is_string($supplied[$f])) {
+                $attempt->{$f} = $supplied[$f];
+            }
+        }
+        $password = $supplied['password'] ?? null;
+        if (is_string($password) && $password !== '' && $password !== '__present__') {
+            $attempt->password_hash = Hash::make($password);
+        }
+        $attempt->missing_fields = $eval['missing_fields'];
+        $attempt->unverified_fields = $eval['unverified_fields'];
+    }
+
+    private function verifiedFlags(SignUpAttempt $attempt): array
+    {
+        $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
+        $flags = [];
+        if (isset($verifications['email_address'])) {
+            $vid = $verifications['email_address'];
+            if ($vid === '__ticket__') {
+                $flags['email_address'] = true;
+            } elseif (is_string($vid)) {
+                $verification = Verification::query()->withoutGlobalScopes()->where('id', $vid)->first();
+                if ($verification !== null && $verification->status === Verification::STATUS_VERIFIED) {
+                    $flags['email_address'] = true;
+                }
+            }
+        }
+
+        return $flags;
+    }
+
+    private function applyIdentifierGuards(Environment $env, ?string $email): ?string
+    {
+        if (! is_string($email) || $email === '') {
+            return null;
+        }
+
+        return $this->restrictions->check($env, $email);
+    }
+
+    private function emailAlreadyTaken(Environment $env, string $canonicalEmail): bool
+    {
+        $userSettings = is_array($env->user_settings) ? $env->user_settings : [];
+        $rows = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->get(['id', 'email_address']);
+        foreach ($rows as $row) {
+            $candidate = $this->normalizer->canonicalize((string) $row->email_address, $userSettings);
+            if ($candidate === $canonicalEmail) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function loadAttempt(string $sid, Client $client): SignUpAttempt|JsonResponse
+    {
+        $attempt = SignUpAttempt::query()
+            ->withoutGlobalScopes()
+            ->where('id', $sid)
+            ->where('client_id', $client->id)
+            ->first();
+        if ($attempt === null) {
+            return $this->error(404, ErrorCodes::SIGN_UP_NOT_FOUND, 'Sign-up attempt not found on this device.', $client);
+        }
+        if ($attempt->status === SignUpAttempt::STATUS_ABANDONED) {
+            return $this->error(422, ErrorCodes::SIGN_UP_ABANDONED, 'This sign-up attempt has been abandoned.', $client, $attempt);
+        }
+        if ($attempt->status === SignUpAttempt::STATUS_COMPLETE) {
+            return $this->error(422, ErrorCodes::SIGN_UP_ALREADY_COMPLETE, 'This sign-up attempt is already complete.', $client, $attempt);
+        }
+
+        return $attempt;
+    }
+
+    private function resolveOrCreateClient(Request $request, Environment $env, bool &$created = false): Client
+    {
+        $cookie = $request->cookie('__client');
+        if (is_string($cookie)) {
+            $client = app(ClientResolver::class)->fromCookie($cookie, $env);
+            if ($client !== null) {
+                return $client;
+            }
+        }
+
+        $created = true;
+
+        return Client::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'last_active_at' => now(),
+        ]);
+    }
+
+    private function envelope(
+        Client $client,
+        ?SignUpAttempt $attempt,
+        int $status = 200,
+        ?Session $newSession = null,
+        bool $attachClientCookie = false,
+    ): JsonResponse {
+        $response = response()->json([
+            'response' => SignUpResource::from($attempt),
+            'client' => ClientResource::from($client->fresh()),
+        ], $status)->header('Cache-Control', 'no-store');
+
+        if ($attachClientCookie) {
+            $response = $response->withCookie($this->buildClientCookie($client));
+        }
+
+        return $response;
+    }
+
+    private function buildClientCookie(Client $client): Cookie
+    {
+        $value = app(ClientResolver::class)->mintCookieValue($client);
+
+        return \Illuminate\Support\Facades\Cookie::make(
+            name: '__client',
+            value: $value,
+            minutes: 60 * 24 * 365,
+            path: '/',
+            domain: null,
+            secure: request()->secure(),
+            httpOnly: true,
+            raw: false,
+            sameSite: 'lax',
+        );
+    }
+
+    private function error(int $status, string $code, string $message, ?Client $client = null, ?SignUpAttempt $attempt = null): JsonResponse
+    {
+        $body = [
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ];
+        if ($client !== null) {
+            $body['client'] = ClientResource::from($client->fresh());
+        }
+        if ($attempt !== null) {
+            $body['response'] = SignUpResource::from($attempt->fresh());
+        }
+
+        return response()->json($body, $status)->header('Cache-Control', 'no-store');
+    }
+}

--- a/app/Http/Resources/ClientResource.php
+++ b/app/Http/Resources/ClientResource.php
@@ -7,12 +7,10 @@ namespace App\Http\Resources;
 use App\Models\Client;
 use App\Models\Session;
 use App\Models\SignInAttempt;
+use App\Models\SignUpAttempt;
 
 /**
  * The Client snapshot returned to the SDK. Mirrors PLAN §8.2.
- *
- * v0.1: only `sessions` is populated — `sign_in` and `sign_up` arrive
- * with AU-9 / AU-10 once those state machines land.
  */
 final class ClientResource
 {
@@ -49,12 +47,23 @@ final class ClientResource
             }
         }
 
+        $signUp = null;
+        if ($client->current_sign_up_attempt_id !== null) {
+            $attempt = SignUpAttempt::query()
+                ->withoutGlobalScopes()
+                ->where('id', $client->current_sign_up_attempt_id)
+                ->first();
+            if ($attempt !== null && ! in_array($attempt->status, [SignUpAttempt::STATUS_COMPLETE, SignUpAttempt::STATUS_ABANDONED], true)) {
+                $signUp = SignUpResource::from($attempt);
+            }
+        }
+
         return [
             'object' => 'client',
             'id' => $client->id,
             'sessions' => $sessions,
             'sign_in' => $signIn,
-            'sign_up' => null,                      // populated in AU-10
+            'sign_up' => $signUp,
             'last_active_session_id' => $client->last_active_session_id,
             'created_at' => $client->created_at?->getTimestampMs(),
             'updated_at' => $client->updated_at?->getTimestampMs(),

--- a/app/Http/Resources/SignUpResource.php
+++ b/app/Http/Resources/SignUpResource.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\SignUpAttempt;
+use App\Models\Verification;
+
+/**
+ * Mirrors PLAN §3.3's SignUp shape — what FAPI returns for any sign-up
+ * state-machine endpoint. Excludes secrets (password_hash, transfer_token).
+ */
+final class SignUpResource
+{
+    public static function from(?SignUpAttempt $attempt): ?array
+    {
+        if ($attempt === null) {
+            return null;
+        }
+
+        $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
+        $emailVerificationId = $verifications['email_address'] ?? null;
+        $emailVerification = is_string($emailVerificationId)
+            ? Verification::query()->withoutGlobalScopes()->where('id', $emailVerificationId)->first()
+            : null;
+
+        return [
+            'object' => 'sign_up_attempt',
+            'id' => $attempt->id,
+            'status' => $attempt->status,
+            'required_fields' => self::expandFields($attempt->missing_fields),
+            'optional_fields' => [],
+            'missing_fields' => self::expandFields($attempt->missing_fields),
+            'unverified_fields' => self::expandFields($attempt->unverified_fields),
+            'verifications' => [
+                'email_address' => self::verificationShape($emailVerification),
+                'phone_number' => null,
+                'web3_wallet' => null,
+                'external_account' => null,
+            ],
+            'email_address' => $attempt->email_address,
+            'username' => $attempt->username,
+            'phone_number' => $attempt->phone_number,
+            'first_name' => $attempt->first_name,
+            'last_name' => $attempt->last_name,
+            'unsafe_metadata' => is_array($attempt->unsafe_metadata) ? $attempt->unsafe_metadata : [],
+            'public_metadata' => is_array($attempt->public_metadata) ? $attempt->public_metadata : [],
+            'created_session_id' => $attempt->created_session_id,
+            'created_user_id' => $attempt->created_user_id,
+            'abandon_at' => $attempt->abandon_at->getTimestampMs(),
+        ];
+    }
+
+    /**
+     * @param  mixed  $fields
+     * @return list<string>
+     */
+    private static function expandFields($fields): array
+    {
+        if (! is_array($fields)) {
+            return [];
+        }
+
+        return array_values(array_map('strval', $fields));
+    }
+
+    private static function verificationShape(?Verification $verification): ?array
+    {
+        if ($verification === null) {
+            return null;
+        }
+
+        return [
+            'object' => 'verification',
+            'status' => $verification->status,
+            'strategy' => $verification->strategy,
+            'attempts' => $verification->attempts,
+            'expire_at' => $verification->expire_at->getTimestampMs(),
+            'external_verification_redirect_url' => $verification->external_verification_redirect_url,
+            'nonce' => $verification->nonce,
+            'error' => $verification->error_code !== null ? [
+                'code' => $verification->error_code,
+                'message' => $verification->error_message,
+            ] : null,
+        ];
+    }
+}

--- a/app/Models/AllowlistIdentifier.php
+++ b/app/Models/AllowlistIdentifier.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string $id
+ * @property string $environment_id
+ * @property string $identifier Email or @domain
+ * @property string $identifier_type email_address | email_domain
+ */
+class AllowlistIdentifier extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    public const TYPE_EMAIL_ADDRESS = 'email_address';
+
+    public const TYPE_EMAIL_DOMAIN = 'email_domain';
+
+    protected string $idPrefix = 'allow_';
+
+    protected $fillable = [
+        'environment_id',
+        'identifier',
+        'identifier_type',
+    ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+}

--- a/app/Models/BlocklistIdentifier.php
+++ b/app/Models/BlocklistIdentifier.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string $id
+ * @property string $environment_id
+ * @property string $identifier
+ * @property string $identifier_type email_address | email_domain
+ */
+class BlocklistIdentifier extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    public const TYPE_EMAIL_ADDRESS = 'email_address';
+
+    public const TYPE_EMAIL_DOMAIN = 'email_domain';
+
+    protected string $idPrefix = 'block_';
+
+    protected $fillable = [
+        'environment_id',
+        'identifier',
+        'identifier_type',
+    ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+}

--- a/app/Models/Environment.php
+++ b/app/Models/Environment.php
@@ -37,6 +37,15 @@ class Environment extends Model
         self::KIND_PRODUCTION,
     ];
 
+    public const SIGNUP_MODE_PUBLIC = 'public';
+
+    public const SIGNUP_MODE_RESTRICTED = 'restricted';
+
+    public const SIGNUP_MODES = [
+        self::SIGNUP_MODE_PUBLIC,
+        self::SIGNUP_MODE_RESTRICTED,
+    ];
+
     protected string $idPrefix = 'env_';
 
     protected $fillable = [
@@ -51,6 +60,8 @@ class Environment extends Model
         'allowed_origins',
         'appearance',
         'localization',
+        'user_settings',
+        'signup_mode',
     ];
 
     protected function casts(): array
@@ -60,6 +71,7 @@ class Environment extends Model
             'allowed_origins' => 'array',
             'appearance' => 'array',
             'localization' => 'array',
+            'user_settings' => 'array',
         ];
     }
 

--- a/app/Models/Invitation.php
+++ b/app/Models/Invitation.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * BAPI-issued sign-up invitation. The full CRUD surface (issue, list, revoke,
+ * resend) lands in AU-13; AU-10 only needs the columns here so the FAPI
+ * `/v1/client/sign_ups` controller can redeem a `ticket` claim.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $email_address
+ * @property string $status
+ * @property array $public_metadata
+ * @property ?string $redirect_url
+ * @property ?string $redeemed_by_user_id
+ * @property ?\DateTimeInterface $expires_at
+ * @property ?\DateTimeInterface $accepted_at
+ * @property ?\DateTimeInterface $revoked_at
+ */
+class Invitation extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_ACCEPTED = 'accepted';
+
+    public const STATUS_REVOKED = 'revoked';
+
+    public const STATUS_EXPIRED = 'expired';
+
+    public const STATUSES = [
+        self::STATUS_PENDING,
+        self::STATUS_ACCEPTED,
+        self::STATUS_REVOKED,
+        self::STATUS_EXPIRED,
+    ];
+
+    protected string $idPrefix = 'inv_';
+
+    protected $fillable = [
+        'environment_id',
+        'email_address',
+        'status',
+        'public_metadata',
+        'redirect_url',
+        'redeemed_by_user_id',
+        'expires_at',
+        'accepted_at',
+        'revoked_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'public_metadata' => 'array',
+            'expires_at' => 'immutable_datetime',
+            'accepted_at' => 'immutable_datetime',
+            'revoked_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function isRedeemable(): bool
+    {
+        if ($this->status !== self::STATUS_PENDING) {
+            return false;
+        }
+        if ($this->expires_at !== null && $this->expires_at->isPast()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/database/migrations/0006_01_01_000000_create_signup_supporting_tables.php
+++ b/database/migrations/0006_01_01_000000_create_signup_supporting_tables.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Sign-up supporting schema (AU-10):
+ *
+ *   - environments.user_settings  jsonb attribute_settings shape (PLAN §13.2)
+ *   - environments.signup_mode    'public' | 'restricted' (allowlist gates)
+ *   - invitations                 BAPI-issued pre-verified invites; AU-13
+ *                                 owns the CRUD surface
+ *   - allowlist_identifiers       email / domain entries that are allowed in
+ *   - blocklist_identifiers       email / domain entries that are blocked
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('environments', function (Blueprint $table): void {
+            $table->jsonb('user_settings')->default(json_encode((object) []));
+            $table->string('signup_mode', 16)->default('public');
+        });
+
+        Schema::create('invitations', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('email_address');
+            $table->string('status', 16)->default('pending'); // pending|accepted|revoked|expired
+            $table->jsonb('public_metadata')->default(json_encode((object) []));
+            $table->string('redirect_url')->nullable();
+            $table->string('redeemed_by_user_id', 64)->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('accepted_at')->nullable();
+            $table->timestamp('revoked_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('redeemed_by_user_id')->references('id')->on('users')->nullOnDelete();
+            $table->index(['environment_id', 'email_address']);
+        });
+
+        Schema::create('allowlist_identifiers', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('identifier');                // foo@bar.com or @bar.com (domain)
+            $table->string('identifier_type', 16);       // email_address | email_domain
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->unique(['environment_id', 'identifier']);
+        });
+
+        Schema::create('blocklist_identifiers', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('identifier');
+            $table->string('identifier_type', 16);
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->unique(['environment_id', 'identifier']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('blocklist_identifiers');
+        Schema::dropIfExists('allowlist_identifiers');
+        Schema::dropIfExists('invitations');
+        Schema::table('environments', function (Blueprint $table): void {
+            $table->dropColumn(['user_settings', 'signup_mode']);
+        });
+    }
+};

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Fapi\EnvironmentController;
 use App\Http\Controllers\Fapi\PingController;
 use App\Http\Controllers\Fapi\SessionTokenController;
 use App\Http\Controllers\Fapi\SignInController;
+use App\Http\Controllers\Fapi\SignUpController;
 use App\Http\Controllers\WellKnown\JwksController;
 use App\Http\Controllers\WellKnown\OpenIdConfigurationController;
 use App\Http\Middleware\EnforceFapiOrigin;
@@ -52,6 +53,7 @@ Route::prefix('v1')->group(function (): void {
     // Sign-in: POST creates the attempt (and, if needed, the Client). The
     // remaining endpoints require an existing Client cookie.
     Route::post('/client/sign_ins', [SignInController::class, 'store'])->name('fapi.sign_in.store');
+    Route::post('/client/sign_ups', [SignUpController::class, 'store'])->name('fapi.sign_up.store');
     Route::middleware(ResolveClientFromCookie::class)->group(function (): void {
         Route::get('/client/sign_ins/{sid}', [SignInController::class, 'show'])->name('fapi.sign_in.show');
         Route::post('/client/sign_ins/{sid}/prepare_first_factor', [SignInController::class, 'prepareFirstFactor'])->name('fapi.sign_in.prepare_first_factor');
@@ -59,6 +61,11 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/client/sign_ins/{sid}/prepare_second_factor', [SignInController::class, 'prepareSecondFactor'])->name('fapi.sign_in.prepare_second_factor');
         Route::post('/client/sign_ins/{sid}/attempt_second_factor', [SignInController::class, 'attemptSecondFactor'])->name('fapi.sign_in.attempt_second_factor');
         Route::post('/client/sign_ins/{sid}/reset_password', [SignInController::class, 'resetPassword'])->name('fapi.sign_in.reset_password');
+
+        Route::get('/client/sign_ups/{sid}', [SignUpController::class, 'show'])->name('fapi.sign_up.show');
+        Route::patch('/client/sign_ups/{sid}', [SignUpController::class, 'patch'])->name('fapi.sign_up.patch');
+        Route::post('/client/sign_ups/{sid}/prepare_verification', [SignUpController::class, 'prepareVerification'])->name('fapi.sign_up.prepare_verification');
+        Route::post('/client/sign_ups/{sid}/attempt_verification', [SignUpController::class, 'attemptVerification'])->name('fapi.sign_up.attempt_verification');
 
         Route::post('/client/sessions/{sid}/tokens', SessionTokenController::class)->name('fapi.session_token');
         Route::post('/client/sessions/{sid}/tokens/{template}', SessionTokenController::class)->name('fapi.session_token.template');

--- a/tests/Feature/Http/SignUp/HappyPathTest.php
+++ b/tests/Feature/Http/SignUp/HappyPathTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\EmailAddress;
+use App\Models\Session;
+use App\Models\User;
+use App\Models\Verification;
+use App\Models\VerificationCode;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Http\SignUp\SignUpTestSupport;
+
+uses(RefreshDatabase::class);
+
+it('runs create → prepare → attempt → complete with email + password', function (): void {
+    $f = SignUpTestSupport::bootEnv();
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+    $cookie = $bs['cookie'];
+
+    // 1. POST /sign_ups with email + password — both required + email verify_at_sign_up.
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+            'email_address' => 'newbie@example.com',
+            'password' => 'super-secret-password',
+        ]);
+
+    $create->assertOk()
+        ->assertJsonPath('response.status', 'missing_requirements')
+        ->assertJsonPath('response.email_address', 'newbie@example.com')
+        ->assertJsonPath('response.unverified_fields', ['email_address']);
+    $sid = $create->json('response.id');
+
+    // 2. POST /prepare_verification strategy=email_code.
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ups/{$sid}/prepare_verification", [
+            'strategy' => 'email_code',
+        ])
+        ->assertOk();
+
+    // 3. Stamp a known code on the row.
+    $verification = Verification::query()->withoutGlobalScopes()->latest('id')->first();
+    $codeRow = VerificationCode::query()->where('verification_id', $verification->id)->latest('id')->first();
+    $known = '424242';
+    $codeRow->forceFill(['code_hash' => hash('sha256', $known)])->save();
+
+    // 4. POST /attempt_verification → complete.
+    $attempt = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ups/{$sid}/attempt_verification", [
+            'strategy' => 'email_code',
+            'code' => $known,
+        ]);
+
+    $attempt->assertOk()
+        ->assertJsonPath('response.status', 'complete');
+    expect($attempt->json('response.created_session_id'))->toStartWith('sess_');
+    expect($attempt->json('response.created_user_id'))->toStartWith('user_');
+
+    // 5. Verify the User + EmailAddress + Session rows exist with the right state.
+    $userId = $attempt->json('response.created_user_id');
+    $user = User::query()->withoutGlobalScopes()->where('id', $userId)->first();
+    expect($user)->not->toBeNull();
+    expect($user->checkPassword('super-secret-password'))->toBeTrue();
+
+    $email = EmailAddress::query()->withoutGlobalScopes()->where('user_id', $userId)->first();
+    expect($email)->not->toBeNull();
+    expect($email->email_address)->toBe('newbie@example.com');
+    expect($email->isVerified())->toBeTrue();
+    expect($email->is_primary)->toBeTrue();
+
+    $sessionId = $attempt->json('response.created_session_id');
+    expect(Session::query()->withoutGlobalScopes()->where('id', $sessionId)->where('status', 'active')->exists())->toBeTrue();
+});
+
+it('returns missing_fields when first_name is required and not provided', function (): void {
+    $f = SignUpTestSupport::bootEnv([
+        'attributes' => [
+            'first_name' => ['enabled' => true, 'required' => true],
+        ],
+    ]);
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+    $cookie = $bs['cookie'];
+
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+            'email_address' => 'newbie@example.com',
+            'password' => 'super-secret-password',
+        ]);
+
+    $create->assertOk()
+        ->assertJsonPath('response.status', 'missing_requirements')
+        ->assertJsonPath('response.missing_fields', ['first_name']);
+
+    // No User row written until everything is supplied + verified.
+    expect(User::query()->withoutGlobalScopes()->count())->toBe(0);
+});

--- a/tests/Feature/Http/SignUp/RestrictionsTest.php
+++ b/tests/Feature/Http/SignUp/RestrictionsTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\AllowlistIdentifier;
+use App\Models\BlocklistIdentifier;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Http\SignUp\SignUpTestSupport;
+
+uses(RefreshDatabase::class);
+
+it('rejects fields the env has disabled with form_param_unknown', function (): void {
+    $f = SignUpTestSupport::bootEnv([
+        'attributes' => [
+            // Disable username explicitly (default is also disabled).
+            'username' => ['enabled' => false],
+        ],
+    ]);
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+            'email_address' => 'a@example.com',
+            'password' => 'super-secret-password',
+            'username' => 'shouldbeignored',
+        ]);
+
+    $r->assertStatus(422)->assertJsonPath('errors.0.code', 'form_param_unknown');
+});
+
+it('only allows allowlisted emails when signup_mode = restricted', function (): void {
+    $f = SignUpTestSupport::bootEnv([], Environment::SIGNUP_MODE_RESTRICTED);
+    AllowlistIdentifier::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'identifier' => 'team.com',
+        'identifier_type' => AllowlistIdentifier::TYPE_EMAIL_DOMAIN,
+    ]);
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+
+    // Outside the allowlist domain → rejected.
+    $bad = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+            'email_address' => 'someone@outside.com',
+            'password' => 'super-secret-password',
+        ]);
+    $bad->assertStatus(422)->assertJsonPath('errors.0.code', 'form_identifier_not_allowed');
+
+    // Inside the allowlist domain → accepted.
+    $good = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+            'email_address' => 'someone@team.com',
+            'password' => 'super-secret-password',
+        ]);
+    $good->assertOk()->assertJsonPath('response.status', 'missing_requirements');
+});
+
+it('rejects blocklisted emails', function (): void {
+    $f = SignUpTestSupport::bootEnv();
+    BlocklistIdentifier::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'identifier' => 'banned@example.com',
+        'identifier_type' => BlocklistIdentifier::TYPE_EMAIL_ADDRESS,
+    ]);
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+            'email_address' => 'banned@example.com',
+            'password' => 'super-secret-password',
+        ])
+        ->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'form_identifier_not_allowed');
+});
+
+it('detects subaddress collisions when block_email_subaddresses is on', function (): void {
+    $f = SignUpTestSupport::bootEnv([
+        'block_email_subaddresses' => true,
+    ]);
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+
+    // Pre-seed a verified user with foo@example.com.
+    $user = User::query()->withoutGlobalScopes()->create(['environment_id' => $f['env']->id]);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'email_address' => 'foo@example.com',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+            'email_address' => 'foo+anything@example.com',
+            'password' => 'super-secret-password',
+        ]);
+    $r->assertStatus(422)->assertJsonPath('errors.0.code', 'form_identifier_exists');
+});
+
+it('treats gmail dot variants as the same identifier', function (): void {
+    $f = SignUpTestSupport::bootEnv(); // ignore_dots_for_gmail_addresses defaults to true
+
+    // Pre-seed a verified user with foo@gmail.com.
+    $user = User::query()->withoutGlobalScopes()->create(['environment_id' => $f['env']->id]);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'email_address' => 'foo@gmail.com',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+            'email_address' => 'f.o.o@gmail.com',
+            'password' => 'super-secret-password',
+        ]);
+    $r->assertStatus(422)->assertJsonPath('errors.0.code', 'form_identifier_exists');
+});

--- a/tests/Feature/Http/SignUp/SignUpTestSupport.php
+++ b/tests/Feature/Http/SignUp/SignUpTestSupport.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\SignUp;
+
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Services\Client\ClientResolver;
+use App\Services\Keys\SigningKeyGenerator;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * Shared fixtures for the SignUp HTTP tests. Mirrors SignInTestSupport
+ * but creates an env tuned for sign-up: open signup_mode by default plus
+ * the user_settings overrides each test passes in.
+ */
+final class SignUpTestSupport
+{
+    public static function reloadRoutes(): void
+    {
+        $router = app('router');
+        $router->setRoutes(new RouteCollection);
+
+        $appHost = (string) config('authn.app_host');
+        $fapi = Route::middleware('fapi');
+        if ((string) config('authn.routing_mode') === 'subdomain') {
+            $fapi->domain('{env_slug}.'.$appHost);
+        } else {
+            $fapi->prefix('{env_slug}');
+        }
+        $fapi->group(base_path('routes/fapi.php'));
+    }
+
+    public static function bootEnv(array $userSettings = [], string $signupMode = 'public', string $allowedOrigin = 'https://app.example.com'): array
+    {
+        config([
+            'authn.routing_mode' => 'subdomain',
+            'authn.app_host' => 'authn.local',
+            'authn.app_scheme' => 'https',
+            'authn.app_port_suffix' => '',
+            'authn.bapi_host' => 'api.authn.local',
+            'authn.dashboard_host' => 'dashboard.authn.local',
+        ]);
+        self::reloadRoutes();
+
+        $project = Project::create(['name' => 'P', 'slug' => 'p']);
+        $env = Environment::create([
+            'project_id' => $project->id,
+            'kind' => Environment::KIND_PRODUCTION,
+            'slug' => 'acme',
+            'frontend_api_host' => 'acme.authn.local',
+            'allowed_origins' => [$allowedOrigin],
+            'user_settings' => $userSettings,
+            'signup_mode' => $signupMode,
+        ]);
+        (new SigningKeyGenerator)->generate($env);
+
+        return ['env' => $env, 'origin' => $allowedOrigin];
+    }
+
+    public static function clientWithCookie(Environment $env): array
+    {
+        $client = Client::create(['environment_id' => $env->id]);
+        $cookie = app(ClientResolver::class)->mintCookieValue($client);
+
+        return ['client' => $client, 'cookie' => $cookie];
+    }
+}

--- a/tests/Feature/Http/SignUp/TicketTest.php
+++ b/tests/Feature/Http/SignUp/TicketTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Invitation;
+use App\Models\Session;
+use App\Models\User;
+use App\Services\Tickets\TicketIssuer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Http\SignUp\SignUpTestSupport;
+
+uses(RefreshDatabase::class);
+
+it('redeems an invitation ticket and completes the sign-up in one call', function (): void {
+    $f = SignUpTestSupport::bootEnv();
+    $invitation = Invitation::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'email_address' => 'invited@example.com',
+        'status' => Invitation::STATUS_PENDING,
+        'expires_at' => now()->addDay(),
+    ]);
+
+    $ticket = app(TicketIssuer::class)->issue($f['env'], 600, [
+        'sub' => 'invited@example.com',
+        'sid' => $invitation->id,
+        'purpose' => 'invitation',
+    ]);
+
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+            'ticket' => $ticket,
+            'password' => 'super-secret-password',
+        ]);
+
+    $r->assertOk()
+        ->assertJsonPath('response.status', 'complete')
+        ->assertJsonPath('response.email_address', 'invited@example.com');
+
+    $userId = $r->json('response.created_user_id');
+    expect($userId)->toStartWith('user_');
+    $user = User::query()->withoutGlobalScopes()->where('id', $userId)->first();
+    expect($user)->not->toBeNull();
+    expect($user->primaryEmailAddress->isVerified())->toBeTrue();
+
+    $sessionId = $r->json('response.created_session_id');
+    expect(Session::query()->withoutGlobalScopes()->where('id', $sessionId)->where('status', 'active')->exists())->toBeTrue();
+
+    $invitation->refresh();
+    expect($invitation->status)->toBe(Invitation::STATUS_ACCEPTED);
+    expect($invitation->redeemed_by_user_id)->toBe($userId);
+});
+
+it('rejects a replayed ticket with ticket_invalid', function (): void {
+    $f = SignUpTestSupport::bootEnv();
+    $invitation = Invitation::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'email_address' => 'replay@example.com',
+        'status' => Invitation::STATUS_PENDING,
+        'expires_at' => now()->addDay(),
+    ]);
+    $ticket = app(TicketIssuer::class)->issue($f['env'], 600, [
+        'sub' => 'replay@example.com',
+        'sid' => $invitation->id,
+        'purpose' => 'invitation',
+    ]);
+
+    // First redemption succeeds.
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+    $first = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+            'ticket' => $ticket,
+            'password' => 'super-secret-password',
+        ]);
+    $first->assertOk();
+
+    // Second redemption (different client) fails — single-use jti guard fires.
+    $bs2 = SignUpTestSupport::clientWithCookie($f['env']);
+    $second = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs2['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+            'ticket' => $ticket,
+            'password' => 'super-secret-password',
+        ]);
+    $second->assertStatus(422)->assertJsonPath('errors.0.code', 'ticket_invalid');
+});


### PR DESCRIPTION
## Summary
- State machine for `POST /v1/client/sign_ups` plus `show` / `patch` / `prepare_verification` / `attempt_verification`.
- Two create-time branches: interactive (stage fields, run an email-code verification round trip) and ticket (redeem an Invitation JWT and complete in one call).
- Schema: adds `user_settings` + `signup_mode` to environments, plus new `invitations`, `allowlist_identifiers`, `blocklist_identifiers` tables.
- Restrictions: signup_mode=restricted gates on the allowlist; blocklist always rejects; opt-in disposable-domain block; opt-in gmail-dot normalisation and `+tag` subaddress collapse for collision detection.
- No User / EmailAddress is written until the staged email is verified.
- Email send is currently the AU-9 stub job — AU-14 swaps in the real renderer + driver.

## Test plan
- [x] `php artisan test` — 195/195 (44 new sign-up assertions across 9 cases)
- [x] HappyPathTest covers create → prepare → attempt → complete and the missing_fields case for first_name.
- [x] RestrictionsTest covers form_param_unknown, allowlist + blocklist, subaddress collisions, gmail dot normalisation.
- [x] TicketTest covers the inline invitation-ticket happy path and replay → ticket_invalid (single-use jti).

🤖 Generated with [Claude Code](https://claude.com/claude-code)