### PR TITLE
BAPI organizations + memberships endpoints (AU-3)

### DIFF
--- a/app/Events/Organizations/OrganizationCreated.php
+++ b/app/Events/Organizations/OrganizationCreated.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\Organization;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Plain event hook so AU-11 can register a webhook-emission listener
+ * without further controller changes. Carries the Organization model;
+ * listeners are responsible for shaping the resource and calling Emitter.
+ */
+final class OrganizationCreated
+{
+    use Dispatchable;
+
+    public function __construct(public readonly Organization $organization) {}
+}

--- a/app/Events/Organizations/OrganizationDeleted.php
+++ b/app/Events/Organizations/OrganizationDeleted.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\Organization;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationDeleted
+{
+    use Dispatchable;
+
+    public function __construct(public readonly Organization $organization) {}
+}

--- a/app/Events/Organizations/OrganizationMembershipCreated.php
+++ b/app/Events/Organizations/OrganizationMembershipCreated.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationMembership;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationMembershipCreated
+{
+    use Dispatchable;
+
+    public function __construct(public readonly OrganizationMembership $membership) {}
+}

--- a/app/Events/Organizations/OrganizationMembershipDeleted.php
+++ b/app/Events/Organizations/OrganizationMembershipDeleted.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationMembership;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationMembershipDeleted
+{
+    use Dispatchable;
+
+    public function __construct(public readonly OrganizationMembership $membership) {}
+}

--- a/app/Events/Organizations/OrganizationMembershipUpdated.php
+++ b/app/Events/Organizations/OrganizationMembershipUpdated.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationMembership;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationMembershipUpdated
+{
+    use Dispatchable;
+
+    public function __construct(public readonly OrganizationMembership $membership) {}
+}

--- a/app/Events/Organizations/OrganizationUpdated.php
+++ b/app/Events/Organizations/OrganizationUpdated.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\Organization;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationUpdated
+{
+    use Dispatchable;
+
+    public function __construct(public readonly Organization $organization) {}
+}

