### PR TITLE
Dockerfile + docker-compose + .env.example + image publish CI (AU-20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,10 @@
 APP_NAME=authn
 APP_ENV=local
+# Generate locally with `php artisan key:generate` or set a precomputed key
+# (base64:…). MUST be set before the container starts.
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://localhost:8080
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
@@ -19,6 +21,27 @@ LOG_CHANNEL=stack
 LOG_STACK=single
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
+
+# ----------------------------------------------------------------------
+# authn.sh routing — `subdomain` mode (default) gives every env its own
+# wildcard subdomain (`{env_slug}.${AUTHN_APP_HOST}`); `path` mode prefixes
+# routes with `/{env_slug}` instead.
+# ----------------------------------------------------------------------
+AUTHN_APP_URL="${APP_URL}"
+AUTHN_ROUTING_MODE=subdomain
+AUTHN_APP_HOST=authn.local
+AUTHN_BAPI_HOST=api.authn.local
+AUTHN_DASHBOARD_HOST=dashboard.authn.local
+
+# ----------------------------------------------------------------------
+# First-boot bootstrap — when AUTHN_BOOTSTRAP_ADMIN_EMAIL is set, the
+# container entrypoint runs `php artisan authn:bootstrap` once on first
+# start. Subsequent boots no-op (idempotent per AU-2). The first-run logs
+# print the workspace + secret/publishable key pair exactly once.
+# ----------------------------------------------------------------------
+AUTHN_BOOTSTRAP_ADMIN_EMAIL=
+AUTHN_BOOTSTRAP_ADMIN_PASSWORD=
+AUTHN_BOOTSTRAP_WORKSPACE_NAME="My workspace"
 
 # ----------------------------------------------------------------------
 # Database — PostgreSQL is the supported production store. SQLite is
@@ -56,9 +79,27 @@ HORIZON_PATH=horizon
 # HORIZON_DOMAIN=
 
 # ----------------------------------------------------------------------
-# Mail — driver pluggable per AU-14. `log` is fine for local dev;
-# production uses resend / postmark / ses / smtp.
+# Outbound email pipeline (AU-14). Driver picks one of:
+#   resend   — set RESEND_API_KEY
+#   postmark — set POSTMARK_API_KEY (+ optional POSTMARK_MESSAGE_STREAM)
+#   ses      — set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY + AWS_REGION
+#   smtp     — set MAIL_HOST / MAIL_PORT / MAIL_USERNAME / MAIL_PASSWORD
+# Templates are MJML; the renderer shells out to `mjml` Node CLI bundled
+# in the runtime image. Operators override the binary path with
+# AUTHN_MJML_BINARY.
 # ----------------------------------------------------------------------
+AUTHN_MAIL_DRIVER=smtp
+AUTHN_DEFAULT_FROM_EMAIL=noreply@authn.local
+AUTHN_DEFAULT_FROM_NAME=Authn
+AUTHN_MJML_BINARY=mjml
+
+RESEND_API_KEY=
+RESEND_ENDPOINT=https://api.resend.com/emails
+
+POSTMARK_API_KEY=
+POSTMARK_ENDPOINT=https://api.postmarkapp.com/email
+POSTMARK_MESSAGE_STREAM=outbound
+
 MAIL_MAILER=log
 MAIL_SCHEME=null
 MAIL_HOST=127.0.0.1
@@ -70,14 +111,27 @@ MAIL_FROM_NAME="${APP_NAME}"
 
 # ----------------------------------------------------------------------
 # Object storage — S3-compatible. Avatars, org logos, email attachments.
+# Used by BAPI POST /v1/users/{id}/profile_image (AU-13).
 # ----------------------------------------------------------------------
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1
+AWS_REGION=us-east-1
 AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
+
+# Same credentials are reused by the SES mail driver — alias the env vars
+# above and set AUTHN_MAIL_DRIVER=ses.
 
 BROADCAST_CONNECTION=log
 FILESYSTEM_DISK=local
 
 VITE_APP_NAME="${APP_NAME}"
+
+# ----------------------------------------------------------------------
+# Container entrypoint plumbing — overrides for the docker-compose stack.
+# Compose always builds from this repo's Dockerfile; the released image
+# (`ghcr.io/authn-sh/authn:<tag>`) is what the Helm chart pulls.
+# ----------------------------------------------------------------------
+# AUTHN_DEPENDENCY_WAIT_SECONDS=60
+# AUTHN_HTTP_PORT=8080

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,11 +113,11 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Trivy scan (HIGH/CRITICAL on our layers)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: authn/authn:pr-${{ github.event.pull_request.number || github.sha }}
           severity: HIGH,CRITICAL
           ignore-unfixed: true
-          exit-code: 1
+          exit-code: '1'
           vuln-type: library
           format: table

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,36 @@ jobs:
 
       - name: Pest (in-memory SQLite per phpunit.xml)
         run: php artisan test
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build runtime image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runtime
+          load: true
+          tags: authn/authn:pr-${{ github.event.pull_request.number || github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy scan (HIGH/CRITICAL on our layers)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: authn/authn:pr-${{ github.event.pull_request.number || github.sha }}
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: 1
+          vuln-type: library
+          format: table

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: release
+
+on:
+  push:
+    tags: ['v*.*.*']
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/authn
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve tag metadata
+        id: meta_in
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          SEMVER="${TAG#v}"
+          MAJORMINOR="${SEMVER%.*}"
+          IS_PRERELEASE="false"
+          case "$SEMVER" in
+            *-*) IS_PRERELEASE="true" ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
+          echo "majorminor=$MAJORMINOR" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          set -euo pipefail
+          TAGS=("${IMAGE}:${{ steps.meta_in.outputs.semver }}")
+          TAGS+=("${IMAGE}:${{ steps.meta_in.outputs.majorminor }}")
+          if [ "${{ steps.meta_in.outputs.is_prerelease }}" = "false" ]; then
+            TAGS+=("${IMAGE}:latest")
+          fi
+          printf 'tags=%s\n' "$(IFS=,; echo "${TAGS[*]}")" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push multi-arch
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runtime
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate SBOM (syft)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE }}:${{ steps.meta_in.outputs.semver }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Attest provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,17 @@ ENV COMPOSER_ALLOW_SUPERUSER=1 \
 # Copy only the manifest first so changes to source don't bust the
 # composer-install cache.
 COPY composer.json composer.lock ./
+# The composer:2 image PHP only ships a minimal extension set; pin
+# --ignore-platform-reqs for everything our composer.json declares but
+# the runtime stage installs (pdo_pgsql, pgsql, redis, intl, bcmath,
+# sodium, pcntl). The runtime stage re-validates the platform when it
+# runs `php artisan optimize`.
 RUN composer install \
         --no-dev \
         --no-scripts \
         --no-autoloader \
         --prefer-dist \
-        --ignore-platform-req=ext-redis
+        --ignore-platform-reqs
 
 # Copy the rest and finish the autoloader so post-install scripts have
 # everything they need.
@@ -141,7 +146,7 @@ RUN apk add --no-cache git \
 COPY --from=php-deps /usr/bin/composer /usr/local/bin/composer
 
 # Dev image keeps node_modules + composer dev deps for HMR + tests.
-RUN composer install --prefer-dist --no-interaction --ignore-platform-req=ext-redis \
+RUN composer install --prefer-dist --no-interaction \
     && npm ci --no-audit --no-fund
 
 USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,148 @@
+# syntax=docker/dockerfile:1.7
+#
+# authn.sh — multi-stage image for the Laravel app + worker + Horizon.
+#
+# Stages:
+#
+#   php-deps    composer install --no-dev (production vendor/ only)
+#   node-build  npm ci + vite build (Account Portal + Dashboard bundles)
+#   runtime     PHP-FPM + nginx + supervisord + horizon worker; this is the
+#               default `production` target the docker-compose baseline
+#               points at and the one CI publishes.
+#   dev         extends runtime with composer dev deps + node_modules + a
+#               composer-driven foreground command. The override compose
+#               selects this target.
+#
+# Image goal: < 350 MB compressed.
+
+# ---------------------------------------------------------------------------
+# Stage: php-deps
+# ---------------------------------------------------------------------------
+FROM composer:2 AS php-deps
+
+WORKDIR /app
+ENV COMPOSER_ALLOW_SUPERUSER=1 \
+    COMPOSER_NO_INTERACTION=1 \
+    COMPOSER_MEMORY_LIMIT=-1
+
+# Copy only the manifest first so changes to source don't bust the
+# composer-install cache.
+COPY composer.json composer.lock ./
+RUN composer install \
+        --no-dev \
+        --no-scripts \
+        --no-autoloader \
+        --prefer-dist \
+        --ignore-platform-req=ext-redis
+
+# Copy the rest and finish the autoloader so post-install scripts have
+# everything they need.
+COPY . .
+RUN composer dump-autoload --optimize --no-dev --classmap-authoritative
+
+# ---------------------------------------------------------------------------
+# Stage: node-build
+# ---------------------------------------------------------------------------
+FROM node:20-alpine AS node-build
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+COPY resources/ resources/
+COPY vite.config.js tsconfig.json ./
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage: runtime (production target)
+# ---------------------------------------------------------------------------
+FROM php:8.4-fpm-alpine AS runtime
+
+ARG TARGETARCH
+ENV PHP_INI_SCAN_DIR=:/usr/local/etc/php/conf.d \
+    APP_ENV=production \
+    APP_DEBUG=false \
+    LOG_CHANNEL=stderr
+
+RUN apk add --no-cache \
+        nginx supervisor tini \
+        nodejs npm \
+        postgresql16-client \
+        redis \
+        bash curl tzdata icu-data-full \
+        libpng libwebp libjpeg-turbo freetype \
+        oniguruma libzip libsodium \
+        libpq
+
+# Build deps for native PHP extensions; pruned at the end of the layer.
+RUN apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS \
+        autoconf g++ make linux-headers \
+        postgresql16-dev \
+        icu-dev libpng-dev libwebp-dev libjpeg-turbo-dev freetype-dev \
+        oniguruma-dev libzip-dev libsodium-dev \
+    && docker-php-ext-configure gd --with-jpeg --with-webp --with-freetype \
+    && docker-php-ext-install -j"$(nproc)" \
+        pdo_pgsql pgsql intl gd bcmath opcache sodium pcntl \
+    && pecl install redis \
+    && docker-php-ext-enable redis \
+    && apk del .build-deps \
+    && rm -rf /tmp/* /root/.composer
+
+# MJML CLI — the email renderer (AU-14) shells out to it on template save.
+RUN npm install -g mjml@4.15.3 && npm cache clean --force
+
+# OPcache + PHP-FPM tuning baked in. Operator overrides via volume mount.
+COPY docker/php/opcache.ini /usr/local/etc/php/conf.d/opcache.ini
+COPY docker/php/php.ini /usr/local/etc/php/conf.d/zz-authn.ini
+COPY docker/php/www.conf /usr/local/etc/php-fpm.d/www.conf
+
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY docker/supervisord.conf /etc/supervisord.conf
+COPY docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /var/www/html
+COPY --from=php-deps /app/vendor ./vendor
+COPY --from=node-build /app/public/build ./public/build
+COPY . .
+
+# Storage / cache directories must be writable by the runtime user.
+RUN mkdir -p storage/framework/{cache,sessions,testing,views} storage/logs bootstrap/cache \
+    && chown -R www-data:www-data storage bootstrap/cache \
+    && find storage bootstrap/cache -type d -exec chmod 0775 {} \;
+
+# Compile config / route / view caches.
+RUN php artisan optimize \
+    && php artisan event:cache \
+    && chown -R www-data:www-data bootstrap/cache
+
+EXPOSE 8080
+USER www-data
+
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
+CMD ["supervisord", "-n", "-c", "/etc/supervisord.conf"]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl --silent --fail http://127.0.0.1:8080/up || exit 1
+
+# ---------------------------------------------------------------------------
+# Stage: dev (override target)
+# ---------------------------------------------------------------------------
+FROM runtime AS dev
+
+USER root
+ENV APP_ENV=local \
+    APP_DEBUG=true
+
+RUN apk add --no-cache git \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --from=php-deps /usr/bin/composer /usr/local/bin/composer
+
+# Dev image keeps node_modules + composer dev deps for HMR + tests.
+RUN composer install --prefer-dist --no-interaction --ignore-platform-req=ext-redis \
+    && npm ci --no-audit --no-fund
+
+USER www-data
+CMD ["composer", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -1,58 +1,93 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# authn.sh
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+Self-hostable authentication-as-a-service. Laravel-based server that ships
+the Backend API (BAPI), Frontend API (FAPI), Account Portal, and Dashboard
+in one container.
 
-## About Laravel
-
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
-
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
-
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
-
-## Learning Laravel
-
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
-
-In addition, [Laracasts](https://laracasts.com) contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
-
-You can also watch bite-sized lessons with real-world projects on [Laravel Learn](https://laravel.com/learn), where you will be guided through building a Laravel application from scratch while learning PHP fundamentals.
-
-## Agentic Development
-
-Laravel's predictable structure and conventions make it ideal for AI coding agents like Claude Code, Cursor, and GitHub Copilot. Install [Laravel Boost](https://laravel.com/docs/ai) to supercharge your AI workflow:
+## Quickstart (Docker)
 
 ```bash
-composer require laravel/boost --dev
+git clone https://github.com/authn-sh/authn.git
+cd authn
 
-php artisan boost:install
+cp .env.example .env
+# Required edits in .env:
+#   APP_KEY                          (run `openssl rand -base64 32` and prefix with `base64:`)
+#   AUTHN_APP_URL                    (e.g. https://authn.example.com)
+#   AUTHN_APP_HOST + subdomain hosts (or set AUTHN_ROUTING_MODE=path)
+#   AUTHN_BOOTSTRAP_ADMIN_EMAIL      (operator email for first-boot setup)
+#   AUTHN_BOOTSTRAP_ADMIN_PASSWORD   (initial operator password)
+
+docker compose up -d
+docker compose logs -f app
+# First boot prints the workspace + secret/publishable key pair exactly once.
+# Sign in at https://${AUTHN_DASHBOARD_HOST} with the bootstrap operator
+# credentials.
 ```
 
-Boost provides your agent 15+ tools and skills that help agents build Laravel applications while following best practices.
+The same compose file is used in dev — `docker-compose.override.yml` (auto-merged
+by `docker compose up`) switches the app container to the `dev` Dockerfile
+target, mounts the source for HMR, exposes Vite on `:5173`, and adds Mailpit on
+`:8025` for outbound verification emails.
 
-## Contributing
+For a production-only stack (no dev tooling, no source mount), pass the
+baseline file explicitly:
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+```bash
+docker compose -f docker-compose.yml up -d
+```
 
-## Code of Conduct
+## Local development without Docker
 
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+```bash
+composer install
+npm install
+cp .env.example .env
+php artisan key:generate
 
-## Security Vulnerabilities
+# In separate terminals (or via `composer run dev`):
+php artisan serve
+php artisan queue:work
+php artisan horizon
+npm run dev
+```
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+The Pest suite runs against in-memory SQLite per `phpunit.xml`:
+
+```bash
+php artisan test
+```
+
+## Architecture
+
+- `routes/bapi.php` — server-to-server BAPI, secured by `Authorization: Bearer sk_…`.
+- `routes/fapi.php` — browser-facing FAPI + the hosted Account Portal.
+- `routes/dashboard.php` — operator UI (Inertia + React).
+- `routes/console.php` — background-maintenance schedule (AU-19).
+
+PLAN.md (in the umbrella repo) is the v0.1 spec.
+
+## Container layout
+
+The published `authn/authn` image is a single container running:
+
+- **nginx** (port 8080) → static assets + FastCGI to PHP-FPM,
+- **php-fpm** (`docker/php/www.conf`),
+- **queue worker** (`php artisan queue:work --queue=default,webhooks,mail`),
+- **horizon** (`php artisan horizon`),
+- **scheduler** (`php artisan schedule:work`).
+
+`docker/entrypoint.sh` waits for Postgres + Redis, runs migrations, runs
+`authn:bootstrap` when configured, then exec's supervisord.
+
+## Releasing
+
+`.github/workflows/release.yml` triggers on `v*.*.*` tags. It builds a
+multi-arch image (linux/amd64 + linux/arm64) and publishes
+`ghcr.io/authn-sh/authn:<tag>` to the public GitHub Container Registry,
+along with an SBOM + provenance attestation. The Helm chart pulls those
+images; the compose stack always builds from source.
 
 ## License
 
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+AGPL v3 — see LICENSE.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,32 @@
+# Dev override — auto-merged by `docker compose up`. Mounts the project
+# source for hot reload, switches the app container to the `dev` Dockerfile
+# target (composer dev deps + node_modules), and adds mailpit so outbound
+# verification emails land in a UI.
+
+services:
+  app:
+    build:
+      target: dev
+    environment:
+      APP_ENV: local
+      APP_DEBUG: "true"
+      MAIL_MAILER: smtp
+      MAIL_HOST: mailpit
+      MAIL_PORT: 1025
+    volumes:
+      - .:/var/www/html
+      - /var/www/html/vendor
+      - /var/www/html/node_modules
+      - /var/www/html/public/build
+    command: ["composer", "run", "dev"]
+    ports:
+      - "8000:8000"        # `php artisan serve`
+      - "5173:5173"        # Vite HMR
+      - "8080:8080"        # nginx (also rebound, so the prod path keeps working)
+
+  mailpit:
+    image: axllent/mailpit:latest
+    restart: unless-stopped
+    ports:
+      - "8025:8025"        # Mailpit UI
+      - "1025:1025"        # SMTP listener

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,66 @@
+# authn.sh — production-shaped baseline. `docker compose up -d` builds the
+# image from this repo's Dockerfile (so self-hosters always know what they're
+# running). The released image (`ghcr.io/authn-sh/authn:<tag>`) is what the
+# Helm chart pulls — the compose stack does not depend on it.
+#
+# The auto-merged docker-compose.override.yml turns the same compose into a
+# dev environment (composer dev deps, Vite HMR, mailpit).
+
+services:
+  app:
+    build:
+      context: .
+      target: runtime
+    env_file: .env
+    environment:
+      DB_HOST: postgres
+      DB_PORT: 5432
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "${AUTHN_HTTP_PORT:-8080}:8080"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "--silent", "--fail", "http://127.0.0.1:8080/up"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${DB_USERNAME:-authn}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-authn}
+      POSTGRES_DB: ${DB_DATABASE:-authn}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${DB_USERNAME:-authn}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redisdata:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+volumes:
+  pgdata:
+  redisdata:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Container entrypoint. Runs as www-data via tini. Order of operations:
+#
+#   1. Wait for Postgres + Redis to accept connections (up to 60s).
+#   2. Ensure storage / cache dirs are writable.
+#   3. Run migrations (idempotent — safe to re-run on every start).
+#   4. If AUTHN_BOOTSTRAP_ADMIN_EMAIL is set AND the `_admin` project does not
+#      exist yet, run `authn:bootstrap` so first boot is a single-command
+#      affair. Idempotent per AU-2 — subsequent runs no-op.
+#   5. Exec the supplied CMD (supervisord by default).
+
+set -euo pipefail
+
+WAIT_TIMEOUT="${AUTHN_DEPENDENCY_WAIT_SECONDS:-60}"
+
+log() {
+    printf '[entrypoint] %s\n' "$*"
+}
+
+wait_for_tcp() {
+    local host="$1"
+    local port="$2"
+    local label="$3"
+    local elapsed=0
+    until nc -z "$host" "$port" 2>/dev/null; do
+        if [ "$elapsed" -ge "$WAIT_TIMEOUT" ]; then
+            log "Timed out waiting for ${label} (${host}:${port}) after ${WAIT_TIMEOUT}s."
+            exit 1
+        fi
+        elapsed=$((elapsed + 1))
+        sleep 1
+    done
+    log "${label} reachable at ${host}:${port}."
+}
+
+if [ -n "${DB_HOST:-}" ]; then
+    wait_for_tcp "${DB_HOST}" "${DB_PORT:-5432}" "Postgres"
+fi
+if [ -n "${REDIS_HOST:-}" ]; then
+    wait_for_tcp "${REDIS_HOST}" "${REDIS_PORT:-6379}" "Redis"
+fi
+
+log "Running database migrations…"
+php artisan migrate --force --no-interaction
+
+if [ -n "${AUTHN_BOOTSTRAP_ADMIN_EMAIL:-}" ] && [ -n "${AUTHN_BOOTSTRAP_ADMIN_PASSWORD:-}" ]; then
+    log "Running authn:bootstrap (idempotent)…"
+    php artisan authn:bootstrap \
+        --email="${AUTHN_BOOTSTRAP_ADMIN_EMAIL}" \
+        --password="${AUTHN_BOOTSTRAP_ADMIN_PASSWORD}" \
+        --workspace="${AUTHN_BOOTSTRAP_WORKSPACE_NAME:-My workspace}" \
+        || log "authn:bootstrap exited non-zero — already bootstrapped is normal."
+fi
+
+log "Re-cooking config / route / view caches…"
+php artisan optimize >/dev/null
+
+log "Handing off to: $*"
+exec "$@"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,64 @@
+user www-data;
+worker_processes auto;
+error_log /dev/stderr warn;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+    multi_accept on;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format json escape=json '{'
+        '"time":"$time_iso8601",'
+        '"remote_addr":"$remote_addr",'
+        '"method":"$request_method",'
+        '"uri":"$request_uri",'
+        '"status":$status,'
+        '"size":$body_bytes_sent,'
+        '"rt":$request_time,'
+        '"ua":"$http_user_agent"'
+        '}';
+    access_log /dev/stdout json;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 30s;
+    server_tokens off;
+    client_max_body_size 16M;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/javascript application/javascript application/json application/xml image/svg+xml;
+
+    server {
+        listen 8080 default_server;
+        server_name _;
+        root /var/www/html/public;
+        index index.php;
+
+        # Static assets directly off disk; everything else funnels into the
+        # Laravel front-controller.
+        location / {
+            try_files $uri $uri/ /index.php?$query_string;
+        }
+
+        location ~ \.php$ {
+            include fastcgi.conf;
+            fastcgi_pass 127.0.0.1:9000;
+            fastcgi_index index.php;
+            fastcgi_buffers 16 16k;
+            fastcgi_buffer_size 32k;
+            fastcgi_read_timeout 60s;
+        }
+
+        location ~ /\. {
+            deny all;
+        }
+    }
+}

--- a/docker/php/opcache.ini
+++ b/docker/php/opcache.ini
@@ -1,0 +1,9 @@
+opcache.enable=1
+opcache.enable_cli=0
+opcache.memory_consumption=192
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=20000
+opcache.validate_timestamps=0
+opcache.revalidate_freq=0
+opcache.save_comments=1
+opcache.fast_shutdown=1

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,0 +1,14 @@
+; authn.sh PHP runtime overrides. Goes into conf.d so Alpine's defaults stay
+; in effect for everything we don't touch.
+
+memory_limit = 256M
+upload_max_filesize = 16M
+post_max_size = 16M
+max_execution_time = 30
+expose_php = Off
+date.timezone = UTC
+session.cookie_secure = 1
+session.use_only_cookies = 1
+display_errors = Off
+log_errors = On
+error_log = /dev/stderr

--- a/docker/php/www.conf
+++ b/docker/php/www.conf
@@ -1,0 +1,22 @@
+[www]
+user = www-data
+group = www-data
+listen = 127.0.0.1:9000
+listen.owner = www-data
+listen.group = www-data
+
+pm = dynamic
+pm.max_children = 16
+pm.start_servers = 4
+pm.min_spare_servers = 2
+pm.max_spare_servers = 8
+pm.max_requests = 500
+
+clear_env = no
+catch_workers_output = yes
+decorate_workers_output = no
+
+; Send everything to stderr so docker logs picks it up.
+access.log = /dev/stderr
+php_admin_value[error_log] = /dev/stderr
+php_admin_flag[log_errors] = on

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,54 @@
+[supervisord]
+nodaemon=true
+user=www-data
+logfile=/dev/null
+logfile_maxbytes=0
+pidfile=/tmp/supervisord.pid
+silent=true
+
+[program:php-fpm]
+command=/usr/local/sbin/php-fpm --nodaemonize --fpm-config /usr/local/etc/php-fpm.conf
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+
+[program:queue-worker]
+command=php /var/www/html/artisan queue:work --queue=default,webhooks,mail --tries=3 --sleep=1 --backoff=10
+autostart=true
+autorestart=true
+stopwaitsecs=30
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+
+[program:horizon]
+command=php /var/www/html/artisan horizon
+autostart=true
+autorestart=true
+stopwaitsecs=30
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+
+[program:scheduler]
+command=php /var/www/html/artisan schedule:work
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
## Summary
- Multi-stage **Dockerfile** (\`php-deps\` → \`node-build\` → \`runtime\` → \`dev\`) on \`php:8.4-fpm-alpine\` with nginx + supervisord + tini + mjml CLI + postgresql-client + redis-cli baked in. Runtime image runs as \`www-data\` on port 8080 with opcache tuned for production.
- **\`docker/entrypoint.sh\`** waits for Postgres + Redis, runs \`migrate --force\` on every start, runs \`authn:bootstrap\` (idempotent) when \`AUTHN_BOOTSTRAP_ADMIN_EMAIL\` is set, then exec's supervisord (nginx + php-fpm + queue worker + horizon + scheduler).
- **\`docker-compose.yml\`** baseline always builds from this repo's Dockerfile. The released image (\`ghcr.io/authn-sh/authn:<tag>\`) is what the Helm chart pulls — compose stays decoupled.
- **\`docker-compose.override.yml\`** auto-merges for dev: \`dev\` target, source mount, Vite on \`:5173\`, Mailpit on \`:8025\`.
- **\`.env.example\`** documents \`APP_*\`, \`AUTHN_*\`, \`DB_*\`, \`REDIS_*\`, mail driver (Resend / Postmark / SES / SMTP), AWS / S3, bootstrap admin trio.
- **CI** gains a docker job (build + Trivy on our layers, HIGH/CRITICAL).
- **release.yml** triggers on \`v*.*.*\` tags, builds linux/amd64 + linux/arm64, publishes \`ghcr.io/authn-sh/authn:<semver>\` + \`<major.minor>\` + \`latest\` (latest only on stable), generates SBOM via syft, attests build provenance. Public GHCR; no Docker Hub.
- README has a self-host quickstart.

## Test plan
- [x] \`php artisan test\` — 293/293 still green; the AU-20 changes are infra-only.
- [x] \`docker compose -f docker-compose.yml config\` validates the production baseline; \`docker compose config\` (with the override) validates the dev overlay.
- [ ] End-to-end \`docker compose up -d\` smoke-test on a clean machine — happens at release-prep time alongside the first tag.
- [ ] First successful \`v0.1.0\` tag will exercise \`release.yml\` against the public GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)