### PR TITLE
Browser smoke tests with Laravel Dusk (#63)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,11 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     env:
-      AUTHN_DEV_UID: "1000"
-      AUTHN_DEV_GID: "1000"
-      DB_USERNAME: authn
-      DB_PASSWORD: authn
-      DB_DATABASE: authn
+      APP_KEY: base64:dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3Q=
       AUTHN_BOOTSTRAP_ADMIN_EMAIL: op@example.com
       AUTHN_BOOTSTRAP_ADMIN_PASSWORD: super-secret-password
       AUTHN_BOOTSTRAP_WORKSPACE_NAME: Acme Inc
@@ -107,19 +103,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build dev + dusk stack
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          extensions: pdo_pgsql, redis, intl, bcmath, gd, sodium
+          coverage: none
+          tools: composer:v2
+
+      - run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Prepare .env
         run: |
           cp .env.example .env
-          sed -i 's/^APP_KEY=.*/APP_KEY=base64:dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3Q=/' .env
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.dusk.yml build app
+          sed -i "s|^APP_KEY=.*|APP_KEY=${APP_KEY}|" .env
 
-      - name: Start dev stack + selenium
+      - name: Boot stack
         run: docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.dusk.yml up -d
 
-      - name: Wait for app to come up
+      - name: Wait for app
         run: |
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:8080/up >/dev/null; then echo "app ready"; exit 0; fi
+          for i in $(seq 1 60); do
+            curl -sf http://localhost:8080/up >/dev/null && exit 0
             sleep 2
           done
           echo "app never came up"; exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,58 @@ jobs:
       - name: Pest (in-memory SQLite per phpunit.xml)
         run: php artisan test
 
+  dusk:
+    runs-on: ubuntu-latest
+    needs: test
+    env:
+      AUTHN_DEV_UID: "1000"
+      AUTHN_DEV_GID: "1000"
+      DB_USERNAME: authn
+      DB_PASSWORD: authn
+      DB_DATABASE: authn
+      AUTHN_BOOTSTRAP_ADMIN_EMAIL: op@example.com
+      AUTHN_BOOTSTRAP_ADMIN_PASSWORD: super-secret-password
+      AUTHN_BOOTSTRAP_WORKSPACE_NAME: Acme Inc
+      DUSK_OPERATOR_EMAIL: op@example.com
+      DUSK_OPERATOR_PASSWORD: super-secret-password
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build dev + dusk stack
+        run: |
+          cp .env.example .env
+          sed -i 's/^APP_KEY=.*/APP_KEY=base64:dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3Q=/' .env
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.dusk.yml build app
+
+      - name: Start dev stack + selenium
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.dusk.yml up -d
+
+      - name: Wait for app to come up
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/up >/dev/null; then echo "app ready"; exit 0; fi
+            sleep 2
+          done
+          echo "app never came up"; exit 1
+
+      - name: Run Dusk smoke suite
+        run: make dusk
+
+      - name: Upload Dusk artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dusk-artifacts
+          path: |
+            tests/Browser/screenshots
+            tests/Browser/console
+            tests/Browser/source
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.dusk.yml down -v
+
   docker:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,13 @@ jobs:
           done
           echo "app never came up"; exit 1
 
+      - name: Bootstrap operator
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.dusk.yml exec -T \
+            -e AUTHN_BOOTSTRAP_ADMIN_EMAIL=${DUSK_OPERATOR_EMAIL} \
+            -e AUTHN_BOOTSTRAP_ADMIN_PASSWORD=${DUSK_OPERATOR_PASSWORD} \
+            app php artisan authn:bootstrap
+
       - name: Run Dusk smoke suite
         run: make dusk
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN apk add --no-cache --virtual .build-deps \
         oniguruma-dev libzip-dev libsodium-dev \
     && docker-php-ext-configure gd --with-jpeg --with-webp --with-freetype \
     && docker-php-ext-install -j"$(nproc)" \
-        pdo_pgsql pgsql intl gd bcmath opcache sodium pcntl \
+        pdo_pgsql pgsql intl gd bcmath opcache sodium pcntl zip \
     && pecl install redis \
     && docker-php-ext-enable redis \
     && apk del .build-deps \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 #   make logs [s=app]
 #   make sh   [s=app]     shell into a service
 #   make test             run the Pest suite inside the dev `app` container
+#   make dusk             run the Dusk smoke suite against the running stack
 #   make pint             run pint --test
 #   make scale w=N        scale the worker service to N replicas
 #   make build            rebuild images
@@ -16,9 +17,10 @@
 DC          ?= docker compose
 DC_PROD      = $(DC) -f docker-compose.yml
 DC_DEV       = $(DC) -f docker-compose.yml -f docker-compose.dev.yml
+DC_DUSK      = $(DC) -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.dusk.yml
 SERVICE     ?= app
 
-.PHONY: up down dev logs sh shell test pint scale build ps restart help
+.PHONY: up down dev logs sh shell test dusk pint scale build ps restart help
 
 up:
 	$(DC_PROD) up -d --build
@@ -41,6 +43,39 @@ sh shell:
 
 test:
 	$(DC_DEV) exec app php artisan test $(args)
+
+# Boots Selenium and runs the browser smoke suite against the `make dev`
+# stack. Tests use unique data + clean up after themselves, so they run
+# against the live dev DB without disturbing the bootstrapped operator.
+#
+# Operator credentials default to op@example.com / super-secret-password;
+# override with `make dusk DUSK_OPERATOR_EMAIL=… DUSK_OPERATOR_PASSWORD=…`
+# (e.g. on a dev box that bootstrapped with custom creds). CI is expected
+# to bootstrap with the defaults before invoking this target.
+DUSK_OPERATOR_EMAIL    ?= op@example.com
+DUSK_OPERATOR_PASSWORD ?= super-secret-password
+
+dusk:
+	$(DC_DUSK) up -d --force-recreate app selenium
+	# Wait for Selenium WebDriver to be ready (up to ~20s).
+	@for i in $$(seq 1 20); do \
+		$(DC_DUSK) exec -T app curl -sf http://selenium:4444/wd/hub/status >/dev/null 2>&1 && break; \
+		sleep 1; \
+	done
+	# Switch the app to manifest mode (built assets, no Vite HMR) by
+	# clearing public/hot — Vite's dev server isn't reachable from the
+	# Selenium container, and Dusk doesn't need HMR anyway.
+	$(DC_DUSK) exec -T -u 0 app rm -f public/hot
+	$(DC_DUSK) exec -T \
+		-e AUTHN_BOOTSTRAP_ADMIN_EMAIL=$(DUSK_OPERATOR_EMAIL) \
+		-e AUTHN_BOOTSTRAP_ADMIN_PASSWORD=$(DUSK_OPERATOR_PASSWORD) \
+		app sh -c "php artisan migrate:fresh --force && php artisan authn:bootstrap"
+	$(DC_DUSK) exec -T \
+		-e DUSK_DRIVER_URL=http://selenium:4444/wd/hub \
+		-e DUSK_MAILPIT_URL=http://mailpit:8025 \
+		-e DUSK_OPERATOR_EMAIL=$(DUSK_OPERATOR_EMAIL) \
+		-e DUSK_OPERATOR_PASSWORD=$(DUSK_OPERATOR_PASSWORD) \
+		app php artisan dusk $(args)
 
 pint:
 	$(DC_DEV) exec app vendor/bin/pint --test

--- a/Makefile
+++ b/Makefile
@@ -44,38 +44,21 @@ sh shell:
 test:
 	$(DC_DEV) exec app php artisan test $(args)
 
-# Boots Selenium and runs the browser smoke suite against the `make dev`
-# stack. Tests use unique data + clean up after themselves, so they run
-# against the live dev DB without disturbing the bootstrapped operator.
-#
-# Operator credentials default to op@example.com / super-secret-password;
-# override with `make dusk DUSK_OPERATOR_EMAIL=… DUSK_OPERATOR_PASSWORD=…`
-# (e.g. on a dev box that bootstrapped with custom creds). CI is expected
-# to bootstrap with the defaults before invoking this target.
 DUSK_OPERATOR_EMAIL    ?= op@example.com
 DUSK_OPERATOR_PASSWORD ?= super-secret-password
 
 dusk:
-	$(DC_DUSK) up -d --force-recreate app selenium
-	# Wait for Selenium WebDriver to be ready (up to ~20s).
+	$(DC_DUSK) up -d selenium
 	@for i in $$(seq 1 20); do \
-		$(DC_DUSK) exec -T app curl -sf http://selenium:4444/wd/hub/status >/dev/null 2>&1 && break; \
+		curl -sf http://localhost:4444/wd/hub/status >/dev/null 2>&1 && break; \
 		sleep 1; \
 	done
-	# Switch the app to manifest mode (built assets, no Vite HMR) by
-	# clearing public/hot — Vite's dev server isn't reachable from the
-	# Selenium container, and Dusk doesn't need HMR anyway.
-	$(DC_DUSK) exec -T -u 0 app rm -f public/hot
-	$(DC_DUSK) exec -T \
-		-e AUTHN_BOOTSTRAP_ADMIN_EMAIL=$(DUSK_OPERATOR_EMAIL) \
-		-e AUTHN_BOOTSTRAP_ADMIN_PASSWORD=$(DUSK_OPERATOR_PASSWORD) \
-		app sh -c "php artisan migrate:fresh --force && php artisan authn:bootstrap"
-	$(DC_DUSK) exec -T \
-		-e DUSK_DRIVER_URL=http://selenium:4444/wd/hub \
-		-e DUSK_MAILPIT_URL=http://mailpit:8025 \
-		-e DUSK_OPERATOR_EMAIL=$(DUSK_OPERATOR_EMAIL) \
-		-e DUSK_OPERATOR_PASSWORD=$(DUSK_OPERATOR_PASSWORD) \
-		app php artisan dusk $(args)
+	DUSK_DRIVER_URL=http://localhost:4444/wd/hub \
+	DUSK_MAILPIT_URL=http://localhost:8025 \
+	DUSK_OPERATOR_EMAIL=$(DUSK_OPERATOR_EMAIL) \
+	DUSK_OPERATOR_PASSWORD=$(DUSK_OPERATOR_PASSWORD) \
+	APP_URL=http://localhost:8080 \
+	php artisan dusk $(args)
 
 pint:
 	$(DC_DEV) exec app vendor/bin/pint --test

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
+        "laravel/dusk": "^8.6",
         "laravel/pail": "^1.2.5",
         "laravel/pao": "^1.0.6",
         "laravel/pint": "^1.27",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6acd4e5faf976db89b3aae3de859139",
+    "content-hash": "a2fede2eb2be18f03bbfcd50755a7afe",
     "packages": [
         {
             "name": "brick/math",
@@ -7053,6 +7053,80 @@
             "time": "2026-04-29T18:32:34+00:00"
         },
         {
+            "name": "laravel/dusk",
+            "version": "v8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/dusk.git",
+                "reference": "e7fd48762c6a82ad2cd311db07587aa2a97ce143"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/dusk/zipball/e7fd48762c6a82ad2cd311db07587aa2a97ce143",
+                "reference": "e7fd48762c6a82ad2cd311db07587aa2a97ce143",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-zip": "*",
+                "guzzlehttp/guzzle": "^7.5",
+                "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1",
+                "php-webdriver/webdriver": "^1.15.2",
+                "symfony/console": "^6.2|^7.0|^8.0",
+                "symfony/finder": "^6.2|^7.0|^8.0",
+                "symfony/process": "^6.2|^7.0|^8.0",
+                "vlucas/phpdotenv": "^5.2"
+            },
+            "require-dev": {
+                "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench-core": "^8.19|^9.17|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.1|^11.0|^12.0.1",
+                "psy/psysh": "^0.11.12|^0.12",
+                "symfony/yaml": "^6.2|^7.0|^8.0"
+            },
+            "suggest": {
+                "ext-pcntl": "Used to gracefully terminate Dusk when tests are running."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Dusk\\DuskServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Dusk\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Dusk provides simple end-to-end testing and browser automation.",
+            "keywords": [
+                "laravel",
+                "testing",
+                "webdriver"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/dusk/issues",
+                "source": "https://github.com/laravel/dusk/tree/v8.6.0"
+            },
+            "time": "2026-04-15T14:50:40+00:00"
+        },
+        {
             "name": "laravel/pail",
             "version": "v1.2.6",
             "source": {
@@ -8103,6 +8177,72 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-webdriver/webdriver",
+            "version": "1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-webdriver/php-webdriver.git",
+                "reference": "ac0662863aa120b4f645869f584013e4c4dba46a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/ac0662863aa120b4f645869f584013e4c4dba46a",
+                "reference": "ac0662863aa120b4f645869f584013e4c4dba46a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php": "^7.3 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.12",
+                "symfony/process": "^5.0 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "replace": {
+                "facebook/webdriver": "*"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.20.0",
+                "ondram/ci-detector": "^4.0",
+                "php-coveralls/php-coveralls": "^2.4",
+                "php-mock/php-mock-phpunit": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpunit/phpunit": "^9.3",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/var-dumper": "^5.0 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "ext-simplexml": "For Firefox profile creation"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Exception/TimeoutException.php"
+                ],
+                "psr-4": {
+                    "Facebook\\WebDriver\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP client for Selenium WebDriver. Previously facebook/webdriver.",
+            "homepage": "https://github.com/php-webdriver/php-webdriver",
+            "keywords": [
+                "Chromedriver",
+                "geckodriver",
+                "php",
+                "selenium",
+                "webdriver"
+            ],
+            "support": {
+                "issues": "https://github.com/php-webdriver/php-webdriver/issues",
+                "source": "https://github.com/php-webdriver/php-webdriver/tree/1.16.0"
+            },
+            "time": "2025-12-28T23:57:40+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/docker-compose.dusk.yml
+++ b/docker-compose.dusk.yml
@@ -1,42 +1,6 @@
-# Dusk-only compose layer. Stack with the dev layer:
-#
-#   docker compose -f docker-compose.yml -f docker-compose.dev.yml \
-#                  -f docker-compose.dusk.yml up -d selenium
-#
-# Or, easier, `make dusk` — that target boots Selenium, runs the suite,
-# and returns the exit code.
-#
-# Adds:
-#   - selenium/standalone-chromium (port 4444 webdriver, 7900 noVNC) so
-#     Dusk has a real browser to drive without needing Chromium installed
-#     on the host.
-#
-# The suite hits the same `authn` Postgres DB the dev stack uses. Each
-# test seeds unique data (`dusk-{nonce}@example.com`, project slug
-# `dusk-{nonce}`) and force-deletes its rows on teardown, so re-runs stay
-# idempotent and the bootstrapped operator state is untouched.
-
 services:
   selenium:
     image: selenium/standalone-chromium:latest
     shm_size: '2gb'
-    ports:
-      - "4444:4444"
-      - "7900:7900"   # noVNC viewer (http://localhost:7900, password "secret")
+    network_mode: host
     restart: unless-stopped
-
-  # The Dusk run reaches the app via `http://authn.test:8080`. We alias
-  # the app container so the hostname has a dot — Chrome auto-upgrades
-  # single-label names like `app` to https via HttpsUpgrades, and the dev
-  # server speaks plaintext. The publishable key baked into the
-  # bootstrapped `_admin` encodes `authn.test:8080`, so the host browser
-  # at `http://localhost:8080` won't be able to use it after a Dusk run —
-  # re-bootstrap with `make dev` env to recover.
-  app:
-    environment:
-      APP_URL: http://authn.test:8080
-      AUTHN_APP_URL: http://authn.test:8080
-    networks:
-      default:
-        aliases:
-          - authn.test

--- a/docker-compose.dusk.yml
+++ b/docker-compose.dusk.yml
@@ -1,0 +1,42 @@
+# Dusk-only compose layer. Stack with the dev layer:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+#                  -f docker-compose.dusk.yml up -d selenium
+#
+# Or, easier, `make dusk` — that target boots Selenium, runs the suite,
+# and returns the exit code.
+#
+# Adds:
+#   - selenium/standalone-chromium (port 4444 webdriver, 7900 noVNC) so
+#     Dusk has a real browser to drive without needing Chromium installed
+#     on the host.
+#
+# The suite hits the same `authn` Postgres DB the dev stack uses. Each
+# test seeds unique data (`dusk-{nonce}@example.com`, project slug
+# `dusk-{nonce}`) and force-deletes its rows on teardown, so re-runs stay
+# idempotent and the bootstrapped operator state is untouched.
+
+services:
+  selenium:
+    image: selenium/standalone-chromium:latest
+    shm_size: '2gb'
+    ports:
+      - "4444:4444"
+      - "7900:7900"   # noVNC viewer (http://localhost:7900, password "secret")
+    restart: unless-stopped
+
+  # The Dusk run reaches the app via `http://authn.test:8080`. We alias
+  # the app container so the hostname has a dot — Chrome auto-upgrades
+  # single-label names like `app` to https via HttpsUpgrades, and the dev
+  # server speaks plaintext. The publishable key baked into the
+  # bootstrapped `_admin` encodes `authn.test:8080`, so the host browser
+  # at `http://localhost:8080` won't be able to use it after a Dusk run —
+  # re-bootstrap with `make dev` env to recover.
+  app:
+    environment:
+      APP_URL: http://authn.test:8080
+      AUTHN_APP_URL: http://authn.test:8080
+    networks:
+      default:
+        aliases:
+          - authn.test

--- a/resources/js/dashboard/pages/CreateProject.tsx
+++ b/resources/js/dashboard/pages/CreateProject.tsx
@@ -17,6 +17,7 @@ export default function CreateProject() {
                 <label style={{ display: 'block', marginBottom: 12 }}>
                     Name
                     <input
+                        name="name"
                         value={form.data.name}
                         onChange={(e) => form.setData('name', e.target.value)}
                         style={{ display: 'block', width: '100%', padding: 8, marginTop: 4 }}
@@ -26,6 +27,7 @@ export default function CreateProject() {
                 <label style={{ display: 'block', marginBottom: 12 }}>
                     Slug
                     <input
+                        name="slug"
                         value={form.data.slug}
                         onChange={(e) => form.setData('slug', e.target.value)}
                         style={{ display: 'block', width: '100%', padding: 8, marginTop: 4 }}

--- a/tests/Browser/CreateProjectFlowTest.php
+++ b/tests/Browser/CreateProjectFlowTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Browser;
+
+use App\Models\Project;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+/**
+ * Smoke test: an authed operator visits /dashboard/create-project, fills
+ * a name + slug, submits, and lands on /dashboard/{slug}/production/overview.
+ * The sidebar nav must show absolute paths under `/dashboard/...` — the
+ * regression that motivated this test was the form posting to
+ * `/create-project` (no prefix) and the sidebar links pointing at
+ * `/{slug}/production/...` instead of `/dashboard/{slug}/production/...`.
+ */
+final class CreateProjectFlowTest extends DuskTestCase
+{
+    public function test_operator_creates_a_project_and_lands_on_its_overview(): void
+    {
+        $slug = 'dusk-'.bin2hex(random_bytes(3));
+        $email = (string) (env('DUSK_OPERATOR_EMAIL') ?: 'op@example.com');
+        $password = (string) (env('DUSK_OPERATOR_PASSWORD') ?: 'super-secret-password');
+
+        $this->browse(function (Browser $browser) use ($slug, $email, $password): void {
+            $browser->visit('/sign-in')
+                ->waitFor('[data-testid="authn-signin"]', 10)
+                ->waitFor('#authn-signin-identifier', 5)
+                ->typeSlowly('#authn-signin-identifier', $email, 20)
+                ->click('[data-testid="authn-signin"] button[type=submit]')
+                ->waitFor('input[type=password]', 10)
+                ->typeSlowly('input[type=password]', $password, 20)
+                ->click('[data-testid="authn-signin-factor-one"] button[type=submit]')
+                ->waitUntil("window.location.pathname.startsWith('/dashboard')", 10)
+                ->visit('/dashboard/create-project')
+                ->waitFor('input[name="name"]', 5)
+                ->type('name', 'Dusk Inc')
+                ->type('slug', $slug)
+                ->press('Create project')
+                ->waitUntil("window.location.pathname === '/dashboard/{$slug}/production/overview'", 10)
+                ->assertAttribute("a[href='/dashboard/{$slug}/production/users']", 'href', "/dashboard/{$slug}/production/users");
+        });
+
+        Project::query()->withoutGlobalScopes()->where('slug', $slug)->each(function (Project $p): void {
+            $p->environments()->delete();
+            $p->forceDelete();
+        });
+    }
+}

--- a/tests/Browser/CreateProjectFlowTest.php
+++ b/tests/Browser/CreateProjectFlowTest.php
@@ -4,18 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Browser;
 
-use App\Models\Project;
 use Laravel\Dusk\Browser;
 use Tests\DuskTestCase;
 
-/**
- * Smoke test: an authed operator visits /dashboard/create-project, fills
- * a name + slug, submits, and lands on /dashboard/{slug}/production/overview.
- * The sidebar nav must show absolute paths under `/dashboard/...` — the
- * regression that motivated this test was the form posting to
- * `/create-project` (no prefix) and the sidebar links pointing at
- * `/{slug}/production/...` instead of `/dashboard/{slug}/production/...`.
- */
 final class CreateProjectFlowTest extends DuskTestCase
 {
     public function test_operator_creates_a_project_and_lands_on_its_overview(): void
@@ -41,11 +32,6 @@ final class CreateProjectFlowTest extends DuskTestCase
                 ->press('Create project')
                 ->waitUntil("window.location.pathname === '/dashboard/{$slug}/production/overview'", 10)
                 ->assertAttribute("a[href='/dashboard/{$slug}/production/users']", 'href', "/dashboard/{$slug}/production/users");
-        });
-
-        Project::query()->withoutGlobalScopes()->where('slug', $slug)->each(function (Project $p): void {
-            $p->environments()->delete();
-            $p->forceDelete();
         });
     }
 }

--- a/tests/Browser/Pages/Page.php
+++ b/tests/Browser/Pages/Page.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use Laravel\Dusk\Page as BasePage;
+
+abstract class Page extends BasePage
+{
+    /**
+     * Get the global element shortcuts for the site.
+     *
+     * @return array<string, string>
+     */
+    public static function siteElements(): array
+    {
+        return [
+            '@element' => '#selector',
+        ];
+    }
+}

--- a/tests/Browser/SignInFlowTest.php
+++ b/tests/Browser/SignInFlowTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Browser;
+
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+/**
+ * Smoke test: sign in as the bootstrapped operator, verify the dashboard
+ * loads, click the user avatar, sign out, end up back on /sign-in.
+ *
+ * Catches the "Inertia tried to resolve AccountPortal/SignIn inside the
+ * Dashboard app" regression and the "no __session cookie set on sign-in"
+ * regression — both of which broke this exact flow during AU-15.
+ */
+final class SignInFlowTest extends DuskTestCase
+{
+    public function test_operator_can_sign_in_and_sign_out(): void
+    {
+        $email = (string) (env('DUSK_OPERATOR_EMAIL') ?: 'op@example.com');
+        $password = (string) (env('DUSK_OPERATOR_PASSWORD') ?: 'super-secret-password');
+
+        $this->browse(function (Browser $browser) use ($email, $password): void {
+            $browser->visit('/sign-in')
+                ->waitFor('[data-testid="authn-signin"]', 10)
+                ->waitFor('#authn-signin-identifier', 5)
+                ->pause(500)
+                ->typeSlowly('#authn-signin-identifier', $email, 20)
+                ->pause(200)
+                ->assertInputValue('#authn-signin-identifier', $email)
+                ->click('[data-testid="authn-signin"] button[type=submit]')
+                ->waitFor('input[type=password]', 10)
+                ->typeSlowly('input[type=password]', $password, 20)
+                ->click('[data-testid="authn-signin-factor-one"] button[type=submit]')
+                ->waitUntil("window.location.pathname.startsWith('/dashboard')", 10)
+                ->waitFor('[data-testid="authn-userbutton-trigger"]', 10)
+                ->click('[data-testid="authn-userbutton-trigger"]')
+                ->waitFor('[data-testid="authn-userbutton-signout"]', 5)
+                ->click('[data-testid="authn-userbutton-signout"]')
+                ->waitUntil("window.location.pathname.startsWith('/sign-in')", 10)
+                ->assertPathBeginsWith('/sign-in');
+        });
+    }
+}

--- a/tests/Browser/SignUpFlowTest.php
+++ b/tests/Browser/SignUpFlowTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Browser;
+
+use App\Models\User;
+use Laravel\Dusk\Browser;
+use Tests\Browser\Support\Mailpit;
+use Tests\DuskTestCase;
+
+/**
+ * Smoke test: sign up a fresh user against the `_admin` env's Account
+ * Portal, click through the email-code verification step (code read from
+ * Mailpit), and end up on /dashboard/create-workspace because the new
+ * user has no organization yet.
+ *
+ * Each run uses a unique `dusk-{nonce}@example.com` so the test is
+ * idempotent against a long-lived Dusk database.
+ */
+final class SignUpFlowTest extends DuskTestCase
+{
+    public function test_new_visitor_signs_up_and_lands_on_create_workspace(): void
+    {
+        $email = 'dusk-'.bin2hex(random_bytes(4)).'@example.com';
+        $mailpit = Mailpit::default();
+        $mailpit->clear();
+
+        $this->browse(function (Browser $browser) use ($email, $mailpit): void {
+            $browser->visit('/sign-up')
+                ->waitFor('[data-testid="authn-signup"]', 10)
+                ->waitFor('#authn-signup-firstname', 5)
+                ->typeSlowly('#authn-signup-firstname', 'Dusk', 20)
+                ->typeSlowly('#authn-signup-lastname', 'Tester', 20)
+                ->typeSlowly('#authn-signup-email', $email, 20)
+                ->typeSlowly('#authn-signup-password', 'super-secret-password', 20)
+                ->click('[data-testid="authn-signup"] button[type=submit]')
+                ->waitFor('[data-testid="authn-signup-verify-email"]', 10);
+
+            $code = $mailpit->fetchVerificationCode($email, 10);
+
+            $browser->typeSlowly('[data-testid="authn-signup-verify-email"] input', $code, 20)
+                ->click('[data-testid="authn-signup-verify-email"] button[type=submit]')
+                ->waitUntil("window.location.pathname === '/dashboard/create-workspace'", 10)
+                ->assertPathIs('/dashboard/create-workspace');
+        });
+
+        // Force-delete so the table doesn't grow across runs.
+        User::query()
+            ->whereHas('emailAddresses', fn ($q) => $q->where('email_address', $email))
+            ->each(fn (User $u) => $u->forceDelete());
+    }
+}

--- a/tests/Browser/SignUpFlowTest.php
+++ b/tests/Browser/SignUpFlowTest.php
@@ -4,20 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Browser;
 
-use App\Models\User;
 use Laravel\Dusk\Browser;
 use Tests\Browser\Support\Mailpit;
 use Tests\DuskTestCase;
 
-/**
- * Smoke test: sign up a fresh user against the `_admin` env's Account
- * Portal, click through the email-code verification step (code read from
- * Mailpit), and end up on /dashboard/create-workspace because the new
- * user has no organization yet.
- *
- * Each run uses a unique `dusk-{nonce}@example.com` so the test is
- * idempotent against a long-lived Dusk database.
- */
 final class SignUpFlowTest extends DuskTestCase
 {
     public function test_new_visitor_signs_up_and_lands_on_create_workspace(): void
@@ -44,10 +34,5 @@ final class SignUpFlowTest extends DuskTestCase
                 ->waitUntil("window.location.pathname === '/dashboard/create-workspace'", 10)
                 ->assertPathIs('/dashboard/create-workspace');
         });
-
-        // Force-delete so the table doesn't grow across runs.
-        User::query()
-            ->whereHas('emailAddresses', fn ($q) => $q->where('email_address', $email))
-            ->each(fn (User $u) => $u->forceDelete());
     }
 }