--- a/app/Http/Controllers/Bapi/OrganizationController.php
+++ b/app/Http/Controllers/Bapi/OrganizationController.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Events\Organizations\OrganizationCreated;
+use App\Events\Organizations\OrganizationDeleted;
+use App\Events\Organizations\OrganizationUpdated;
+use App\Http\Requests\Bapi\Organizations\CreateOrganizationRequest;
+use App\Http\Requests\Bapi\Organizations\UpdateOrganizationRequest;
+use App\Http\Resources\OrganizationResource;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+/**
+ * BAPI organizations surface (PLAN §3.1, OA-2).
+ *
+ *   GET    /v1/organizations
+ *   POST   /v1/organizations
+ *   GET    /v1/organizations/{id}
+ *   PATCH  /v1/organizations/{id}
+ *   DELETE /v1/organizations/{id}
+ */
+final class OrganizationController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $query = Organization::query()->withoutGlobalScopes()->where('environment_id', $env->id);
+
+        if ($request->has('query')) {
+            $needle = '%'.strtolower((string) $request->input('query')).'%';
+            $query->where(function ($q) use ($needle): void {
+                $q->whereRaw('LOWER(name) LIKE ?', [$needle])
+                    ->orWhereRaw('LOWER(slug) LIKE ?', [$needle]);
+            });
+        }
+        if ($request->has('user_id')) {
+            $userIds = (array) $request->input('user_id');
+            $query->whereHas('memberships', fn ($q) => $q->whereIn('user_id', $userIds));
+        }
+
+        $orderBy = (string) $request->input('order_by', '-created_at');
+        $direction = str_starts_with($orderBy, '-') ? 'desc' : 'asc';
+        $column = ltrim($orderBy, '-+');
+        $allowed = ['created_at', 'updated_at', 'name', 'members_count'];
+        $query->orderBy(in_array($column, $allowed, true) ? $column : 'created_at', $direction);
+
+        $limit = max(1, min(500, (int) $request->input('limit', 10)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (Organization $o) => OrganizationResource::from($o, includePrivate: true))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(CreateOrganizationRequest $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        $createdBy = $request->input('created_by');
+        if (is_string($createdBy) && $createdBy !== '') {
+            $exists = User::query()
+                ->withoutGlobalScopes()
+                ->where('environment_id', $env->id)
+                ->where('id', $createdBy)
+                ->exists();
+            if (! $exists) {
+                return $this->error(422, 'form_param_value_invalid', 'created_by user does not exist in this environment.');
+            }
+        }
+
+        $name = (string) $request->input('name');
+        $slug = $request->filled('slug') ? (string) $request->input('slug') : $this->slugify($name);
+
+        $duplicate = Organization::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('slug', $slug)
+            ->exists();
+        if ($duplicate) {
+            return $this->error(409, 'form_identifier_exists', 'An organization with that slug already exists.');
+        }
+
+        $org = Organization::create([
+            'environment_id' => $env->id,
+            'name' => $name,
+            'slug' => $slug,
+            'created_by_user_id' => is_string($createdBy) && $createdBy !== '' ? $createdBy : null,
+            'max_allowed_memberships' => $request->input('max_allowed_memberships'),
+            'admin_delete_enabled' => $request->boolean('admin_delete_enabled', true),
+            'public_metadata' => $request->input('public_metadata') ?? [],
+            'private_metadata' => $request->input('private_metadata') ?? [],
+        ]);
+
+        OrganizationCreated::dispatch($org);
+
+        return response()->json(OrganizationResource::from($org->fresh(), includePrivate: true), 201);
+    }
+
+    public function show(string $id): JsonResponse
+    {
+        $org = $this->find($id);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+
+        return response()->json(OrganizationResource::from($org, includePrivate: true))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function update(UpdateOrganizationRequest $request, string $id): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = $this->find($id);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+
+        if ($request->has('slug')) {
+            $newSlug = (string) $request->input('slug');
+            if ($newSlug !== $org->slug) {
+                $duplicate = Organization::query()
+                    ->withoutGlobalScopes()
+                    ->where('environment_id', $env->id)
+                    ->where('slug', $newSlug)
+                    ->where('id', '!=', $org->id)
+                    ->exists();
+                if ($duplicate) {
+                    return $this->error(409, 'form_identifier_exists', 'An organization with that slug already exists.');
+                }
+            }
+            $org->slug = $newSlug;
+        }
+        if ($request->has('name')) {
+            $org->name = (string) $request->input('name');
+        }
+        if ($request->has('max_allowed_memberships')) {
+            $org->max_allowed_memberships = $request->input('max_allowed_memberships');
+        }
+        if ($request->has('admin_delete_enabled')) {
+            $org->admin_delete_enabled = $request->boolean('admin_delete_enabled');
+        }
+        foreach (['public_metadata', 'private_metadata'] as $blob) {
+            if ($request->has($blob) && is_array($request->input($blob))) {
+                $org->{$blob} = $request->input($blob);
+            }
+        }
+        $org->save();
+
+        OrganizationUpdated::dispatch($org->fresh());
+
+        return response()->json(OrganizationResource::from($org->fresh(), includePrivate: true));
+    }
+
+    public function destroy(string $id): JsonResponse
+    {
+        $org = $this->find($id);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+        if (! $org->admin_delete_enabled) {
+            return $this->error(422, 'organization_admin_delete_disabled', 'Admin delete is disabled for this organization.');
+        }
+
+        $copy = $org->replicate();
+        $copy->id = $org->id;
+        $copy->setRawAttributes($org->getAttributes(), sync: true);
+
+        $org->delete();
+
+        OrganizationDeleted::dispatch($copy);
+
+        return response()->json([
+            'object' => 'deleted_object',
+            'id' => $id,
+            'slug' => $copy->slug,
+            'deleted' => true,
+        ]);
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    private function find(string $id): ?Organization
+    {
+        $env = app(Environment::class);
+
+        return Organization::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $id)
+            ->first();
+    }
+
+    private function slugify(string $name): string
+    {
+        $slug = Str::slug($name);
+        if ($slug === '') {
+            $slug = 'org-'.Str::lower(Str::random(8));
+        }
+
+        return Str::limit($slug, 60, '');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Controllers/Bapi/OrganizationMembershipController.php
+++ b/app/Http/Controllers/Bapi/OrganizationMembershipController.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Events\Organizations\OrganizationMembershipCreated;
+use App\Events\Organizations\OrganizationMembershipDeleted;
+use App\Events\Organizations\OrganizationMembershipUpdated;
+use App\Http\Requests\Bapi\Organizations\CreateMembershipRequest;
+use App\Http\Requests\Bapi\Organizations\UpdateMembershipRequest;
+use App\Http\Resources\OrganizationMembershipResource;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\User;
+use App\Services\Tenancy\RoleSeeder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * BAPI organization memberships surface (PLAN §3.1, OA-2).
+ *
+ *   GET    /v1/organizations/{organization_id}/memberships
+ *   POST   /v1/organizations/{organization_id}/memberships
+ *   PATCH  /v1/organizations/{organization_id}/memberships/{user_id}
+ *   DELETE /v1/organizations/{organization_id}/memberships/{user_id}
+ */
+final class OrganizationMembershipController
+{
+    public function index(Request $request, string $organizationId): JsonResponse
+    {
+        $org = $this->findOrganization($organizationId);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+
+        $query = OrganizationMembership::query()->where('organization_id', $org->id);
+        if ($request->has('role')) {
+            $roles = (array) $request->input('role');
+            $query->whereHas('role', fn ($q) => $q->whereIn('key', $roles));
+        }
+        if ($request->has('user_id')) {
+            $query->whereIn('user_id', (array) $request->input('user_id'));
+        }
+
+        $orderBy = (string) $request->input('order_by', '-created_at');
+        $direction = str_starts_with($orderBy, '-') ? 'desc' : 'asc';
+        $column = ltrim($orderBy, '-+');
+        $allowed = ['created_at', 'updated_at'];
+        $query->orderBy(in_array($column, $allowed, true) ? $column : 'created_at', $direction);
+
+        $limit = max(1, min(500, (int) $request->input('limit', 10)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->with(['user', 'role.permissions'])->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (OrganizationMembership $m) => OrganizationMembershipResource::from($m, includePrivate: true))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(CreateMembershipRequest $request, string $organizationId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = $this->findOrganization($organizationId);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+
+        $userId = (string) $request->input('user_id');
+        $user = User::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $userId)
+            ->first();
+        if ($user === null) {
+            return $this->error(422, 'form_param_value_invalid', 'user_id does not match a user in this environment.');
+        }
+
+        $role = $this->resolveRole($env, (string) $request->input('role'));
+        if ($role === null) {
+            return $this->error(422, 'form_param_value_invalid', 'role is not a known role key in this environment.');
+        }
+
+        $duplicate = OrganizationMembership::query()
+            ->where('organization_id', $org->id)
+            ->where('user_id', $userId)
+            ->exists();
+        if ($duplicate) {
+            return $this->error(409, 'form_identifier_exists', 'User is already a member of this organization.');
+        }
+
+        if ($org->max_allowed_memberships !== null && $org->members_count >= $org->max_allowed_memberships) {
+            return $this->error(422, 'organization_membership_quota_exceeded', 'Organization has reached its membership cap.');
+        }
+
+        $membership = DB::transaction(function () use ($env, $org, $userId, $role, $request): OrganizationMembership {
+            $row = OrganizationMembership::create([
+                'environment_id' => $env->id,
+                'organization_id' => $org->id,
+                'user_id' => $userId,
+                'role_id' => $role->id,
+                'public_metadata' => $request->input('public_metadata') ?? [],
+                'private_metadata' => $request->input('private_metadata') ?? [],
+            ]);
+            // Counter cache. Keep it inline (per AU-1's note); a job-based
+            // backfill is deferred.
+            $org->increment('members_count');
+
+            return $row;
+        });
+
+        OrganizationMembershipCreated::dispatch($membership);
+
+        return response()->json(
+            OrganizationMembershipResource::from($membership->fresh()->load(['user', 'role.permissions']), includePrivate: true),
+            201,
+        );
+    }
+
+    public function update(UpdateMembershipRequest $request, string $organizationId, string $userId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = $this->findOrganization($organizationId);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+
+        $membership = OrganizationMembership::query()
+            ->where('organization_id', $org->id)
+            ->where('user_id', $userId)
+            ->first();
+        if ($membership === null) {
+            return $this->error(404, 'organization_membership_not_found', 'No membership matches that user in this organization.');
+        }
+
+        $role = $this->resolveRole($env, (string) $request->input('role'));
+        if ($role === null) {
+            return $this->error(422, 'form_param_value_invalid', 'role is not a known role key in this environment.');
+        }
+
+        if (
+            $membership->role?->key === RoleSeeder::ROLE_ADMIN
+            && $role->key !== RoleSeeder::ROLE_ADMIN
+            && $this->countAdmins($org) <= 1
+        ) {
+            return $this->error(422, 'organization_last_admin', 'Cannot demote the last admin of an organization.');
+        }
+
+        $membership->role_id = $role->id;
+        if ($request->has('public_metadata') && is_array($request->input('public_metadata'))) {
+            $membership->public_metadata = $request->input('public_metadata');
+        }
+        if ($request->has('private_metadata') && is_array($request->input('private_metadata'))) {
+            $membership->private_metadata = $request->input('private_metadata');
+        }
+        $membership->save();
+
+        OrganizationMembershipUpdated::dispatch($membership->fresh());
+
+        return response()->json(
+            OrganizationMembershipResource::from(
+                $membership->fresh()->load(['user', 'role.permissions']),
+                includePrivate: true,
+            ),
+        );
+    }
+
+    public function destroy(string $organizationId, string $userId): JsonResponse
+    {
+        $org = $this->findOrganization($organizationId);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+
+        $membership = OrganizationMembership::query()
+            ->where('organization_id', $org->id)
+            ->where('user_id', $userId)
+            ->first();
+        if ($membership === null) {
+            return $this->error(404, 'organization_membership_not_found', 'No membership matches that user in this organization.');
+        }
+
+        if (
+            $membership->role?->key === RoleSeeder::ROLE_ADMIN
+            && $this->countAdmins($org) <= 1
+        ) {
+            return $this->error(422, 'organization_last_admin', 'Cannot remove the last admin of an organization.');
+        }
+
+        DB::transaction(function () use ($org, $membership): void {
+            $membership->delete();
+            $org->decrement('members_count');
+        });
+
+        OrganizationMembershipDeleted::dispatch($membership);
+
+        return response()->json([
+            'object' => 'deleted_object',
+            'id' => $membership->id,
+            'deleted' => true,
+        ]);
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    private function findOrganization(string $id): ?Organization
+    {
+        $env = app(Environment::class);
+
+        return Organization::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $id)
+            ->first();
+    }
+
+    private function resolveRole(Environment $env, string $key): ?Role
+    {
+        return Role::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('key', $key)
+            ->first();
+    }
+
+    private function countAdmins(Organization $org): int
+    {
+        return OrganizationMembership::query()
+            ->where('organization_id', $org->id)
+            ->whereHas('role', fn ($q) => $q->where('key', RoleSeeder::ROLE_ADMIN))
+            ->count();
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Requests/Bapi/Organizations/CreateMembershipRequest.php
+++ b/app/Http/Requests/Bapi/Organizations/CreateMembershipRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\Organizations;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class CreateMembershipRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'user_id' => ['required', 'string'],
+            'role' => ['required', 'string', 'max:96'],
+            'public_metadata' => ['nullable', 'array'],
+            'private_metadata' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/app/Http/Requests/Bapi/Organizations/CreateOrganizationRequest.php
+++ b/app/Http/Requests/Bapi/Organizations/CreateOrganizationRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\Organizations;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class CreateOrganizationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:64', 'regex:/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/'],
+            'created_by' => ['nullable', 'string'],
+            'max_allowed_memberships' => ['nullable', 'integer', 'min:0'],
+            'admin_delete_enabled' => ['nullable', 'boolean'],
+            'public_metadata' => ['nullable', 'array'],
+            'private_metadata' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/app/Http/Requests/Bapi/Organizations/UpdateMembershipRequest.php
+++ b/app/Http/Requests/Bapi/Organizations/UpdateMembershipRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\Organizations;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class UpdateMembershipRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'role' => ['required', 'string', 'max:96'],
+            'public_metadata' => ['sometimes', 'array'],
+            'private_metadata' => ['sometimes', 'array'],
+        ];
+    }
+}

--- a/app/Http/Requests/Bapi/Organizations/UpdateOrganizationRequest.php
+++ b/app/Http/Requests/Bapi/Organizations/UpdateOrganizationRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\Organizations;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class UpdateOrganizationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'string', 'max:255'],
+            'slug' => ['sometimes', 'string', 'max:64', 'regex:/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/'],
+            'max_allowed_memberships' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'admin_delete_enabled' => ['sometimes', 'boolean'],
+            'public_metadata' => ['sometimes', 'array'],
+            'private_metadata' => ['sometimes', 'array'],
+        ];
+    }
+}

