### PR TITLE
Models + migrations for v0.2 organization domain (AU-1)

### DIFF
--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -12,14 +13,17 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
- * Minimal v0.1 Organization shape. The full v0.2 surface (logos, public/
- * private metadata, members_count, max_allowed_memberships, …) lands when
- * AU-13 / v0.2 lights up the org features.
- *
  * @property string $id
  * @property string $environment_id
  * @property string $name
  * @property string $slug
+ * @property ?string $image_path
+ * @property int $members_count
+ * @property int $pending_invitations_count
+ * @property ?int $max_allowed_memberships
+ * @property bool $admin_delete_enabled
+ * @property array $public_metadata
+ * @property array $private_metadata
  * @property ?string $created_by_user_id
  */
 class Organization extends Model
@@ -33,8 +37,36 @@ class Organization extends Model
         'environment_id',
         'name',
         'slug',
+        'image_path',
+        'members_count',
+        'pending_invitations_count',
+        'max_allowed_memberships',
+        'admin_delete_enabled',
+        'public_metadata',
+        'private_metadata',
         'created_by_user_id',
     ];
+
+    protected $hidden = [
+        'private_metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'admin_delete_enabled' => 'boolean',
+            'members_count' => 'integer',
+            'pending_invitations_count' => 'integer',
+            'max_allowed_memberships' => 'integer',
+            'public_metadata' => 'array',
+            'private_metadata' => 'array',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
 
     public function environment(): BelongsTo
     {
@@ -49,12 +81,27 @@ class Organization extends Model
     public function members(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'organization_memberships')
-            ->withPivot(['id', 'role', 'created_at', 'updated_at']);
+            ->withPivot(['id', 'role', 'role_id', 'created_at', 'updated_at']);
     }
 
     public function memberships(): HasMany
     {
         return $this->hasMany(OrganizationMembership::class);
+    }
+
+    public function invitations(): HasMany
+    {
+        return $this->hasMany(OrganizationInvitation::class);
+    }
+
+    public function domains(): HasMany
+    {
+        return $this->hasMany(OrganizationDomain::class);
+    }
+
+    public function membershipRequests(): HasMany
+    {
+        return $this->hasMany(OrganizationMembershipRequest::class);
     }
 
     public function ownedProjects(): HasMany

--- a/app/Models/OrganizationDomain.php
+++ b/app/Models/OrganizationDomain.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $environment_id
+ * @property string $organization_id
+ * @property string $name
+ * @property bool $verified
+ * @property string $enrollment_mode
+ * @property ?string $verification_id
+ * @property ?string $affiliation_email_address
+ * @property int $total_pending_invitations
+ * @property int $total_pending_suggestions
+ */
+class OrganizationDomain extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    public const MODE_MANUAL_INVITATION = 'manual_invitation';
+
+    public const MODE_AUTOMATIC_INVITATION = 'automatic_invitation';
+
+    public const MODE_AUTOMATIC_SUGGESTION = 'automatic_suggestion';
+
+    public const ENROLLMENT_MODES = [
+        self::MODE_MANUAL_INVITATION,
+        self::MODE_AUTOMATIC_INVITATION,
+        self::MODE_AUTOMATIC_SUGGESTION,
+    ];
+
+    protected string $idPrefix = 'orgdom_';
+
+    protected $fillable = [
+        'environment_id',
+        'organization_id',
+        'name',
+        'verified',
+        'enrollment_mode',
+        'verification_id',
+        'affiliation_email_address',
+        'total_pending_invitations',
+        'total_pending_suggestions',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'verified' => 'boolean',
+            'total_pending_invitations' => 'integer',
+            'total_pending_suggestions' => 'integer',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function verification(): BelongsTo
+    {
+        return $this->belongsTo(Verification::class);
+    }
+}

--- a/app/Models/OrganizationInvitation.php
+++ b/app/Models/OrganizationInvitation.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $environment_id
+ * @property string $organization_id
+ * @property string $email_address
+ * @property string $role_id
+ * @property ?string $inviter_user_id
+ * @property ?string $redirect_url
+ * @property string $status
+ * @property array $public_metadata
+ * @property ?\DateTimeInterface $expires_at
+ * @property ?int $ticket_verification_code_id
+ */
+class OrganizationInvitation extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_ACCEPTED = 'accepted';
+
+    public const STATUS_REVOKED = 'revoked';
+
+    public const STATUS_EXPIRED = 'expired';
+
+    public const STATUSES = [
+        self::STATUS_PENDING,
+        self::STATUS_ACCEPTED,
+        self::STATUS_REVOKED,
+        self::STATUS_EXPIRED,
+    ];
+
+    protected string $idPrefix = 'orginv_';
+
+    protected $fillable = [
+        'environment_id',
+        'organization_id',
+        'email_address',
+        'role_id',
+        'inviter_user_id',
+        'redirect_url',
+        'status',
+        'public_metadata',
+        'expires_at',
+        'ticket_verification_code_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'public_metadata' => 'array',
+            'expires_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function role(): BelongsTo
+    {
+        return $this->belongsTo(Role::class, 'role_id');
+    }
+
+    public function inviter(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'inviter_user_id');
+    }
+
+    public function ticket(): BelongsTo
+    {
+        return $this->belongsTo(VerificationCode::class, 'ticket_verification_code_id');
+    }
+}

