### PR TITLE
FAPI sessions: touch / end / remove + multi-session policy + token hardening (AU-11)

### DIFF
--- a/app/Http/Controllers/Fapi/ClientController.php
+++ b/app/Http/Controllers/Fapi/ClientController.php
@@ -52,6 +52,9 @@ final class ClientController
                 'last_active_at' => now(),
             ]);
             $createdHere = true;
+        } else {
+            // Lazy collapse if the env was toggled to single-session mode.
+            $this->sessions->enforceSingleSessionOnRead($env, $client);
         }
 
         $response = response()

--- a/app/Http/Controllers/Fapi/SessionTokenController.php
+++ b/app/Http/Controllers/Fapi/SessionTokenController.php
@@ -6,9 +6,13 @@ namespace App\Http\Controllers\Fapi;
 
 use App\Models\Client;
 use App\Models\Session;
+use App\Models\User;
+use App\Services\Sessions\SessionLifecycle;
 use App\Services\Sessions\SessionTokenIssuer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\RateLimiter;
 use InvalidArgumentException;
 
 /**
@@ -23,7 +27,15 @@ use InvalidArgumentException;
  */
 final class SessionTokenController
 {
-    public function __construct(private readonly SessionTokenIssuer $issuer) {}
+    /** Per-session burst (PLAN §7.3): 3 requests over 30 seconds. */
+    public const RATE_LIMIT_MAX = 3;
+
+    public const RATE_LIMIT_DECAY_SECONDS = 30;
+
+    public function __construct(
+        private readonly SessionTokenIssuer $issuer,
+        private readonly SessionLifecycle $lifecycle,
+    ) {}
 
     public function __invoke(Request $request): JsonResponse
     {
@@ -46,6 +58,35 @@ final class SessionTokenController
             return $this->error(401, 'session_revoked', "Session is in status {$session->status}.");
         }
 
+        // Refuse — and revoke — when the user is banned/locked. The SDK will
+        // then sign out cleanly on the next /v1/client read.
+        $user = User::query()->withoutGlobalScopes()->where('id', $session->user_id)->first();
+        if ($user !== null) {
+            if ($user->banned) {
+                $this->lifecycle->revoke($session);
+
+                return $this->error(401, 'user_banned', 'This user is banned.');
+            }
+            if ($user->locked && $user->lockout_expires_at?->isFuture()) {
+                $this->lifecycle->revoke($session);
+
+                return $this->error(401, 'user_locked', 'This user is temporarily locked.');
+            }
+        }
+
+        $rateLimitKey = 'fapi:session_token:'.$session->id;
+        if (RateLimiter::tooManyAttempts($rateLimitKey, self::RATE_LIMIT_MAX)) {
+            $retryAfter = RateLimiter::availableIn($rateLimitKey);
+
+            return $this->error(
+                429,
+                'rate_limit_exceeded',
+                "Too many token-mint requests for this session. Retry in {$retryAfter}s.",
+                ['Retry-After' => (string) $retryAfter],
+            );
+        }
+        RateLimiter::hit($rateLimitKey, self::RATE_LIMIT_DECAY_SECONDS);
+
         try {
             $minted = $this->issuer->mint($session, $template, $request);
         } catch (InvalidArgumentException $e) {
@@ -55,6 +96,10 @@ final class SessionTokenController
             throw $e;
         }
 
+        if ($user !== null) {
+            $this->bumpUserActivity($user);
+        }
+
         return response()->json([
             'jwt' => $minted['jwt'],
             'expires_at' => $minted['expires_at'],
@@ -62,7 +107,19 @@ final class SessionTokenController
         ]);
     }
 
-    private function error(int $status, string $code, string $message): JsonResponse
+    private function bumpUserActivity(User $user): void
+    {
+        $cacheKey = 'user:active:'.$user->id;
+        if (! Cache::add($cacheKey, 1, 60)) {
+            return;
+        }
+        $user->forceFill(['last_active_at' => now()])->saveQuietly();
+    }
+
+    /**
+     * @param  array<string, string>  $headers
+     */
+    private function error(int $status, string $code, string $message, array $headers = []): JsonResponse
     {
         return response()->json([
             'errors' => [[
@@ -72,6 +129,6 @@ final class SessionTokenController
                 'meta' => [],
             ]],
             'trace_id' => null,
-        ], $status);
+        ], $status, $headers);
     }
 }