--- a/app/Http/Resources/OrganizationMembershipResource.php
+++ b/app/Http/Resources/OrganizationMembershipResource.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\OrganizationMembership;
+use App\Models\User;
+
+final class OrganizationMembershipResource
+{
+    public static function from(OrganizationMembership $membership, bool $includePrivate = false): array
+    {
+        $role = $membership->role;
+        $shape = [
+            'object' => 'organization_membership',
+            'id' => $membership->id,
+            'organization_id' => $membership->organization_id,
+            'role' => $role?->key,
+            'role_name' => $role?->name,
+            'permissions' => $role !== null ? $role->permissions->pluck('key')->all() : [],
+            'public_metadata' => is_array($membership->public_metadata) ? $membership->public_metadata : [],
+            'public_user_data' => self::publicUserData($membership->user),
+            'created_at' => $membership->created_at?->getTimestampMs(),
+            'updated_at' => $membership->updated_at?->getTimestampMs(),
+        ];
+        $shape['private_metadata'] = $includePrivate
+            ? (is_array($membership->private_metadata) ? $membership->private_metadata : [])
+            : null;
+
+        return $shape;
+    }
+
+    private static function publicUserData(?User $user): ?array
+    {
+        if ($user === null) {
+            return null;
+        }
+        $primaryId = $user->primary_email_address_id;
+        $primaryEmail = null;
+        if (is_string($primaryId) && $primaryId !== '') {
+            $row = $user->emailAddresses()->withoutGlobalScopes()->where('id', $primaryId)->first();
+            $primaryEmail = $row?->email_address;
+        }
+
+        return [
+            'user_id' => $user->id,
+            'first_name' => $user->first_name,
+            'last_name' => $user->last_name,
+            'identifier' => $primaryEmail ?? $user->username,
+            'image_url' => $user->image_url,
+            'has_image' => (bool) $user->has_image,
+            'profile_image_url' => $user->image_url,
+        ];
+    }
+}