--- a/app/Models/OrganizationMembership.php
+++ b/app/Models/OrganizationMembership.php
@@ -14,7 +14,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $environment_id
  * @property string $organization_id
  * @property string $user_id
- * @property string $role
+ * @property ?string $role legacy v0.1 string slug; replaced by role_id in v0.2 (AU-2 backfills + drops)
+ * @property ?string $role_id
+ * @property array $public_metadata
+ * @property array $private_metadata
  */
 class OrganizationMembership extends Model
 {
@@ -50,7 +53,22 @@ class OrganizationMembership extends Model
         'organization_id',
         'user_id',
         'role',
+        'role_id',
+        'public_metadata',
+        'private_metadata',
     ];
+
+    protected $hidden = [
+        'private_metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'public_metadata' => 'array',
+            'private_metadata' => 'array',
+        ];
+    }
 
     public function organization(): BelongsTo
     {
@@ -60,5 +78,25 @@ class OrganizationMembership extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function roleRef(): BelongsTo
+    {
+        return $this->belongsTo(Role::class, 'role_id');
+    }
+
+    /**
+     * Permission keys granted by this membership's role. Returns an empty
+     * list when the membership predates the v0.2 role table (legacy `role`
+     * string only); AU-2's backfill populates `role_id` for those rows.
+     */
+    public function permissionKeys(): array
+    {
+        $role = $this->roleRef;
+        if ($role === null) {
+            return [];
+        }
+
+        return $role->permissions->pluck('key')->all();
     }
 }

--- a/app/Models/OrganizationMembershipRequest.php
+++ b/app/Models/OrganizationMembershipRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $environment_id
+ * @property string $organization_id
+ * @property string $user_id
+ * @property string $status
+ */
+class OrganizationMembershipRequest extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_ACCEPTED = 'accepted';
+
+    public const STATUS_REVOKED = 'revoked';
+
+    public const STATUS_EXPIRED = 'expired';
+
+    public const STATUSES = [
+        self::STATUS_PENDING,
+        self::STATUS_ACCEPTED,
+        self::STATUS_REVOKED,
+        self::STATUS_EXPIRED,
+    ];
+
+    protected string $idPrefix = 'orgreq_';
+
+    protected $table = 'organization_membership_requests';
+
+    protected $fillable = [
+        'environment_id',
+        'organization_id',
+        'user_id',
+        'status',
+    ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+/**
+ * @property string $id
+ * @property string $environment_id
+ * @property string $key
+ * @property string $name
+ * @property ?string $description
+ * @property bool $is_system
+ */
+class Permission extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    protected string $idPrefix = 'perm_';
+
+    protected $fillable = [
+        'environment_id',
+        'key',
+        'name',
+        'description',
+        'is_system',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_system' => 'boolean',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'role_permission');
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property string $id
+ * @property string $environment_id
+ * @property string $key
+ * @property string $name
+ * @property ?string $description
+ * @property bool $is_creator_eligible
+ * @property bool $is_default
+ * @property bool $is_system
+ */
+class Role extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    protected string $idPrefix = 'role_';
+
+    protected $fillable = [
+        'environment_id',
+        'key',
+        'name',
+        'description',
+        'is_creator_eligible',
+        'is_default',
+        'is_system',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_creator_eligible' => 'boolean',
+            'is_default' => 'boolean',
+            'is_system' => 'boolean',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, 'role_permission');
+    }
+
+    public function memberships(): HasMany
+    {
+        return $this->hasMany(OrganizationMembership::class, 'role_id');
+    }
+}