--- a/app/Http/Controllers/Fapi/SessionsController.php
+++ b/app/Http/Controllers/Fapi/SessionsController.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Http\Resources\ClientResource;
+use App\Models\Client;
+use App\Models\Session;
+use App\Services\Sessions\SessionLifecycle;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Lifecycle endpoints for the live `Session` rows on a Client:
+ *
+ *   GET    /v1/client/sessions/{sid}            — fetch the resource
+ *   POST   /v1/client/sessions/{sid}/touch      — heartbeat (debounced 60s)
+ *   POST   /v1/client/sessions/{sid}/end        — user signed out on this device
+ *   POST   /v1/client/sessions/{sid}/remove     — user removed this session from another device
+ *
+ * `tokens` lives on a separate controller so the rate limit middleware can
+ * be scoped just to the mint endpoint without touching these verbs.
+ */
+final class SessionsController
+{
+    public function __construct(private readonly SessionLifecycle $lifecycle) {}
+
+    public function show(Request $request): JsonResponse
+    {
+        $session = $this->loadSession($request);
+        if ($session instanceof JsonResponse) {
+            return $session;
+        }
+
+        return $this->envelope($session);
+    }
+
+    public function touch(Request $request): JsonResponse
+    {
+        $session = $this->loadSession($request);
+        if ($session instanceof JsonResponse) {
+            return $session;
+        }
+        if (! $session->isLive()) {
+            return $this->error(409, 'session_not_live', "Session is in status {$session->status}.");
+        }
+
+        // Forward-compat capture: orgs land in v0.2 and `last_active_organization_id`
+        // is already on the Session row. Storing the value now lets the SDK keep
+        // sending it without a flag flip later.
+        $org = $request->input('active_organization_id');
+        if (is_string($org) && $org !== '' && $session->last_active_organization_id !== $org) {
+            $session->forceFill(['last_active_organization_id' => $org])->saveQuietly();
+        }
+
+        $this->lifecycle->touch($session->fresh(), $request);
+
+        return $this->envelope($session->fresh());
+    }
+
+    public function end(Request $request): JsonResponse
+    {
+        $session = $this->loadSession($request);
+        if ($session instanceof JsonResponse) {
+            return $session;
+        }
+        if ($session->isLive()) {
+            $this->lifecycle->end($session);
+            $this->clearLastActiveIfMatches($session);
+        }
+
+        return $this->envelope($session->fresh());
+    }
+
+    public function remove(Request $request): JsonResponse
+    {
+        $session = $this->loadSession($request);
+        if ($session instanceof JsonResponse) {
+            return $session;
+        }
+        if ($session->isLive()) {
+            $this->lifecycle->remove($session);
+            $this->clearLastActiveIfMatches($session);
+        }
+
+        return $this->envelope($session->fresh());
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    private function loadSession(Request $request): Session|JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $client = app(Client::class);
+        $session = Session::query()
+            ->withoutGlobalScopes()
+            ->where('id', $sid)
+            ->where('client_id', $client->id)
+            ->first();
+        if ($session === null) {
+            return $this->error(404, 'session_not_found', 'No session matches that id on this device.');
+        }
+
+        return $session;
+    }
+
+    private function clearLastActiveIfMatches(Session $session): void
+    {
+        Client::query()
+            ->withoutGlobalScopes()
+            ->where('id', $session->client_id)
+            ->where('last_active_session_id', $session->id)
+            ->update(['last_active_session_id' => null]);
+    }
+
+    private function envelope(Session $session): JsonResponse
+    {
+        $client = Client::query()
+            ->withoutGlobalScopes()
+            ->where('id', $session->client_id)
+            ->first();
+
+        return response()->json([
+            'response' => $this->sessionShape($session),
+            'client' => ClientResource::from($client),
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    private function sessionShape(Session $session): array
+    {
+        return [
+            'object' => 'session',
+            'id' => $session->id,
+            'status' => $session->status,
+            'last_active_at' => $session->last_active_at?->getTimestampMs(),
+            'expire_at' => $session->expire_at->getTimestampMs(),
+            'abandon_at' => $session->abandon_at?->getTimestampMs(),
+            'last_active_organization_id' => $session->last_active_organization_id,
+            'actor' => $session->actor,
+            'user_id' => $session->user_id,
+            'client_id' => $session->client_id,
+        ];
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Controllers/Fapi/SignInController.php
+++ b/app/Http/Controllers/Fapi/SignInController.php
@@ -16,6 +16,7 @@ use App\Models\SignInAttempt;
 use App\Models\User;
 use App\Models\Verification;
 use App\Services\Client\ClientResolver;
+use App\Services\Sessions\SessionLifecycle;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -300,6 +301,15 @@ final class SignInController
 
         // Stamp the user as recently signed in.
         $user->forceFill(['last_sign_in_at' => now(), 'last_active_at' => now()])->saveQuietly();
+
+        // Apply the env's multi-session policy: in single-session mode, evict
+        // every other live session on this client; in multi-session mode,
+        // enforce the per-client cap by evicting LRU sessions.
+        $client = Client::query()->withoutGlobalScopes()->where('id', $attempt->client_id)->first();
+        if ($client !== null) {
+            app(SessionLifecycle::class)
+                ->enforceMultiSessionPolicy(app(Environment::class), $client, $session);
+        }
 
         return $session;
     }

--- a/app/Http/Controllers/Fapi/SignUpController.php
+++ b/app/Http/Controllers/Fapi/SignUpController.php
@@ -22,6 +22,7 @@ use App\Models\User;
 use App\Models\Verification;
 use App\Models\VerificationCode;
 use App\Services\Client\ClientResolver;
+use App\Services\Sessions\SessionLifecycle;
 use App\Services\Verification\VerificationManager;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -362,6 +363,12 @@ final class SignUpController
                 ->withoutGlobalScopes()
                 ->where('id', $client->id)
                 ->update(['last_active_session_id' => $session->id, 'last_active_at' => now()]);
+
+            $reloadedClient = Client::query()->withoutGlobalScopes()->where('id', $client->id)->first();
+            if ($reloadedClient !== null) {
+                app(SessionLifecycle::class)
+                    ->enforceMultiSessionPolicy($env, $reloadedClient, $session);
+            }
 
             if ($redeemingInvitation !== null) {
                 $redeemingInvitation->forceFill([

--- a/app/Services/Sessions/SessionLifecycle.php
+++ b/app/Services/Sessions/SessionLifecycle.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Sessions;
 
+use App\Models\Client;
+use App\Models\Environment;
 use App\Models\Session;
 use App\Models\SessionActivity;
 use Illuminate\Http\Request;
@@ -30,6 +32,13 @@ final class SessionLifecycle
 {
     /** Per-session debounce window for touch writes (seconds). Matches PLAN §10. */
     public const TOUCH_DEBOUNCE_SECONDS = 60;
+
+    /**
+     * Default cap when `multi_session = true`. Configurable per-env via
+     * `Environment.user_settings.sessions.max_concurrent_sessions_per_client`
+     * once the dashboard exposes it (AU-13). Matches PLAN §13.5.
+     */
+    public const DEFAULT_MAX_CONCURRENT_SESSIONS = 10;
 
     private const TOUCH_CACHE_PREFIX = 'session:touch:';
 
@@ -93,6 +102,92 @@ final class SessionLifecycle
         }
 
         return $this->transitionTo($session, Session::STATUS_ACTIVE);
+    }
+
+    /**
+     * Apply the env's multi-session policy after a fresh Session was minted.
+     *
+     * - multi_session = false: every other live session on the Client is
+     *   evicted (status → replaced).
+     * - multi_session = true:  if the live count exceeds the configured cap,
+     *   evict the oldest-by-`last_active_at` until back under the cap.
+     *
+     * Returns the list of evicted session ids so the caller can fire
+     * webhooks (AU-15 will subscribe to this list).
+     *
+     * @return list<string>
+     */
+    public function enforceMultiSessionPolicy(Environment $environment, Client $client, Session $newSession): array
+    {
+        $userSettings = is_array($environment->user_settings) ? $environment->user_settings : [];
+        $sessionCfg = is_array($userSettings['sessions'] ?? null) ? $userSettings['sessions'] : [];
+        $multiSession = (bool) ($sessionCfg['multi_session'] ?? true);
+        $maxConcurrent = (int) ($sessionCfg['max_concurrent_sessions_per_client'] ?? self::DEFAULT_MAX_CONCURRENT_SESSIONS);
+
+        $live = Session::query()
+            ->withoutGlobalScopes()
+            ->where('client_id', $client->id)
+            ->where('id', '!=', $newSession->id)
+            ->whereIn('status', Session::LIVE_STATUSES)
+            ->orderBy('last_active_at')
+            ->get();
+
+        $evicted = [];
+
+        if (! $multiSession) {
+            foreach ($live as $session) {
+                $this->replaced($session);
+                $evicted[] = $session->id;
+            }
+
+            return $evicted;
+        }
+
+        $excess = ($live->count() + 1) - max(1, $maxConcurrent);
+        if ($excess <= 0) {
+            return [];
+        }
+        foreach ($live->take($excess) as $session) {
+            $this->replaced($session);
+            $evicted[] = $session->id;
+        }
+
+        return $evicted;
+    }
+
+    /**
+     * Lazy collapse on `GET /v1/client` when multi_session was toggled to
+     * false but the client still carries multiple live sessions. Keeps the
+     * one with the most-recent `last_active_at`; evicts the rest.
+     *
+     * @return list<string>
+     */
+    public function enforceSingleSessionOnRead(Environment $environment, Client $client): array
+    {
+        $userSettings = is_array($environment->user_settings) ? $environment->user_settings : [];
+        $sessionCfg = is_array($userSettings['sessions'] ?? null) ? $userSettings['sessions'] : [];
+        if (($sessionCfg['multi_session'] ?? true) !== false) {
+            return [];
+        }
+
+        $live = Session::query()
+            ->withoutGlobalScopes()
+            ->where('client_id', $client->id)
+            ->whereIn('status', Session::LIVE_STATUSES)
+            ->orderByDesc('last_active_at')
+            ->get();
+
+        if ($live->count() <= 1) {
+            return [];
+        }
+
+        $evicted = [];
+        foreach ($live->slice(1) as $session) {
+            $this->replaced($session);
+            $evicted[] = $session->id;
+        }
+
+        return $evicted;
     }
 
     private function transitionTo(Session $session, string $target): Session

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Http\Controllers\Fapi\ClientController;
 use App\Http\Controllers\Fapi\EnvironmentController;
 use App\Http\Controllers\Fapi\PingController;
+use App\Http\Controllers\Fapi\SessionsController;
 use App\Http\Controllers\Fapi\SessionTokenController;
 use App\Http\Controllers\Fapi\SignInController;
 use App\Http\Controllers\Fapi\SignUpController;
@@ -66,6 +67,11 @@ Route::prefix('v1')->group(function (): void {
         Route::patch('/client/sign_ups/{sid}', [SignUpController::class, 'patch'])->name('fapi.sign_up.patch');
         Route::post('/client/sign_ups/{sid}/prepare_verification', [SignUpController::class, 'prepareVerification'])->name('fapi.sign_up.prepare_verification');
         Route::post('/client/sign_ups/{sid}/attempt_verification', [SignUpController::class, 'attemptVerification'])->name('fapi.sign_up.attempt_verification');
+
+        Route::get('/client/sessions/{sid}', [SessionsController::class, 'show'])->name('fapi.session.show');
+        Route::post('/client/sessions/{sid}/touch', [SessionsController::class, 'touch'])->name('fapi.session.touch');
+        Route::post('/client/sessions/{sid}/end', [SessionsController::class, 'end'])->name('fapi.session.end');
+        Route::post('/client/sessions/{sid}/remove', [SessionsController::class, 'remove'])->name('fapi.session.remove');
 
         Route::post('/client/sessions/{sid}/tokens', SessionTokenController::class)->name('fapi.session_token');
         Route::post('/client/sessions/{sid}/tokens/{template}', SessionTokenController::class)->name('fapi.session_token.template');

--- a/tests/Feature/Http/Sessions/LifecycleTest.php
+++ b/tests/Feature/Http/Sessions/LifecycleTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Session;
+use App\Models\SessionActivity;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Http\Sessions\SessionsTestSupport;
+
+uses(RefreshDatabase::class);
+
+it('touch updates last_active_at and writes one SessionActivity per debounce window', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $sid = $bs['session']->id;
+    $cookie = $bs['cookie'];
+
+    $before = $bs['session']->last_active_at;
+
+    $first = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin'], 'User-Agent' => 'Mozilla/5.0 Chrome/100'])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$sid}/touch", []);
+    $first->assertOk()->assertJsonPath('response.id', $sid);
+
+    expect(SessionActivity::query()->where('session_id', $sid)->count())->toBe(1);
+
+    // Second touch within debounce window — no new activity row written.
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$sid}/touch", [])
+        ->assertOk();
+    expect(SessionActivity::query()->where('session_id', $sid)->count())->toBe(1);
+
+    expect(Session::query()->withoutGlobalScopes()->where('id', $sid)->first()->last_active_at?->getTimestamp())
+        ->toBeGreaterThanOrEqual($before?->getTimestamp() ?? 0);
+});
+
+it('end flips status to ended; subsequent token mint returns 401', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $sid = $bs['session']->id;
+    $cookie = $bs['cookie'];
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$sid}/end", [])
+        ->assertOk()
+        ->assertJsonPath('response.status', 'ended');
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$sid}/tokens", [])
+        ->assertStatus(401)
+        ->assertJsonPath('errors.0.code', 'session_revoked');
+});
+
+it('remove flips status to removed; subsequent token mint returns 401', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $sid = $bs['session']->id;
+    $cookie = $bs['cookie'];
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$sid}/remove", [])
+        ->assertOk()
+        ->assertJsonPath('response.status', 'removed');
+
+    $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$sid}/tokens", [])
+        ->assertStatus(401)
+        ->assertJsonPath('errors.0.code', 'session_revoked');
+});
+
+it('rate-limits token mints to 3 per 30s with Retry-After', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $sid = $bs['session']->id;
+    $cookie = $bs['cookie'];
+
+    for ($i = 0; $i < 3; $i++) {
+        $this->withCredentials()
+            ->withUnencryptedCookie('__client', $cookie)
+            ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+            ->postJson("https://acme.authn.local/v1/client/sessions/{$sid}/tokens", [])
+            ->assertOk();
+    }
+
+    $fourth = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$sid}/tokens", []);
+    $fourth->assertStatus(429)
+        ->assertJsonPath('errors.0.code', 'rate_limit_exceeded')
+        ->assertHeader('Retry-After');
+});
+
+it('refuses (and revokes) a token mint for a banned user', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $bs['user']->forceFill(['banned' => true])->save();
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sessions/{$bs['session']->id}/tokens", []);
+    $r->assertStatus(401)->assertJsonPath('errors.0.code', 'user_banned');
+
+    expect(Session::query()->withoutGlobalScopes()->where('id', $bs['session']->id)->first()->status)
+        ->toBe('revoked');
+});