--- a/app/Http/Resources/OrganizationResource.php
+++ b/app/Http/Resources/OrganizationResource.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Organization;
+
+final class OrganizationResource
+{
+    public static function from(Organization $org, bool $includePrivate = false): array
+    {
+        $shape = [
+            'object' => 'organization',
+            'id' => $org->id,
+            'name' => $org->name,
+            'slug' => $org->slug,
+            'image_url' => $org->image_path,
+            'has_image' => $org->image_path !== null,
+            'members_count' => (int) $org->members_count,
+            'pending_invitations_count' => (int) $org->pending_invitations_count,
+            'max_allowed_memberships' => $org->max_allowed_memberships,
+            'admin_delete_enabled' => (bool) $org->admin_delete_enabled,
+            'public_metadata' => is_array($org->public_metadata) ? $org->public_metadata : [],
+            'created_by' => $org->created_by_user_id,
+            'created_at' => $org->created_at?->getTimestampMs(),
+            'updated_at' => $org->updated_at?->getTimestampMs(),
+        ];
+        $shape['private_metadata'] = $includePrivate
+            ? (is_array($org->private_metadata) ? $org->private_metadata : [])
+            : null;
+
+        return $shape;
+    }
+}

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Bapi\AllowlistIdentifiersController;
 use App\Http\Controllers\Bapi\BlocklistIdentifiersController;
 use App\Http\Controllers\Bapi\InstanceController;
 use App\Http\Controllers\Bapi\InvitationsController;