--- a/tests/Browser/Support/Mailpit.php
+++ b/tests/Browser/Support/Mailpit.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Browser\Support;
+
+use RuntimeException;
+
+/**
+ * Tiny client for the Mailpit HTTP API. The dev compose stack runs Mailpit
+ * at http://mailpit:8025 (or http://localhost:8025 from the host). Dusk
+ * tests use it to read the verification code that authn just emailed,
+ * without depending on a real SMTP capture or a Laravel-side fake.
+ */
+final class Mailpit
+{
+    public function __construct(private readonly string $baseUrl) {}
+
+    public static function default(): self
+    {
+        return new self((string) (
+            $_ENV['DUSK_MAILPIT_URL']
+            ?? env('DUSK_MAILPIT_URL')
+            ?? 'http://mailpit:8025'
+        ));
+    }
+
+    public function clear(): void
+    {
+        $this->request('DELETE', '/api/v1/messages');
+    }
+
+    /**
+     * Poll for the most recent message addressed to `$recipient` and return
+     * its first 6-digit code. Retries up to ~5s to absorb queue latency.
+     */
+    public function fetchVerificationCode(string $recipient, int $timeoutSeconds = 5): string
+    {
+        $deadline = microtime(true) + $timeoutSeconds;
+        $lastBody = '';
+        while (microtime(true) < $deadline) {
+            $messages = $this->messagesTo($recipient);
+            if (! empty($messages)) {
+                $body = $this->body((string) $messages[0]['ID']);
+                $lastBody = $body;
+                if (preg_match('/\b(\d{6})\b/', $body, $m)) {
+                    return $m[1];
+                }
+            }
+            usleep(250_000);
+        }
+
+        throw new RuntimeException('No verification code found for '.$recipient.' within '.$timeoutSeconds.'s. Last body: '.substr($lastBody, 0, 200));
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function messagesTo(string $recipient): array
+    {
+        $payload = json_decode(
+            $this->request('GET', '/api/v1/messages?query='.rawurlencode('to:'.$recipient)),
+            true
+        );
+
+        return is_array($payload['messages'] ?? null) ? $payload['messages'] : [];
+    }
+
+    private function body(string $id): string
+    {
+        $payload = json_decode($this->request('GET', '/api/v1/message/'.$id), true);
+
+        return (string) ($payload['Text'] ?? $payload['HTML'] ?? '');
+    }
+
+    private function request(string $method, string $path): string
+    {
+        $ch = curl_init($this->baseUrl.$path);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CUSTOMREQUEST => $method,
+            CURLOPT_TIMEOUT => 5,
+        ]);
+        $body = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($body === false || $status >= 400) {
+            throw new RuntimeException("Mailpit {$method} {$path} → {$status}");
+        }
+
+        return (string) $body;
+    }
+}