--- a/tests/Feature/Http/Sessions/MultiSessionTest.php
+++ b/tests/Feature/Http/Sessions/MultiSessionTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\Session;
+use App\Models\User;
+use App\Services\Sessions\SessionLifecycle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Http\Sessions\SessionsTestSupport;
+
+uses(RefreshDatabase::class);
+
+it('multi_session=false evicts the prior session when a fresh one is minted', function (): void {
+    $f = SessionsTestSupport::bootEnv([
+        'sessions' => ['multi_session' => false],
+    ]);
+
+    // Two users; one Client (browser) signs in as both — single-session mode
+    // should evict the first session when the second is created.
+    $client = Client::create(['environment_id' => $f['env']->id]);
+
+    $userA = new User(['environment_id' => $f['env']->id]);
+    $userA->setPassword('secret');
+    $userA->save();
+    EmailAddress::create([
+        'environment_id' => $f['env']->id, 'user_id' => $userA->id,
+        'email_address' => 'a@example.com', 'verified_at' => now(), 'is_primary' => true,
+    ]);
+
+    $userB = new User(['environment_id' => $f['env']->id]);
+    $userB->setPassword('secret');
+    $userB->save();
+    EmailAddress::create([
+        'environment_id' => $f['env']->id, 'user_id' => $userB->id,
+        'email_address' => 'b@example.com', 'verified_at' => now(), 'is_primary' => true,
+    ]);
+
+    $sessionA = Session::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'user_id' => $userA->id,
+        'status' => Session::STATUS_ACTIVE,
+    ]);
+
+    // Simulate the new sign-in by minting session B and running enforcement.
+    $sessionB = Session::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'user_id' => $userB->id,
+        'status' => Session::STATUS_ACTIVE,
+    ]);
+    app(SessionLifecycle::class)->enforceMultiSessionPolicy($f['env'], $client, $sessionB);
+
+    expect(Session::query()->withoutGlobalScopes()->where('id', $sessionA->id)->first()->status)->toBe('replaced');
+    expect(Session::query()->withoutGlobalScopes()->where('id', $sessionB->id)->first()->status)->toBe('active');
+});
+
+it('multi_session=true with cap=2 evicts the oldest live session on overflow', function (): void {
+    $f = SessionsTestSupport::bootEnv([
+        'sessions' => [
+            'multi_session' => true,
+            'max_concurrent_sessions_per_client' => 2,
+        ],
+    ]);
+    $client = Client::create(['environment_id' => $f['env']->id]);
+
+    // Three users with one session each on the same client. Activity ordering
+    // (oldest → newest by last_active_at) determines who gets evicted.
+    $sessions = [];
+    foreach (['a', 'b', 'c'] as $i => $tag) {
+        $user = new User(['environment_id' => $f['env']->id]);
+        $user->setPassword('secret');
+        $user->save();
+        EmailAddress::create([
+            'environment_id' => $f['env']->id, 'user_id' => $user->id,
+            'email_address' => "{$tag}@example.com", 'verified_at' => now(), 'is_primary' => true,
+        ]);
+        $sessions[$tag] = Session::create([
+            'environment_id' => $f['env']->id,
+            'client_id' => $client->id,
+            'user_id' => $user->id,
+            'status' => Session::STATUS_ACTIVE,
+            'last_active_at' => now()->subMinutes(10 - $i * 4), // a oldest, c newest
+        ]);
+    }
+
+    app(SessionLifecycle::class)->enforceMultiSessionPolicy($f['env'], $client, $sessions['c']);
+
+    // The oldest session (a) is evicted; b and c remain.
+    expect(Session::query()->withoutGlobalScopes()->where('id', $sessions['a']->id)->first()->status)->toBe('replaced');
+    expect(Session::query()->withoutGlobalScopes()->where('id', $sessions['b']->id)->first()->status)->toBe('active');
+    expect(Session::query()->withoutGlobalScopes()->where('id', $sessions['c']->id)->first()->status)->toBe('active');
+});
+
+it('lazy collapse on GET /v1/client when multi_session was toggled off', function (): void {
+    $f = SessionsTestSupport::bootEnv([
+        'sessions' => ['multi_session' => false],
+    ]);
+    $client = Client::create(['environment_id' => $f['env']->id]);
+
+    foreach (['a', 'b'] as $i => $tag) {
+        $user = new User(['environment_id' => $f['env']->id]);
+        $user->setPassword('secret');
+        $user->save();
+        EmailAddress::create([
+            'environment_id' => $f['env']->id, 'user_id' => $user->id,
+            'email_address' => "{$tag}@example.com", 'verified_at' => now(), 'is_primary' => true,
+        ]);
+        Session::create([
+            'environment_id' => $f['env']->id,
+            'client_id' => $client->id,
+            'user_id' => $user->id,
+            'status' => Session::STATUS_ACTIVE,
+            'last_active_at' => now()->subMinutes(10 - $i * 4),
+        ]);
+    }
+
+    app(SessionLifecycle::class)->enforceSingleSessionOnRead($f['env'], $client);
+
+    $live = Session::query()
+        ->withoutGlobalScopes()
+        ->where('client_id', $client->id)
+        ->whereIn('status', Session::LIVE_STATUSES)
+        ->count();
+    expect($live)->toBe(1);
+});