+use App\Http\Controllers\Bapi\OrganizationController;
+use App\Http\Controllers\Bapi\OrganizationMembershipController;
 use App\Http\Controllers\Bapi\PingController;
 use App\Http\Controllers\Bapi\RedirectUrlsController;
 use App\Http\Controllers\Bapi\SessionsController;
@@ -86,6 +88,18 @@ Route::post('/webhooks/endpoints/{id}/rotate_secret', [WebhookEndpointsControlle
 Route::get('/webhooks/deliveries', [WebhookDeliveriesController::class, 'index'])->middleware(RateLimit::class.':webhooks.list,300,60');
 Route::get('/webhooks/deliveries/{id}', [WebhookDeliveriesController::class, 'show'])->middleware(RateLimit::class.':webhooks.read,300,60');
 Route::post('/webhooks/deliveries/{id}/replay', [WebhookDeliveriesController::class, 'replay'])->middleware(RateLimit::class.':webhooks.replay,30,60');
+
+// Organizations
+Route::get('/organizations', [OrganizationController::class, 'index'])->middleware(RateLimit::class.':orgs.list,300,60')->name('bapi.organizations.index');
+Route::post('/organizations', [OrganizationController::class, 'store'])->middleware(RateLimit::class.':orgs.create,30,60')->name('bapi.organizations.store');
+Route::get('/organizations/{organization_id}', [OrganizationController::class, 'show'])->middleware(RateLimit::class.':orgs.read,300,60')->name('bapi.organizations.show');
+Route::patch('/organizations/{organization_id}', [OrganizationController::class, 'update'])->middleware(RateLimit::class.':orgs.update,60,60')->name('bapi.organizations.update');
+Route::delete('/organizations/{organization_id}', [OrganizationController::class, 'destroy'])->middleware(RateLimit::class.':orgs.destroy,30,60')->name('bapi.organizations.destroy');
+
+Route::get('/organizations/{organization_id}/memberships', [OrganizationMembershipController::class, 'index'])->middleware(RateLimit::class.':orgs.members.list,300,60')->name('bapi.organizations.memberships.index');
+Route::post('/organizations/{organization_id}/memberships', [OrganizationMembershipController::class, 'store'])->middleware(RateLimit::class.':orgs.members.create,60,60')->name('bapi.organizations.memberships.store');
+Route::patch('/organizations/{organization_id}/memberships/{user_id}', [OrganizationMembershipController::class, 'update'])->middleware(RateLimit::class.':orgs.members.update,60,60')->name('bapi.organizations.memberships.update');
+Route::delete('/organizations/{organization_id}/memberships/{user_id}', [OrganizationMembershipController::class, 'destroy'])->middleware(RateLimit::class.':orgs.members.destroy,60,60')->name('bapi.organizations.memberships.destroy');
 
 // Instance settings
 Route::get('/instance', [InstanceController::class, 'show'])->middleware(RateLimit::class.':instance.read,300,60');

--- a/tests/Feature/Http/Bapi/OrganizationMembershipsTest.php
+++ b/tests/Feature/Http/Bapi/OrganizationMembershipsTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\Organizations\OrganizationMembershipCreated;
+use App\Events\Organizations\OrganizationMembershipDeleted;
+use App\Events\Organizations\OrganizationMembershipUpdated;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+use Tests\TestCase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * @return array{env: Environment, token: string, headers: array, org_id: string, admin: User, member: User, other: User}
+ */
+function setupOrgWithAdmin(TestCase $testCase): array
+{
+    $f = BapiTestSupport::bootEnv();
+    /** @var Environment $env */
+    $env = $f['env'];
+    $headers = BapiTestSupport::headers($f['token']);
+
+    $r = $testCase->withHeaders($headers)->postJson(BapiTestSupport::url('/organizations'), ['name' => 'Acme']);
+    $orgId = $r->json('id');
+
+    $admin = new User(['environment_id' => $env->id, 'username' => 'admin']);
+    $admin->save();
+    $member = new User(['environment_id' => $env->id, 'username' => 'member']);
+    $member->save();
+    $other = new User(['environment_id' => $env->id, 'username' => 'other']);
+    $other->save();
+
+    $adminRole = Role::withoutGlobalScopes()->where('environment_id', $env->id)->where('key', 'org:admin')->firstOrFail();
+    OrganizationMembership::create([
+        'environment_id' => $env->id,
+        'organization_id' => $orgId,
+        'user_id' => $admin->id,
+        'role_id' => $adminRole->id,
+    ]);
+    Organization::query()->withoutGlobalScopes()->where('id', $orgId)->increment('members_count');
+
+    return [
+        'env' => $env,
+        'token' => $f['token'],
+        'headers' => $headers,
+        'org_id' => $orgId,
+        'admin' => $admin,
+        'member' => $member,
+        'other' => $other,
+    ];
+}
+
+it('POST /memberships adds a user, increments members_count, fires the event', function (): void {
+    Event::fake([OrganizationMembershipCreated::class]);
+    $ctx = setupOrgWithAdmin($this);
+
+    $r = $this->withHeaders($ctx['headers'])
+        ->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships"), [
+            'user_id' => $ctx['member']->id,
+            'role' => 'org:member',
+        ]);
+    $r->assertStatus(201)
+        ->assertJsonPath('object', 'organization_membership')
+        ->assertJsonPath('role', 'org:member')
+        ->assertJsonPath('public_user_data.user_id', $ctx['member']->id);
+    expect($r->json('id'))->toStartWith('orgmem_');
+
+    $org = Organization::query()->withoutGlobalScopes()->where('id', $ctx['org_id'])->firstOrFail();
+    expect($org->members_count)->toBe(2);
+    Event::assertDispatched(OrganizationMembershipCreated::class, 1);
+});
+
+it('POST /memberships 409s on duplicate (org_id, user_id)', function (): void {
+    $ctx = setupOrgWithAdmin($this);
+    $body = ['user_id' => $ctx['member']->id, 'role' => 'org:member'];
+
+    $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships"), $body)->assertStatus(201);
+    $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships"), $body)->assertStatus(409);
+});
+
+it('POST /memberships 422s when role key is unknown', function (): void {
+    $ctx = setupOrgWithAdmin($this);
+    $this->withHeaders($ctx['headers'])
+        ->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships"), [
+            'user_id' => $ctx['member']->id,
+            'role' => 'org:nonsense',
+        ])->assertStatus(422);
+});
+
+it('POST /memberships 422s when the org is at its membership cap', function (): void {
+    $ctx = setupOrgWithAdmin($this);
+    Organization::query()->withoutGlobalScopes()->where('id', $ctx['org_id'])->update([
+        'max_allowed_memberships' => 1,
+    ]);
+
+    $this->withHeaders($ctx['headers'])
+        ->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships"), [
+            'user_id' => $ctx['member']->id,
+            'role' => 'org:member',
+        ])->assertStatus(422);
+});
+
+it('GET /memberships paginates and surfaces public_user_data', function (): void {
+    $ctx = setupOrgWithAdmin($this);
+
+    foreach ([$ctx['member'], $ctx['other']] as $u) {
+        $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships"), [
+            'user_id' => $u->id,
+            'role' => 'org:member',
+        ])->assertStatus(201);
+    }
+
+    $r = $this->withHeaders($ctx['headers'])->getJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships"));
+    $r->assertOk()->assertJsonPath('total_count', 3);
+    expect($r->json('data.0.public_user_data'))->not->toBeNull();
+});
+
+it('PATCH /memberships/{user_id} updates role and fires the event', function (): void {
+    Event::fake([OrganizationMembershipUpdated::class]);
+    $ctx = setupOrgWithAdmin($this);
+    $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships"), [
+        'user_id' => $ctx['member']->id,
+        'role' => 'org:member',
+    ])->assertStatus(201);
+
+    $r = $this->withHeaders($ctx['headers'])->patchJson(
+        BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships/{$ctx['member']->id}"),
+        ['role' => 'org:admin'],
+    );
+    $r->assertOk()->assertJsonPath('role', 'org:admin');
+    Event::assertDispatched(OrganizationMembershipUpdated::class, 1);
+});
+
+it('PATCH refuses to demote the last admin', function (): void {
+    $ctx = setupOrgWithAdmin($this);
+    $this->withHeaders($ctx['headers'])->patchJson(
+        BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships/{$ctx['admin']->id}"),
+        ['role' => 'org:member'],
+    )->assertStatus(422);
+});
+
+it('DELETE /memberships/{user_id} removes the row, decrements counter, fires event', function (): void {
+    Event::fake([OrganizationMembershipDeleted::class]);
+    $ctx = setupOrgWithAdmin($this);
+    $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships"), [
+        'user_id' => $ctx['member']->id,
+        'role' => 'org:member',
+    ])->assertStatus(201);
+
+    $r = $this->withHeaders($ctx['headers'])->deleteJson(
+        BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships/{$ctx['member']->id}"),
+    );
+    $r->assertOk()->assertJsonPath('deleted', true);
+
+    $org = Organization::query()->withoutGlobalScopes()->where('id', $ctx['org_id'])->firstOrFail();
+    expect($org->members_count)->toBe(1);
+    Event::assertDispatched(OrganizationMembershipDeleted::class, 1);
+});
+
+it('DELETE refuses to remove the last admin', function (): void {
+    $ctx = setupOrgWithAdmin($this);
+    $this->withHeaders($ctx['headers'])->deleteJson(
+        BapiTestSupport::url("/organizations/{$ctx['org_id']}/memberships/{$ctx['admin']->id}"),
+    )->assertStatus(422);
+});