--- a/database/migrations/0012_01_01_000000_create_permissions.php
+++ b/database/migrations/0012_01_01_000000_create_permissions.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('permissions', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('key', 96);
+            $table->string('name');
+            $table->string('description', 512)->nullable();
+            $table->boolean('is_system')->default(false);
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->unique(['environment_id', 'key']);
+            $table->index(['environment_id', 'is_system']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('permissions');
+    }
+};

--- a/database/migrations/0012_01_01_000001_create_roles.php
+++ b/database/migrations/0012_01_01_000001_create_roles.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('key', 96);
+            $table->string('name');
+            $table->string('description', 512)->nullable();
+            $table->boolean('is_creator_eligible')->default(false);
+            $table->boolean('is_default')->default(false);
+            $table->boolean('is_system')->default(false);
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->unique(['environment_id', 'key']);
+            $table->index(['environment_id', 'is_default']);
+            $table->index(['environment_id', 'is_creator_eligible']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/database/migrations/0012_01_01_000002_create_role_permission.php
+++ b/database/migrations/0012_01_01_000002_create_role_permission.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('role_permission', function (Blueprint $table): void {
+            $table->string('role_id', 64);
+            $table->string('permission_id', 64);
+
+            $table->primary(['role_id', 'permission_id']);
+            $table->foreign('role_id')->references('id')->on('roles')->cascadeOnDelete();
+            $table->foreign('permission_id')->references('id')->on('permissions')->cascadeOnDelete();
+            $table->index('permission_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('role_permission');
+    }
+};

--- a/database/migrations/0012_01_01_000003_expand_organizations.php
+++ b/database/migrations/0012_01_01_000003_expand_organizations.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Lift the v0.1 stub organizations table to its full v0.2 surface.
+ *
+ * The v0.1 cut shipped with just (id, environment_id, name, slug,
+ * created_by_user_id) — enough for the bootstrap workspace. v0.2 adds
+ * branding, counter caches, the membership cap, the admin-delete flag,
+ * and the public/private metadata bags every other resource carries.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('organizations', function (Blueprint $table): void {
+            $table->string('image_path')->nullable()->after('slug');
+            $table->unsignedInteger('members_count')->default(0)->after('image_path');
+            $table->unsignedInteger('pending_invitations_count')->default(0)->after('members_count');
+            $table->unsignedInteger('max_allowed_memberships')->nullable()->after('pending_invitations_count');
+            $table->boolean('admin_delete_enabled')->default(true)->after('max_allowed_memberships');
+            $table->jsonb('public_metadata')->default(json_encode((object) []))->after('admin_delete_enabled');
+            $table->jsonb('private_metadata')->default(json_encode((object) []))->after('public_metadata');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('organizations', function (Blueprint $table): void {
+            $table->dropColumn([
+                'image_path',
+                'members_count',
+                'pending_invitations_count',
+                'max_allowed_memberships',
+                'admin_delete_enabled',
+                'public_metadata',
+                'private_metadata',
+            ]);
+        });
+    }
+};

--- a/database/migrations/0012_01_01_000004_expand_organization_memberships.php
+++ b/database/migrations/0012_01_01_000004_expand_organization_memberships.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add `role_id` (FK to roles), public/private metadata bags. The legacy
+ * `role` string column stays in place until AU-2 backfills `role_id` and
+ * cuts the bootstrap over to the seeded roles. After that, AU-2 drops
+ * the string column.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('organization_memberships', function (Blueprint $table): void {
+            $table->string('role_id', 64)->nullable()->after('user_id');
+            $table->jsonb('public_metadata')->default(json_encode((object) []))->after('role');
+            $table->jsonb('private_metadata')->default(json_encode((object) []))->after('public_metadata');
+
+            $table->foreign('role_id')->references('id')->on('roles')->restrictOnDelete();
+            $table->index(['environment_id', 'role_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('organization_memberships', function (Blueprint $table): void {
+            $table->dropForeign(['role_id']);
+            $table->dropIndex(['environment_id', 'role_id']);
+            $table->dropColumn(['role_id', 'public_metadata', 'private_metadata']);
+        });
+    }
+};

--- a/database/migrations/0012_01_01_000005_create_organization_invitations.php
+++ b/database/migrations/0012_01_01_000005_create_organization_invitations.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Org-scoped invitations. The single-use ticket carried on the magic-link
+ * URL is materialised as a `verification_codes` row (`purpose=invitation_ticket`,
+ * see PLAN §4 / §9.7) — `ticket_verification_code_id` points at it.
+ *
+ * Distinct from the env-scoped `invitations` table that AU-10 sign-up uses;
+ * these are issued by an org admin to add someone to a specific org.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('organization_invitations', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('organization_id', 64);
+            $table->string('email_address');
+            $table->string('role_id', 64);
+            $table->string('inviter_user_id', 64)->nullable();
+            $table->string('redirect_url')->nullable();
+            $table->string('status', 16)->default('pending');
+            $table->jsonb('public_metadata')->default(json_encode((object) []));
+            $table->timestamp('expires_at')->nullable();
+            $table->unsignedBigInteger('ticket_verification_code_id')->nullable();
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+            $table->foreign('role_id')->references('id')->on('roles')->restrictOnDelete();
+            $table->foreign('inviter_user_id')->references('id')->on('users')->nullOnDelete();
+            $table->foreign('ticket_verification_code_id')->references('id')->on('verification_codes')->nullOnDelete();
+
+            $table->index(['organization_id', 'status']);
+            $table->index(['environment_id', 'email_address']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('organization_invitations');
+    }
+};

--- a/database/migrations/0012_01_01_000006_create_organization_domains.php
+++ b/database/migrations/0012_01_01_000006_create_organization_domains.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('organization_domains', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('organization_id', 64);
+            $table->string('name');
+            $table->boolean('verified')->default(false);
+            $table->string('enrollment_mode', 32)->default('manual_invitation');
+            $table->string('verification_id', 64)->nullable();
+            $table->string('affiliation_email_address')->nullable();
+            $table->unsignedInteger('total_pending_invitations')->default(0);
+            $table->unsignedInteger('total_pending_suggestions')->default(0);
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+            $table->foreign('verification_id')->references('id')->on('verifications')->nullOnDelete();
+
+            $table->unique(['environment_id', 'name']);
+            $table->index(['organization_id', 'verified']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('organization_domains');
+    }
+};

--- a/database/migrations/0012_01_01_000007_create_organization_membership_requests.php
+++ b/database/migrations/0012_01_01_000007_create_organization_membership_requests.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('organization_membership_requests', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('organization_id', 64);
+            $table->string('user_id', 64);
+            $table->string('status', 16)->default('pending');
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+
+            $table->unique(['organization_id', 'user_id']);
+            $table->index(['organization_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('organization_membership_requests');
+    }
+};

--- a/tests/Feature/Models/OrganizationDomainTest.php
+++ b/tests/Feature/Models/OrganizationDomainTest.php
@@ -98,13 +98,17 @@ it('creates a Role + Permission and links them through role_permission', functio
     expect($perm->roles->pluck('key')->all())->toBe(['org:admin']);
 });
 
-it('enforces unique role and permission keys per environment', function (): void {
+it('enforces unique role keys per environment', function (): void {
     $env = makeOrgEnv();
 
     Role::create(['environment_id' => $env->id, 'key' => 'org:admin', 'name' => 'A']);
     expect(fn () => Role::create([
         'environment_id' => $env->id, 'key' => 'org:admin', 'name' => 'B',
     ]))->toThrow(QueryException::class);
+});
+
+it('enforces unique permission keys per environment', function (): void {
+    $env = makeOrgEnv();
 
     Permission::create(['environment_id' => $env->id, 'key' => 'org:x:read', 'name' => 'X']);
     expect(fn () => Permission::create([

--- a/tests/Feature/Models/OrganizationDomainTest.php
+++ b/tests/Feature/Models/OrganizationDomainTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationDomain;
+use App\Models\OrganizationInvitation;
+use App\Models\OrganizationMembership;
+use App\Models\OrganizationMembershipRequest;
+use App\Models\Permission;
+use App\Models\Project;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function makeOrgEnv(string $slug = 'env-org'): Environment
+{
+    $project = Project::create(['name' => 'P '.$slug, 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+function makeOrgUser(Environment $env, string $emailLocal): User
+{
+    $u = new User(['environment_id' => $env->id, 'first_name' => $emailLocal]);
+    $u->save();
+
+    return $u;
+}
+
+it('creates an Organization with a prefixed ULID and v0.2 columns', function (): void {
+    $env = makeOrgEnv();
+
+    $org = Organization::create([
+        'environment_id' => $env->id,
+        'name' => 'Acme',
+        'slug' => 'acme',
+        'public_metadata' => ['plan' => 'pro'],
+        'private_metadata' => ['internal' => 'x'],
+        'max_allowed_memberships' => 50,
+    ])->fresh();
+
+    expect($org->id)->toStartWith('org_');
+    expect($org->members_count)->toBe(0);
+    expect($org->pending_invitations_count)->toBe(0);
+    expect($org->admin_delete_enabled)->toBeTrue();
+    expect($org->public_metadata)->toBe(['plan' => 'pro']);
+    expect($org->max_allowed_memberships)->toBe(50);
+    expect($org->toArray())->not->toHaveKey('private_metadata');
+});
+
+it('enforces unique slug per environment for organizations', function (): void {
+    $envA = makeOrgEnv('a');
+    $envB = makeOrgEnv('b');
+
+    Organization::create(['environment_id' => $envA->id, 'name' => 'Acme', 'slug' => 'acme']);
+    // Same slug in a different env is fine.
+    Organization::create(['environment_id' => $envB->id, 'name' => 'Acme', 'slug' => 'acme']);
+
+    expect(fn () => Organization::create([
+        'environment_id' => $envA->id,
+        'name' => 'Dup',
+        'slug' => 'acme',
+    ]))->toThrow(QueryException::class);
+});
+
+it('creates a Role + Permission and links them through role_permission', function (): void {
+    $env = makeOrgEnv();
+
+    $perm = Permission::create([
+        'environment_id' => $env->id,
+        'key' => 'org:sys_profile:manage',
+        'name' => 'Manage organization profile',
+        'is_system' => true,
+    ]);
+    $role = Role::create([
+        'environment_id' => $env->id,
+        'key' => 'org:admin',
+        'name' => 'Organization admin',
+        'is_creator_eligible' => true,
+        'is_system' => true,
+    ]);
+
+    $role->permissions()->attach($perm->id);
+
+    expect($role->id)->toStartWith('role_');
+    expect($perm->id)->toStartWith('perm_');
+    expect($role->permissions->pluck('key')->all())->toBe(['org:sys_profile:manage']);
+    expect($perm->roles->pluck('key')->all())->toBe(['org:admin']);
+});
+
+it('enforces unique role and permission keys per environment', function (): void {
+    $env = makeOrgEnv();
+
+    Role::create(['environment_id' => $env->id, 'key' => 'org:admin', 'name' => 'A']);
+    expect(fn () => Role::create([
+        'environment_id' => $env->id, 'key' => 'org:admin', 'name' => 'B',
+    ]))->toThrow(QueryException::class);
+
+    Permission::create(['environment_id' => $env->id, 'key' => 'org:x:read', 'name' => 'X']);
+    expect(fn () => Permission::create([
+        'environment_id' => $env->id, 'key' => 'org:x:read', 'name' => 'Y',
+    ]))->toThrow(QueryException::class);
+});
+
+it('exposes membership.permissionKeys() through the role linkage', function (): void {
+    $env = makeOrgEnv();
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => 'acme']);
+    $user = makeOrgUser($env, 'alice');
+
+    $perm = Permission::create([
+        'environment_id' => $env->id, 'key' => 'org:sys_memberships:read', 'name' => 'X',
+    ]);
+    $role = Role::create([
+        'environment_id' => $env->id, 'key' => 'org:member', 'name' => 'Member',
+    ]);
+    $role->permissions()->attach($perm->id);
+
+    $mem = OrganizationMembership::create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'user_id' => $user->id,
+        'role' => OrganizationMembership::ROLE_MEMBER,
+        'role_id' => $role->id,
+    ]);
+
+    expect($mem->id)->toStartWith('orgmem_');
+    expect($mem->fresh()->permissionKeys())->toBe(['org:sys_memberships:read']);
+});
+
+it('legacy memberships without role_id return an empty permissionKeys list', function (): void {
+    $env = makeOrgEnv();
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => 'acme']);
+    $user = makeOrgUser($env, 'a');
+
+    $mem = OrganizationMembership::create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'user_id' => $user->id,
+        'role' => OrganizationMembership::ROLE_WORKSPACE_OWNER,
+    ]);
+
+    expect($mem->permissionKeys())->toBe([]);
+});
+
+it('creates an OrganizationInvitation and round-trips relations', function (): void {
+    $env = makeOrgEnv();
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => 'acme']);
+    $inviter = makeOrgUser($env, 'admin');
+    $role = Role::create(['environment_id' => $env->id, 'key' => 'org:member', 'name' => 'Member']);
+
+    $inv = OrganizationInvitation::create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'email_address' => 'newbie@example.com',
+        'role_id' => $role->id,
+        'inviter_user_id' => $inviter->id,
+        'redirect_url' => 'https://example.com/welcome',
+        'status' => OrganizationInvitation::STATUS_PENDING,
+        'public_metadata' => ['source' => 'dashboard'],
+        'expires_at' => now()->addDays(7),
+    ]);
+
+    expect($inv->id)->toStartWith('orginv_');
+    expect($inv->organization->is($org))->toBeTrue();
+    expect($inv->role->is($role))->toBeTrue();
+    expect($inv->inviter->is($inviter))->toBeTrue();
+    expect($org->fresh()->invitations->pluck('id')->all())->toBe([$inv->id]);
+});
+
+it('creates an OrganizationDomain unique per env', function (): void {
+    $envA = makeOrgEnv('a');
+    $envB = makeOrgEnv('b');
+    $orgA = Organization::create(['environment_id' => $envA->id, 'name' => 'A', 'slug' => 'a']);
+    $orgB = Organization::create(['environment_id' => $envB->id, 'name' => 'B', 'slug' => 'b']);
+
+    $d = OrganizationDomain::create([
+        'environment_id' => $envA->id,
+        'organization_id' => $orgA->id,
+        'name' => 'acme.test',
+        'enrollment_mode' => OrganizationDomain::MODE_AUTOMATIC_INVITATION,
+    ]);
+    expect($d->id)->toStartWith('orgdom_');
+
+    OrganizationDomain::create([
+        'environment_id' => $envB->id,
+        'organization_id' => $orgB->id,
+        'name' => 'acme.test',
+    ]);
+
+    expect(fn () => OrganizationDomain::create([
+        'environment_id' => $envA->id,
+        'organization_id' => $orgA->id,
+        'name' => 'acme.test',
+    ]))->toThrow(QueryException::class);
+});
+
+it('creates an OrganizationMembershipRequest and enforces uniqueness', function (): void {
+    $env = makeOrgEnv();
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'A', 'slug' => 'a']);
+    $user = makeOrgUser($env, 'u');
+
+    $req = OrganizationMembershipRequest::create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'user_id' => $user->id,
+        'status' => OrganizationMembershipRequest::STATUS_PENDING,
+    ]);
+    expect($req->id)->toStartWith('orgreq_');
+
+    expect(fn () => OrganizationMembershipRequest::create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'user_id' => $user->id,
+        'status' => OrganizationMembershipRequest::STATUS_PENDING,
+    ]))->toThrow(QueryException::class);
+});
+
+it('cascades org-scoped rows when their Organization is deleted', function (): void {
+    $env = makeOrgEnv();
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'A', 'slug' => 'a']);
+    $other = Organization::create(['environment_id' => $env->id, 'name' => 'B', 'slug' => 'b']);
+    $user = makeOrgUser($env, 'u');
+    $role = Role::create(['environment_id' => $env->id, 'key' => 'org:member', 'name' => 'M']);
+
+    OrganizationMembership::create([
+        'environment_id' => $env->id, 'organization_id' => $org->id, 'user_id' => $user->id,
+        'role' => 'org:member', 'role_id' => $role->id,
+    ]);
+    OrganizationInvitation::create([
+        'environment_id' => $env->id, 'organization_id' => $org->id,
+        'email_address' => 'x@example.com', 'role_id' => $role->id,
+        'status' => 'pending',
+    ]);
+    OrganizationDomain::create([
+        'environment_id' => $env->id, 'organization_id' => $org->id, 'name' => 'acme.test',
+    ]);
+    OrganizationMembershipRequest::create([
+        'environment_id' => $env->id, 'organization_id' => $org->id, 'user_id' => $user->id,
+        'status' => 'pending',
+    ]);
+    // Sibling org keeps a row to prove no cross-pollution.
+    OrganizationDomain::create([
+        'environment_id' => $env->id, 'organization_id' => $other->id, 'name' => 'sibling.test',
+    ]);
+
+    $org->delete();
+
+    expect(OrganizationMembership::where('organization_id', $org->id)->exists())->toBeFalse();
+    expect(OrganizationInvitation::where('organization_id', $org->id)->exists())->toBeFalse();
+    expect(OrganizationDomain::where('organization_id', $org->id)->exists())->toBeFalse();
+    expect(OrganizationMembershipRequest::where('organization_id', $org->id)->exists())->toBeFalse();
+    expect(OrganizationDomain::where('organization_id', $other->id)->exists())->toBeTrue();
+});
+
+it('cascades roles + permissions + pivot when their Environment is deleted', function (): void {
+    $envA = makeOrgEnv('a');
+    $envB = makeOrgEnv('b');
+
+    $permA = Permission::create(['environment_id' => $envA->id, 'key' => 'p:a', 'name' => 'A']);
+    $roleA = Role::create(['environment_id' => $envA->id, 'key' => 'r:a', 'name' => 'A']);
+    $roleA->permissions()->attach($permA->id);
+
+    $permB = Permission::create(['environment_id' => $envB->id, 'key' => 'p:b', 'name' => 'B']);
+    $roleB = Role::create(['environment_id' => $envB->id, 'key' => 'r:b', 'name' => 'B']);
+    $roleB->permissions()->attach($permB->id);
+
+    // Delete via project, which cascades through environment.
+    Project::find($envA->project_id)->delete();
+
+    expect(Role::withoutGlobalScopes()->where('id', $roleA->id)->exists())->toBeFalse();
+    expect(Permission::withoutGlobalScopes()->where('id', $permA->id)->exists())->toBeFalse();
+    expect(Role::withoutGlobalScopes()->where('id', $roleB->id)->exists())->toBeTrue();
+    expect(Permission::withoutGlobalScopes()->where('id', $permB->id)->exists())->toBeTrue();
+});