--- a/tests/Browser/console/.gitignore
+++ b/tests/Browser/console/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Browser/screenshots/.gitignore
+++ b/tests/Browser/screenshots/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Browser/source/.gitignore
+++ b/tests/Browser/source/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests;
+
+use Facebook\WebDriver\Chrome\ChromeOptions;
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Laravel\Dusk\TestCase as BaseTestCase;
+
+abstract class DuskTestCase extends BaseTestCase
+{
+    /**
+     * Dusk runs against the live `make dev` stack at http://app:8080 (inside
+     * the compose network). The docker-compose.dusk.yml layer ships a
+     * `selenium/standalone-chromium` container; we point Dusk at it via
+     * DUSK_DRIVER_URL. ChromeDriver is owned by Selenium — we don't start
+     * one locally.
+     */
+    protected function driver(): RemoteWebDriver
+    {
+        $options = (new ChromeOptions)->addArguments([
+            '--window-size=1280,800',
+            '--disable-search-engine-choice-screen',
+            '--disable-smooth-scrolling',
+            '--no-sandbox',
+            '--disable-dev-shm-usage',
+            // Modern Chrome auto-upgrades single-label hostnames (e.g.
+            // `app`) to HTTPS via the HttpsUpgrades feature. The dev stack
+            // serves plaintext, so the upgrade trips ERR_SSL_PROTOCOL_ERROR.
+            // Disable both feature flags so http://app:8080 stays http.
+            '--disable-features=HttpsUpgrades,HttpsFirstBalancedMode,SingleLetterHostnameRedirect,HttpsFirstModeForTypicallySecureUsers,HttpsFirstModeIncognito',
+            '--ignore-certificate-errors',
+        ]);
+
+        return RemoteWebDriver::create(
+            $_ENV['DUSK_DRIVER_URL'] ?? env('DUSK_DRIVER_URL') ?? 'http://localhost:4444/wd/hub',
+            DesiredCapabilities::chrome()->setCapability(
+                ChromeOptions::CAPABILITY, $options
+            )
+        );
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,9 @@
 <?php
 
+pest()->extend(Tests\DuskTestCase::class)
+//  ->use(Illuminate\Foundation\Testing\DatabaseMigrations::class)
+    ->in('Browser');
+
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,11 +1,10 @@
 <?php
 
-pest()->extend(Tests\DuskTestCase::class)
-//  ->use(Illuminate\Foundation\Testing\DatabaseMigrations::class)
-    ->in('Browser');
-
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\DuskTestCase;
 use Tests\TestCase;
+
+pest()->extend(DuskTestCase::class)->in('Browser');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #63. Stands up three Dusk smoke tests covering the operator's critical paths — sign-in/out, sign-up + email verification, and create-project. Tests run against a live `make dev` stack inside a `selenium/standalone-chromium` container; `make dusk` is the entry point locally and a new `dusk` job runs the suite on every push in CI.

The tests target the regressions we kept catching by hand during AU-15:
- Inertia cross-app handoff between Account Portal and Dashboard.
- `__session` cookie on sign-in / sign-up completion.
- The Dashboard URL-prefix bug (sidebar links + form action).

## Test plan
- [x] `make dusk` passes locally (3/3 green).
- [ ] CI `dusk` job passes on the PR.
- [ ] Failure artifacts (screenshots / console / source) attach on red.