--- a/tests/Feature/Http/Bapi/OrganizationsTest.php
+++ b/tests/Feature/Http/Bapi/OrganizationsTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\Organizations\OrganizationCreated;
+use App\Events\Organizations\OrganizationDeleted;
+use App\Events\Organizations\OrganizationUpdated;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+
+uses(RefreshDatabase::class);
+
+function makeUser(Environment $env, string $username): User
+{
+    $u = new User(['environment_id' => $env->id, 'username' => $username]);
+    $u->save();
+
+    return $u;
+}
+
+it('POST /v1/organizations creates an org, fires OrganizationCreated, returns the resource', function (): void {
+    Event::fake([OrganizationCreated::class]);
+    $f = BapiTestSupport::bootEnv();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/organizations'), [
+            'name' => 'Acme Inc',
+            'slug' => 'acme',
+            'public_metadata' => ['plan' => 'pro'],
+            'max_allowed_memberships' => 10,
+        ]);
+    $r->assertStatus(201)
+        ->assertJsonPath('object', 'organization')
+        ->assertJsonPath('name', 'Acme Inc')
+        ->assertJsonPath('slug', 'acme')
+        ->assertJsonPath('members_count', 0)
+        ->assertJsonPath('public_metadata.plan', 'pro')
+        ->assertJsonPath('max_allowed_memberships', 10);
+    expect($r->json('id'))->toStartWith('org_');
+    Event::assertDispatched(OrganizationCreated::class, 1);
+});
+
+it('POST auto-slugifies the name when no slug is supplied', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/organizations'), ['name' => 'Hello World']);
+    $r->assertStatus(201)->assertJsonPath('slug', 'hello-world');
+});
+
+it('POST 409s on duplicate slug within the same env', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $headers = BapiTestSupport::headers($f['token']);
+    $this->withHeaders($headers)->postJson(BapiTestSupport::url('/organizations'), ['name' => 'A', 'slug' => 'dup'])->assertStatus(201);
+    $this->withHeaders($headers)->postJson(BapiTestSupport::url('/organizations'), ['name' => 'B', 'slug' => 'dup'])->assertStatus(409);
+});
+
+it('POST 422s when created_by user does not exist in this env', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/organizations'), [
+            'name' => 'A',
+            'created_by' => 'user_doesnotexist',
+        ])->assertStatus(422);
+});
+
+it('POST 422s on a malformed slug', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/organizations'), ['name' => 'A', 'slug' => 'BAD SLUG'])->assertStatus(422);
+});
+
+it('GET /v1/organizations returns 401 without a key', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $this->withHeaders(['Host' => 'api.authn.local', 'Accept' => 'application/json'])
+        ->getJson(BapiTestSupport::url('/organizations'))->assertStatus(401);
+});
+
+it('GET /v1/organizations only returns rows from the bound env', function (): void {
+    $a = BapiTestSupport::bootEnv('aaa');
+    $headersA = BapiTestSupport::headers($a['token']);
+    $this->withHeaders($headersA)->postJson(BapiTestSupport::url('/organizations'), ['name' => 'OnlyA', 'slug' => 'only-a'])->assertStatus(201);
+
+    $b = BapiTestSupport::bootEnv('bbb');
+    $headersB = BapiTestSupport::headers($b['token']);
+    $this->withHeaders($headersB)->postJson(BapiTestSupport::url('/organizations'), ['name' => 'OnlyB', 'slug' => 'only-b'])->assertStatus(201);
+
+    $r = $this->withHeaders($headersB)->getJson(BapiTestSupport::url('/organizations'));
+    $r->assertOk()->assertJsonPath('total_count', 1)->assertJsonPath('data.0.slug', 'only-b');
+});
+
+it('GET supports query and pagination', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $headers = BapiTestSupport::headers($f['token']);
+    foreach (['Alpha', 'Beta', 'Aleph'] as $name) {
+        $this->withHeaders($headers)->postJson(BapiTestSupport::url('/organizations'), ['name' => $name]);
+    }
+    $r = $this->withHeaders($headers)->getJson(BapiTestSupport::url('/organizations?query=al&limit=10'));
+    $r->assertOk();
+    expect($r->json('total_count'))->toBe(2);
+});
+
+it('GET /v1/organizations/{id} returns 404 across env boundaries', function (): void {
+    $a = BapiTestSupport::bootEnv('aaa');
+    $r = $this->withHeaders(BapiTestSupport::headers($a['token']))
+        ->postJson(BapiTestSupport::url('/organizations'), ['name' => 'Only A', 'slug' => 'only-a']);
+    $orgId = $r->json('id');
+
+    $b = BapiTestSupport::bootEnv('bbb');
+    $this->withHeaders(BapiTestSupport::headers($b['token']))
+        ->getJson(BapiTestSupport::url("/organizations/{$orgId}"))->assertStatus(404);
+});
+
+it('PATCH /v1/organizations/{id} updates fields and fires OrganizationUpdated', function (): void {
+    Event::fake([OrganizationUpdated::class]);
+    $f = BapiTestSupport::bootEnv();
+    $headers = BapiTestSupport::headers($f['token']);
+    $r = $this->withHeaders($headers)->postJson(BapiTestSupport::url('/organizations'), ['name' => 'Old']);
+    $id = $r->json('id');
+
+    $r2 = $this->withHeaders($headers)->patchJson(BapiTestSupport::url("/organizations/{$id}"), [
+        'name' => 'New',
+        'public_metadata' => ['k' => 'v'],
+    ]);
+    $r2->assertOk()->assertJsonPath('name', 'New')->assertJsonPath('public_metadata.k', 'v');
+    Event::assertDispatched(OrganizationUpdated::class, 1);
+});
+
+it('PATCH 409s when renaming to an existing slug', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $headers = BapiTestSupport::headers($f['token']);
+    $this->withHeaders($headers)->postJson(BapiTestSupport::url('/organizations'), ['name' => 'A', 'slug' => 'a'])->assertStatus(201);
+    $r = $this->withHeaders($headers)->postJson(BapiTestSupport::url('/organizations'), ['name' => 'B', 'slug' => 'b']);
+    $id = $r->json('id');
+
+    $this->withHeaders($headers)->patchJson(BapiTestSupport::url("/organizations/{$id}"), ['slug' => 'a'])->assertStatus(409);
+});
+
+it('DELETE /v1/organizations/{id} cascades children and fires OrganizationDeleted', function (): void {
+    Event::fake([OrganizationDeleted::class]);
+    $f = BapiTestSupport::bootEnv();
+    $headers = BapiTestSupport::headers($f['token']);
+    $r = $this->withHeaders($headers)->postJson(BapiTestSupport::url('/organizations'), ['name' => 'A']);
+    $id = $r->json('id');
+
+    $r2 = $this->withHeaders($headers)->deleteJson(BapiTestSupport::url("/organizations/{$id}"));
+    $r2->assertOk()->assertJsonPath('deleted', true);
+    expect(Organization::query()->withoutGlobalScopes()->where('id', $id)->exists())->toBeFalse();
+    Event::assertDispatched(OrganizationDeleted::class, 1);
+});
+
+it('DELETE 422s when admin_delete_enabled is false', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $headers = BapiTestSupport::headers($f['token']);
+    $r = $this->withHeaders($headers)->postJson(BapiTestSupport::url('/organizations'), [
+        'name' => 'No-Delete',
+        'admin_delete_enabled' => false,
+    ]);
+    $id = $r->json('id');
+    $this->withHeaders($headers)->deleteJson(BapiTestSupport::url("/organizations/{$id}"))->assertStatus(422);
+});