--- a/tests/Feature/Http/Sessions/SessionsTestSupport.php
+++ b/tests/Feature/Http/Sessions/SessionsTestSupport.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Sessions;
+
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\Session;
+use App\Models\User;
+use App\Services\Client\ClientResolver;
+use App\Services\Keys\SigningKeyGenerator;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+final class SessionsTestSupport
+{
+    public static function reloadRoutes(): void
+    {
+        $router = app('router');
+        $router->setRoutes(new RouteCollection);
+
+        $appHost = (string) config('authn.app_host');
+        $fapi = Route::middleware('fapi');
+        if ((string) config('authn.routing_mode') === 'subdomain') {
+            $fapi->domain('{env_slug}.'.$appHost);
+        } else {
+            $fapi->prefix('{env_slug}');
+        }
+        $fapi->group(base_path('routes/fapi.php'));
+    }
+
+    public static function bootEnv(array $userSettings = [], string $allowedOrigin = 'https://app.example.com'): array
+    {
+        config([
+            'authn.routing_mode' => 'subdomain',
+            'authn.app_host' => 'authn.local',
+            'authn.app_scheme' => 'https',
+            'authn.app_port_suffix' => '',
+            'authn.bapi_host' => 'api.authn.local',
+            'authn.dashboard_host' => 'dashboard.authn.local',
+        ]);
+        self::reloadRoutes();
+
+        $project = Project::create(['name' => 'P', 'slug' => 'p']);
+        $env = Environment::create([
+            'project_id' => $project->id,
+            'kind' => Environment::KIND_PRODUCTION,
+            'slug' => 'acme',
+            'frontend_api_host' => 'acme.authn.local',
+            'allowed_origins' => [$allowedOrigin],
+            'user_settings' => $userSettings,
+        ]);
+        (new SigningKeyGenerator)->generate($env);
+
+        return ['env' => $env, 'origin' => $allowedOrigin];
+    }
+
+    public static function makeUserWithSession(Environment $env, ?Client $client = null, string $email = 'alice@example.com'): array
+    {
+        $user = new User(['environment_id' => $env->id, 'first_name' => 'Alice']);
+        $user->setPassword('super-secret-password');
+        $user->save();
+
+        EmailAddress::create([
+            'environment_id' => $env->id,
+            'user_id' => $user->id,
+            'email_address' => $email,
+            'verified_at' => now(),
+            'is_primary' => true,
+        ]);
+
+        $client ??= Client::create(['environment_id' => $env->id]);
+        $cookie = app(ClientResolver::class)->mintCookieValue($client);
+        $session = Session::create([
+            'environment_id' => $env->id,
+            'client_id' => $client->id,
+            'user_id' => $user->id,
+            'status' => Session::STATUS_ACTIVE,
+        ]);
+
+        return ['user' => $user, 'client' => $client, 'cookie' => $cookie, 'session' => $session];
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the four lifecycle endpoints (\`show\`, \`touch\`, \`end\`, \`remove\`) plus their routes.
- Multi-session policy lands in \`SessionLifecycle::enforceMultiSessionPolicy\` (called from sign-in / sign-up after each \`createSession\`) and \`enforceSingleSessionOnRead\` (called from \`GET /v1/client\`). Configurable per-env via \`Environment.user_settings.sessions.{multi_session, max_concurrent_sessions_per_client}\`.
- Token-mint endpoint now refuses (and revokes) banned/locked users, applies a per-session 3 / 30s rate limit with \`Retry-After\`, and debounce-bumps \`User.last_active_at\`.

## Test plan
- [x] \`php artisan test\` — 203/203 (8 new sessions assertions across 8 cases)
- [x] LifecycleTest covers touch debounce, end → 401 on token mint, remove → 401 on token mint, rate limit + Retry-After, banned-user revoke.
- [x] MultiSessionTest covers single-session eviction, cap=2 LRU eviction, lazy collapse on read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)