### PR TITLE
Rename dev compose layer; gitignore override; add Makefile (#59)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@
 /storage/*.key
 /storage/pail
 /vendor
+docker-compose.override.yml
+docker-compose.override.yaml
 _ide_helper.php
 Homestead.json
 Homestead.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -154,9 +154,12 @@ RUN apk add --no-cache git \
 
 COPY --from=php-deps /usr/bin/composer /usr/local/bin/composer
 
-# Dev image keeps node_modules + composer dev deps for HMR + tests.
+# Dev image keeps composer dev deps + node_modules for in-container
+# tests / pint runs. The CMD is intentionally inherited from `runtime`
+# (supervisord → nginx + php-fpm) so `make dev` exercises the same
+# routing and FPM pool the released image uses; queue:work / schedule:work
+# / vite / mailpit live in their own compose services.
 RUN composer install --prefer-dist --no-interaction \
     && npm ci --no-audit --no-fund
 
 USER www-data
-CMD ["composer", "run", "dev"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+# authn.sh — convenience targets around the Docker compose stack.
+#
+#   make up         start the production-shaped stack
+#   make dev        start the dev stack (app + worker + scheduler + vite + mailpit)
+#   make down       stop everything; pass V=1 to drop volumes
+#   make logs [s=app]
+#   make sh   [s=app]     shell into a service
+#   make test             run the Pest suite inside the dev `app` container
+#   make pint             run pint --test
+#   make scale w=N        scale the worker service to N replicas
+#   make build            rebuild images
+#
+# Self-hosters can keep a local `docker-compose.override.yml` next to
+# this file — it's gitignored and compose auto-merges it.
+
+DC          ?= docker compose
+DC_PROD      = $(DC) -f docker-compose.yml
+DC_DEV       = $(DC) -f docker-compose.yml -f docker-compose.dev.yml
+SERVICE     ?= app
+
+.PHONY: up down dev logs sh shell test pint scale build ps restart help
+
+up:
+	$(DC_PROD) up -d --build
+
+dev:
+	$(DC_DEV) up -d --build
+
+down:
+ifeq ($(V),1)
+	$(DC_DEV) down -v
+else
+	$(DC_DEV) down
+endif
+
+logs:
+	$(DC_DEV) logs -f $(or $(s),$(SERVICE))
+
+sh shell:
+	$(DC_DEV) exec $(or $(s),$(SERVICE)) sh
+
+test:
+	$(DC_DEV) exec app php artisan test $(args)
+
+pint:
+	$(DC_DEV) exec app vendor/bin/pint --test
+
+scale:
+	@if [ -z "$(w)" ]; then echo "usage: make scale w=N"; exit 2; fi
+	$(DC_DEV) up -d --scale worker=$(w)
+
+build:
+	$(DC_DEV) build
+
+ps:
+	$(DC_DEV) ps
+
+restart:
+	$(DC_DEV) restart $(or $(s),$(SERVICE))
+
+help:
+	@awk '/^# / { print substr($$0, 3) }' $(MAKEFILE_LIST) | head -20

--- a/README.md
+++ b/README.md
@@ -18,43 +18,48 @@ cp .env.example .env
 #   AUTHN_BOOTSTRAP_ADMIN_EMAIL      (operator email for first-boot setup)
 #   AUTHN_BOOTSTRAP_ADMIN_PASSWORD   (initial operator password)
 
-docker compose up -d
+make up                  # production-shaped stack (app + worker + scheduler + postgres + redis)
 docker compose logs -f app
 # First boot prints the workspace + secret/publishable key pair exactly once.
 # Sign in at https://${AUTHN_DASHBOARD_HOST} with the bootstrap operator
 # credentials.
 ```
 
-The same compose file is used in dev — `docker-compose.override.yml` (auto-merged
-by `docker compose up`) switches the app container to the `dev` Dockerfile
-target, mounts the source for HMR, exposes Vite on `:5173`, and adds Mailpit on
-`:8025` for outbound verification emails.
-
-For a production-only stack (no dev tooling, no source mount), pass the
-baseline file explicitly:
+Workers scale independently from the web container:
 
 ```bash
-docker compose -f docker-compose.yml up -d
+docker compose up -d --scale worker=4
 ```
 
-## Local development without Docker
+### Local customisations
+
+`docker-compose.override.yml` is gitignored. Drop one in your checkout
+and Docker Compose auto-merges it on every command — handy for setting
+your own ports, mail driver, S3 endpoint, etc.
+
+## Dev workflow
+
+```bash
+make dev                 # app + worker + scheduler (dev image) + vite + mailpit
+make logs                # tail app
+make logs s=worker
+make sh                  # shell into app
+make test                # Pest suite inside the app container
+make scale w=3           # scale worker
+make down                # stop; add V=1 to drop volumes
+```
+
+`docker-compose.dev.yml` is the dev layer — same nginx + php-fpm stack
+the production image runs (no `php artisan serve`), with selective
+source bind-mounts for HMR. Vite runs in its own container against the
+shared source mount, exposes `:5173`. Mailpit captures outbound mail at
+`http://localhost:8025`.
+
+The Pest suite also runs without Docker against in-memory SQLite per
+`phpunit.xml`:
 
 ```bash
 composer install
-npm install
-cp .env.example .env
-php artisan key:generate
-
-# In separate terminals (or via `composer run dev`):
-php artisan serve
-php artisan queue:work
-php artisan horizon
-npm run dev
-```
-
-The Pest suite runs against in-memory SQLite per `phpunit.xml`:
-
-```bash
 php artisan test
 ```
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,12 @@
-# Dev override — auto-merged by `docker compose up`.
+# Dev compose layer — opt-in, NOT auto-merged. Use:
+#
+#   make dev                              # full dev stack (app + worker + scheduler + vite + mailpit)
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+#
+# Self-hosters who want their own overrides can drop a
+# `docker-compose.override.yml` next to this file (gitignored, so it's
+# safe to keep local). Compose auto-merges that file on every
+# `docker compose ...` call.
 #
 # Same shape as production (app + worker + scheduler all running nginx+fpm
 # resp. queue:work / schedule:work) but switched to the `dev` Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,12 @@
 # running). The released image (`ghcr.io/authn-sh/authn:<tag>`) is what the
 # Helm chart pulls — the compose stack does not depend on it.
 #
-# The auto-merged docker-compose.override.yml turns the same compose into a
-# dev environment (dev Dockerfile target + Vite + Mailpit).
+# Dev workflow lives in the opt-in `docker-compose.dev.yml` layer:
+#   make dev                                            # convenience
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# Self-hosters can drop a local `docker-compose.override.yml` (gitignored)
+# for their own customizations; compose auto-merges it.
 #
 # Three application services share one image:
 #

--- a/tests/Feature/Http/Dashboard/DashboardTest.php
+++ b/tests/Feature/Http/Dashboard/DashboardTest.php
@@ -62,6 +62,9 @@ function bootAdminEnv(): array
         'authn.app_host' => 'authn.local',
         'authn.bapi_host' => 'api.authn.local',
         'authn.dashboard_host' => 'dashboard.authn.local',
+        'authn.app_scheme' => 'http',
+        'authn.app_port_suffix' => '',
+        'app.url' => 'http://authn.local',
     ]);
     reloadDashboardRoutes();
 


### PR DESCRIPTION
Closes #59.

## Summary
- \`docker-compose.override.yml\` → \`docker-compose.dev.yml\` so the dev workflow is opt-in. Self-hosters can now drop a local \`docker-compose.override.yml\` (gitignored) which Docker Compose auto-merges on every command.
- New Makefile wraps the common compose calls (\`make dev\`, \`make up\`, \`make down\`, \`make logs\`, \`make sh\`, \`make test\`, \`make pint\`, \`make scale w=N\`, \`make build\`).
- README + base compose comments updated to point at the new commands.
- Drive-by: pin \`app.url\` + \`authn.app_port_suffix\` in \`DashboardTest::bootAdminEnv\` so the redirect-URL substring assertion is stable regardless of what \`APP_URL\` the host's \`.env\` carries (\`.env.example\` now ships with \`http://localhost:8080\` which surfaced the old test's hidden coupling).

## Test plan
- [x] \`php artisan test\` — 293/293 green.
- [x] \`docker compose -f docker-compose.yml config --services\` lists \`postgres\`, \`redis\`, \`app\`, \`worker\`, \`scheduler\`.
- [x] \`docker compose -f docker-compose.yml -f docker-compose.dev.yml config --services\` adds \`vite\` + \`mailpit\`.
- [x] \`make help\` prints the targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)