### PR DESCRIPTION
## Summary

Privileged BAPI surface for organizations + memberships:

- 9 new routes under `/v1/organizations` (index/store/show/update/destroy on the org, plus index/store/update/destroy on memberships).
- `OrganizationController` with auto-slug, duplicate-slug 409s, `admin_delete_enabled` guard.
- `OrganizationMembershipController` with target-user lookup, role-key resolution, duplicate-membership 409, `max_allowed_memberships` 422 cap, last-admin-removal guard (both on demote and delete) returning 422 `organization_last_admin`.
- Counter cache `members_count` maintained inline on create/delete (in a transaction).
- `OrganizationCreated` / `Updated` / `Deleted` + the three membership events as plain `Dispatchable` holders. AU-11 will wire listeners that call the webhook `Emitter`.
- `OrganizationResource` + `OrganizationMembershipResource` matching the OpenAPI shape; membership resource includes `public_user_data` and the role's permission keys inlined.

## Test plan

- [x] `OrganizationsTest`: happy-path create / read / update / delete; 401 without key; cross-env 404 isolation; auto-slug; duplicate-slug 409 (create + update); `admin_delete_enabled` 422 on delete; query / pagination smoke; `created_by` validation; events dispatched. 13 tests.
- [x] `OrganizationMembershipsTest`: counter-cache invariants on create + delete; 409 on duplicate; 422 on unknown role / membership cap; last-admin guard on PATCH and DELETE; pagination + `public_user_data`; events dispatched. 9 tests.
- [x] Full Pest suite passes (343 tests).
- [x] `vendor/bin/pint --test` clean.

Closes #37