### PR DESCRIPTION
## Summary

Schema spine for v0.2 organizations:

- Five new tables: `permissions`, `roles`, `role_permission` (composite-PK pivot), `organization_invitations`, `organization_domains`, `organization_membership_requests`.
- Column expansions on the v0.1 stubs:
  - `organizations`: `image_path`, `members_count`, `pending_invitations_count`, `max_allowed_memberships`, `admin_delete_enabled`, `public_metadata`, `private_metadata`.
  - `organization_memberships`: `role_id` (FK to `roles`, nullable), `public_metadata`, `private_metadata`.
- Six new Eloquent models with the prefixed-ULID cast wired (`Permission`, `Role`, `OrganizationInvitation`, `OrganizationDomain`, `OrganizationMembershipRequest`, plus the expanded `Organization` / `OrganizationMembership`).
- `OrganizationInvitation.ticket_verification_code_id` reuses the v0.1 `verification_codes` primitive — no new ticket table.
- The legacy `organization_memberships.role` string column stays in place as a transitional column. AU-2 will seed default roles, backfill `role_id`, cut the bootstrap over, and drop it.
- All 7 new id prefixes (`org_`, `orgmem_`, `orginv_`, `orgdom_`, `orgreq_`, `role_`, `perm_`) are already registered in `IdPrefix`; the cast picks them up automatically.

## Test plan

- [x] `php artisan migrate:fresh` applies all 8 new migrations cleanly on SQLite (in-memory test DB).
- [x] `tests/Feature/Models/OrganizationDomainTest.php` covers: prefixed ULIDs, unique-slug-per-env, role/permission attach + reverse lookup, unique role/permission keys, membership → permissionKeys() through role linkage, legacy memberships return empty permissions, `OrganizationInvitation` round-trip relations, `OrganizationDomain` unique-name-per-env, `OrganizationMembershipRequest` uniqueness, cascade delete from Organization, cascade from Project (Environment) leaves siblings untouched.
- [x] Full Pest suite passes (310 tests).
- [x] `vendor/bin/pint --test` clean.
- [ ] CI must run migrations on PostgreSQL.

Closes #35