### PR TITLE
BAPI organization invitations + domains endpoints (AU-4)

### DIFF
--- a/app/Events/Organizations/OrganizationDomainCreated.php
+++ b/app/Events/Organizations/OrganizationDomainCreated.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationDomain;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationDomainCreated
+{
+    use Dispatchable;
+
+    public function __construct(public readonly OrganizationDomain $domain) {}
+}

--- a/app/Events/Organizations/OrganizationDomainDeleted.php
+++ b/app/Events/Organizations/OrganizationDomainDeleted.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationDomain;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationDomainDeleted
+{
+    use Dispatchable;
+
+    public function __construct(public readonly OrganizationDomain $domain) {}
+}

--- a/app/Events/Organizations/OrganizationDomainUpdated.php
+++ b/app/Events/Organizations/OrganizationDomainUpdated.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationDomain;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationDomainUpdated
+{
+    use Dispatchable;
+
+    public function __construct(public readonly OrganizationDomain $domain) {}
+}

--- a/app/Events/Organizations/OrganizationInvitationCreated.php
+++ b/app/Events/Organizations/OrganizationInvitationCreated.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationInvitation;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Carries both the invitation row and the freshly-minted ticket URL so
+ * the email worker (AU-14 v0.2) can render the message without re-issuing
+ * the JWT.
+ */
+final class OrganizationInvitationCreated
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly OrganizationInvitation $invitation,
+        public readonly string $url,
+    ) {}
+}

--- a/app/Events/Organizations/OrganizationInvitationRevoked.php
+++ b/app/Events/Organizations/OrganizationInvitationRevoked.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationInvitation;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationInvitationRevoked
+{
+    use Dispatchable;
+
+    public function __construct(public readonly OrganizationInvitation $invitation) {}
+}

--- a/app/Http/Controllers/Bapi/OrganizationDomainController.php
+++ b/app/Http/Controllers/Bapi/OrganizationDomainController.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Events\Organizations\OrganizationDomainCreated;
+use App\Events\Organizations\OrganizationDomainDeleted;
+use App\Events\Organizations\OrganizationDomainUpdated;
+use App\Http\Requests\Bapi\Organizations\CreateDomainRequest;
+use App\Http\Requests\Bapi\Organizations\UpdateDomainRequest;
+use App\Http\Resources\OrganizationDomainResource;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationDomain;
+use App\Models\Verification;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * BAPI organization-domains surface (PLAN §3.1, OA-2).
+ *
+ *   GET    /v1/organizations/{organization_id}/domains
+ *   POST   /v1/organizations/{organization_id}/domains
+ *   GET    /v1/organizations/{organization_id}/domains/{domain_id}
+ *   PATCH  /v1/organizations/{organization_id}/domains/{domain_id}
+ *   DELETE /v1/organizations/{organization_id}/domains/{domain_id}
+ *   POST   /v1/organizations/{organization_id}/domains/{domain_id}/verify
+ *
+ * The actual DNS TXT lookup (and the verified=true transition) is owned by
+ * AU-9's domain-verification job. This controller only mints the row + the
+ * paired Verification challenge.
+ */
+final class OrganizationDomainController
+{
+    public const VERIFICATION_TTL_SECONDS = 14 * 24 * 60 * 60;
+
+    public function index(Request $request, string $organizationId): JsonResponse
+    {
+        $org = $this->findOrganization($organizationId);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+
+        $query = OrganizationDomain::query()->where('organization_id', $org->id);
+        if ($request->has('verified')) {
+            $query->where('verified', $request->boolean('verified'));
+        }
+        $query->latest('created_at');
+
+        $limit = max(1, min(500, (int) $request->input('limit', 10)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (OrganizationDomain $d) => OrganizationDomainResource::from($d))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(CreateDomainRequest $request, string $organizationId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = $this->findOrganization($organizationId);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+
+        $name = strtolower((string) $request->input('name'));
+        $duplicate = OrganizationDomain::query()
+            ->where('environment_id', $env->id)
+            ->where('name', $name)
+            ->exists();
+        if ($duplicate) {
+            return $this->error(409, 'form_identifier_exists', 'A domain with that name is already registered in this environment.');
+        }
+
+        [$domain, $verification] = DB::transaction(function () use ($env, $org, $name, $request): array {
+            $domain = OrganizationDomain::create([
+                'environment_id' => $env->id,
+                'organization_id' => $org->id,
+                'name' => $name,
+                'verified' => false,
+                'enrollment_mode' => $request->input('enrollment_mode', OrganizationDomain::MODE_MANUAL_INVITATION),
+                'affiliation_email_address' => $request->input('affiliation_email_address'),
+            ]);
+
+            $verification = $this->issueDnsTxtVerification($env, $domain);
+
+            return [$domain, $verification];
+        });
+
+        OrganizationDomainCreated::dispatch($domain);
+
+        return response()->json(OrganizationDomainResource::from($domain->fresh(), $verification), 201);
+    }
+
+    public function show(string $organizationId, string $domainId): JsonResponse
+    {
+        $domain = $this->find($organizationId, $domainId);
+        if ($domain === null) {
+            return $this->error(404, 'organization_domain_not_found', 'No domain matches that id in this organization.');
+        }
+
+        return response()->json(OrganizationDomainResource::from($domain))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function update(UpdateDomainRequest $request, string $organizationId, string $domainId): JsonResponse
+    {
+        $domain = $this->find($organizationId, $domainId);
+        if ($domain === null) {
+            return $this->error(404, 'organization_domain_not_found', 'No domain matches that id in this organization.');
+        }
+
+        if ($request->has('enrollment_mode')) {
+            $domain->enrollment_mode = (string) $request->input('enrollment_mode');
+        }
+        if ($request->has('affiliation_email_address')) {
+            $domain->affiliation_email_address = $request->input('affiliation_email_address');
+        }
+        $domain->save();
+
+        OrganizationDomainUpdated::dispatch($domain->fresh());
+
+        return response()->json(OrganizationDomainResource::from($domain->fresh()));
+    }
+
+    public function destroy(string $organizationId, string $domainId): JsonResponse
+    {
+        $domain = $this->find($organizationId, $domainId);
+        if ($domain === null) {
+            return $this->error(404, 'organization_domain_not_found', 'No domain matches that id in this organization.');
+        }
+
+        $copy = $domain->replicate();
+        $copy->setRawAttributes($domain->getAttributes(), sync: true);
+
+        $domain->delete();
+
+        OrganizationDomainDeleted::dispatch($copy);
+
+        return response()->json([
+            'object' => 'deleted_object',
+            'id' => $domainId,
+            'deleted' => true,
+        ]);
+    }
+
+    public function verify(string $organizationId, string $domainId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $domain = $this->find($organizationId, $domainId);
+        if ($domain === null) {
+            return $this->error(404, 'organization_domain_not_found', 'No domain matches that id in this organization.');
+        }
+
+        $verification = $this->issueDnsTxtVerification($env, $domain);
+
+        return response()->json(OrganizationDomainResource::from($domain->fresh(), $verification));
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    /**
+     * Mint (or re-mint) a domain_dns_txt Verification carrying a fresh nonce
+     * the operator must publish as a TXT record. The actual DNS lookup is in
+     * AU-9; this issue just keeps the challenge state.
+     */
+    private function issueDnsTxtVerification(Environment $env, OrganizationDomain $domain): Verification
+    {
+        $nonce = 'authn-domain-verify='.Str::lower(Str::random(40));
+
+        $verification = Verification::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'verifiable_type' => $domain->getMorphClass(),
+            'verifiable_id' => $domain->id,
+            'strategy' => Verification::STRATEGY_DOMAIN_DNS_TXT,
+            'status' => Verification::STATUS_UNVERIFIED,
+            'attempts' => 0,
+            'expire_at' => now()->addSeconds(self::VERIFICATION_TTL_SECONDS),
+            'nonce' => $nonce,
+        ]);
+
+        $domain->forceFill(['verification_id' => $verification->id])->save();
+
+        return $verification;
+    }
+
+    private function find(string $organizationId, string $domainId): ?OrganizationDomain
+    {
+        $org = $this->findOrganization($organizationId);
+        if ($org === null) {
+            return null;
+        }
+
+        return OrganizationDomain::query()
+            ->where('organization_id', $org->id)
+            ->where('id', $domainId)
+            ->first();
+    }
+
+    private function findOrganization(string $id): ?Organization
+    {
+        $env = app(Environment::class);
+
+        return Organization::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $id)
+            ->first();
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Controllers/Bapi/OrganizationInvitationController.php
+++ b/app/Http/Controllers/Bapi/OrganizationInvitationController.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Events\Organizations\OrganizationInvitationCreated;
+use App\Events\Organizations\OrganizationInvitationRevoked;
+use App\Http\Requests\Bapi\Organizations\BulkInvitationRequest;
+use App\Http\Requests\Bapi\Organizations\CreateInvitationRequest;
+use App\Http\Resources\OrganizationInvitationResource;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationInvitation;
+use App\Models\Role;
+use App\Models\User;
+use App\Services\Tickets\TicketIssuer;
+use App\Support\Url;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * BAPI organization-invitations surface (PLAN §3.1, OA-2).
+ *
+ *   GET    /v1/organizations/{organization_id}/invitations
+ *   POST   /v1/organizations/{organization_id}/invitations
+ *   POST   /v1/organizations/{organization_id}/invitations/bulk
+ *   POST   /v1/organizations/{organization_id}/invitations/{invitation_id}/revoke
+ */
+final class OrganizationInvitationController
+{
+    public const DEFAULT_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+    public function __construct(private readonly TicketIssuer $tickets) {}
+
+    public function index(Request $request, string $organizationId): JsonResponse
+    {
+        $org = $this->findOrganization($organizationId);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+
+        $query = OrganizationInvitation::query()->where('organization_id', $org->id);
+        if ($request->has('status')) {
+            $query->whereIn('status', (array) $request->input('status'));
+        }
+        if ($request->has('query')) {
+            $needle = '%'.strtolower((string) $request->input('query')).'%';
+            $query->whereRaw('LOWER(email_address) LIKE ?', [$needle]);
+        }
+        $query->latest('created_at');
+
+        $limit = max(1, min(500, (int) $request->input('limit', 10)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->with('role')->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (OrganizationInvitation $i) => OrganizationInvitationResource::from($i, $this->ticketUrl($i)))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(CreateInvitationRequest $request, string $organizationId): JsonResponse
+    {
+        $org = $this->findOrganization($organizationId);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+
+        $env = app(Environment::class);
+        $payload = $request->all();
+        $err = $this->validatePayload($env, $org, $payload);
+        if (is_array($err)) {
+            return $this->error($err['status'], $err['code'], $err['message']);
+        }
+
+        [$invitation, $url] = $this->createOne($env, $org, $payload);
+
+        OrganizationInvitationCreated::dispatch($invitation, $url);
+
+        return response()->json(
+            OrganizationInvitationResource::from($invitation->fresh()->load('role'), $url),
+            201,
+        );
+    }
+
+    public function bulkStore(BulkInvitationRequest $request, string $organizationId): JsonResponse
+    {
+        $org = $this->findOrganization($organizationId);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+
+        $env = app(Environment::class);
+        $rows = (array) $request->input('invitations');
+
+        // Pre-validate the entire batch so failures roll the whole thing back
+        // — partial successes would leave half-baked state for the caller.
+        foreach ($rows as $i => $row) {
+            $err = $this->validatePayload($env, $org, (array) $row);
+            if (is_array($err)) {
+                return response()->json([
+                    'errors' => [[
+                        'code' => $err['code'],
+                        'message' => "Row {$i}: ".$err['message'],
+                        'long_message' => "Row {$i}: ".$err['message'],
+                        'meta' => ['index' => $i],
+                    ]],
+                    'trace_id' => null,
+                ], $err['status']);
+            }
+        }
+
+        try {
+            $created = DB::transaction(function () use ($env, $org, $rows): array {
+                $out = [];
+                foreach ($rows as $row) {
+                    [$invitation, $url] = $this->createOne($env, $org, (array) $row);
+                    $out[] = ['invitation' => $invitation, 'url' => $url];
+                }
+
+                return $out;
+            });
+        } catch (Throwable $e) {
+            return $this->error(422, 'bulk_invitation_failed', $e->getMessage());
+        }
+
+        foreach ($created as $entry) {
+            OrganizationInvitationCreated::dispatch($entry['invitation'], $entry['url']);
+        }
+
+        return response()->json([
+            'object' => 'bulk_organization_invitation_result',
+            'total' => count($created),
+            'created' => count($created),
+            'data' => array_map(
+                fn (array $entry) => OrganizationInvitationResource::from($entry['invitation']->fresh()->load('role'), $entry['url']),
+                $created,
+            ),
+        ], 201);
+    }
+
+    public function revoke(string $organizationId, string $invitationId): JsonResponse
+    {
+        $org = $this->findOrganization($organizationId);
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id in this environment.');
+        }
+
+        $invitation = OrganizationInvitation::query()
+            ->where('organization_id', $org->id)
+            ->where('id', $invitationId)
+            ->first();
+        if ($invitation === null) {
+            return $this->error(404, 'organization_invitation_not_found', 'No invitation matches that id in this organization.');
+        }
+
+        // Idempotent: re-revoking a revoked invitation just returns the row.
+        if ($invitation->status === OrganizationInvitation::STATUS_PENDING) {
+            DB::transaction(function () use ($invitation, $org): void {
+                $invitation->forceFill(['status' => OrganizationInvitation::STATUS_REVOKED])->save();
+                $org->decrement('pending_invitations_count');
+            });
+            OrganizationInvitationRevoked::dispatch($invitation->fresh());
+        }
+
+        return response()->json(OrganizationInvitationResource::from($invitation->fresh()->load('role')));
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    /**
+     * @return array{0: OrganizationInvitation, 1: string}
+     */
+    private function createOne(Environment $env, Organization $org, array $data): array
+    {
+        $email = strtolower((string) ($data['email_address'] ?? ''));
+        $expiresAt = isset($data['expires_at'])
+            ? Carbon::parse($data['expires_at'])
+            : now()->addSeconds(self::DEFAULT_TTL_SECONDS);
+
+        $role = $this->resolveRole($env, (string) ($data['role'] ?? ''));
+
+        $invitation = OrganizationInvitation::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'organization_id' => $org->id,
+            'email_address' => $email,
+            'role_id' => $role?->id,
+            'inviter_user_id' => $data['inviter_user_id'] ?? null,
+            'redirect_url' => $data['redirect_url'] ?? null,
+            'status' => OrganizationInvitation::STATUS_PENDING,
+            'public_metadata' => $data['public_metadata'] ?? [],
+            'expires_at' => $expiresAt,
+        ]);
+
+        $org->increment('pending_invitations_count');
+
+        $jwt = $this->tickets->issue($env, max(60, $expiresAt->getTimestamp() - now()->getTimestamp()), [
+            'sub' => $email,
+            'sid' => $invitation->id,
+            'purpose' => 'organization_invitation',
+            'metadata' => is_array($invitation->public_metadata) ? $invitation->public_metadata : [],
+            'redirect_url' => $invitation->redirect_url,
+        ]);
+
+        return [$invitation, $this->ticketUrlWithJwt($env, $jwt, $invitation->redirect_url)];
+    }
+
+    /**
+     * Returns null when the payload is well-formed; otherwise an error spec.
+     *
+     * @return array{status:int,code:string,message:string}|null
+     */
+    private function validatePayload(Environment $env, Organization $org, array $data): ?array
+    {
+        $email = strtolower((string) ($data['email_address'] ?? ''));
+        if ($email === '') {
+            return ['status' => 422, 'code' => 'form_param_nil', 'message' => 'email_address is required.'];
+        }
+
+        $role = $this->resolveRole($env, (string) ($data['role'] ?? ''));
+        if ($role === null) {
+            return ['status' => 422, 'code' => 'form_param_value_invalid', 'message' => 'role is not a known role key in this environment.'];
+        }
+
+        if (! empty($data['inviter_user_id'])) {
+            $exists = User::query()
+                ->withoutGlobalScopes()
+                ->where('environment_id', $env->id)
+                ->where('id', (string) $data['inviter_user_id'])
+                ->exists();
+            if (! $exists) {
+                return ['status' => 422, 'code' => 'form_param_value_invalid', 'message' => 'inviter_user_id does not match a user in this environment.'];
+            }
+        }
+
+        $duplicate = OrganizationInvitation::query()
+            ->where('organization_id', $org->id)
+            ->where('email_address', $email)
+            ->where('status', OrganizationInvitation::STATUS_PENDING)
+            ->exists();
+        if ($duplicate) {
+            return ['status' => 409, 'code' => 'organization_invitation_already_exists', 'message' => 'A pending invitation for this email already exists in this organization.'];
+        }
+
+        return null;
+    }
+
+    private function findOrganization(string $id): ?Organization
+    {
+        $env = app(Environment::class);
+
+        return Organization::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $id)
+            ->first();
+    }
+
+    private function resolveRole(Environment $env, string $key): ?Role
+    {
+        if ($key === '') {
+            return null;
+        }
+
+        return Role::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('key', $key)
+            ->first();
+    }
+
+    private function ticketUrl(OrganizationInvitation $invitation): string
+    {
+        $env = app(Environment::class);
+        $ttl = $invitation->expires_at !== null
+            ? max(60, $invitation->expires_at->getTimestamp() - now()->getTimestamp())
+            : self::DEFAULT_TTL_SECONDS;
+        $jwt = $this->tickets->issue($env, $ttl, [
+            'sub' => strtolower($invitation->email_address),
+            'sid' => $invitation->id,
+            'purpose' => 'organization_invitation',
+            'metadata' => is_array($invitation->public_metadata) ? $invitation->public_metadata : [],
+            'redirect_url' => $invitation->redirect_url,
+        ]);
+
+        return $this->ticketUrlWithJwt($env, $jwt, $invitation->redirect_url);
+    }
+
+    private function ticketUrlWithJwt(Environment $env, string $jwt, ?string $redirect): string
+    {
+        $base = Url::fapi($env, '');
+        $query = http_build_query(array_filter([
+            '__authn_ticket' => $jwt,
+            '__authn_status' => 'sign_up',
+            'redirect_url' => $redirect,
+        ], fn ($v) => $v !== null && $v !== ''));
+
+        return rtrim($base, '/').'/sign-up?'.$query;
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Requests/Bapi/Organizations/BulkInvitationRequest.php
+++ b/app/Http/Requests/Bapi/Organizations/BulkInvitationRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\Organizations;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class BulkInvitationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'invitations' => ['required', 'array', 'min:1', 'max:100'],
+            'invitations.*.email_address' => ['required', 'email'],
+            'invitations.*.role' => ['required', 'string', 'max:96'],
+            'invitations.*.inviter_user_id' => ['nullable', 'string'],
+            'invitations.*.redirect_url' => ['nullable', 'url'],
+            'invitations.*.public_metadata' => ['nullable', 'array'],
+            'invitations.*.expires_at' => ['nullable', 'date'],
+        ];
+    }
+}

--- a/app/Http/Requests/Bapi/Organizations/CreateDomainRequest.php
+++ b/app/Http/Requests/Bapi/Organizations/CreateDomainRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\Organizations;
+
+use App\Models\OrganizationDomain;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class CreateDomainRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:253', 'regex:/^(?=.{1,253}$)(?!-)[a-z0-9-]{1,63}(\.[a-z0-9-]{1,63})+$/i'],
+            'enrollment_mode' => ['nullable', Rule::in(OrganizationDomain::ENROLLMENT_MODES)],
+            'affiliation_email_address' => ['nullable', 'email'],
+        ];
+    }
+}

--- a/app/Http/Requests/Bapi/Organizations/CreateInvitationRequest.php
+++ b/app/Http/Requests/Bapi/Organizations/CreateInvitationRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\Organizations;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class CreateInvitationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email_address' => ['required', 'email'],
+            'role' => ['required', 'string', 'max:96'],
+            'inviter_user_id' => ['nullable', 'string'],
+            'redirect_url' => ['nullable', 'url'],
+            'public_metadata' => ['nullable', 'array'],
+            'expires_at' => ['nullable', 'date'],
+        ];
+    }
+}

--- a/app/Http/Requests/Bapi/Organizations/UpdateDomainRequest.php
+++ b/app/Http/Requests/Bapi/Organizations/UpdateDomainRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\Organizations;
+
+use App\Models\OrganizationDomain;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class UpdateDomainRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'enrollment_mode' => ['sometimes', Rule::in(OrganizationDomain::ENROLLMENT_MODES)],
+            'affiliation_email_address' => ['sometimes', 'nullable', 'email'],
+        ];
+    }
+}

--- a/app/Http/Resources/OrganizationDomainResource.php
+++ b/app/Http/Resources/OrganizationDomainResource.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\OrganizationDomain;
+use App\Models\Verification;
+
+final class OrganizationDomainResource
+{
+    public static function from(OrganizationDomain $domain, ?Verification $verification = null): array
+    {
+        $verification ??= $domain->verification_id !== null
+            ? Verification::query()->withoutGlobalScopes()->where('id', $domain->verification_id)->first()
+            : null;
+
+        return [
+            'object' => 'organization_domain',
+            'id' => $domain->id,
+            'organization_id' => $domain->organization_id,
+            'name' => $domain->name,
+            'verified' => (bool) $domain->verified,
+            'enrollment_mode' => $domain->enrollment_mode,
+            'affiliation_email_address' => $domain->affiliation_email_address,
+            'total_pending_invitations' => (int) $domain->total_pending_invitations,
+            'total_pending_suggestions' => (int) $domain->total_pending_suggestions,
+            'verification' => $verification !== null ? [
+                'object' => 'verification',
+                'id' => $verification->id,
+                'strategy' => $verification->strategy,
+                'status' => $verification->status,
+                'attempts' => (int) $verification->attempts,
+                'expire_at' => $verification->expire_at?->getTimestampMs(),
+                'nonce' => $verification->nonce,
+            ] : null,
+            'created_at' => $domain->created_at?->getTimestampMs(),
+            'updated_at' => $domain->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/app/Http/Resources/OrganizationInvitationResource.php
+++ b/app/Http/Resources/OrganizationInvitationResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\OrganizationInvitation;
+
+final class OrganizationInvitationResource
+{
+    public static function from(OrganizationInvitation $invitation, ?string $url = null): array
+    {
+        $role = $invitation->role;
+
+        return [
+            'object' => 'organization_invitation',
+            'id' => $invitation->id,
+            'organization_id' => $invitation->organization_id,
+            'email_address' => $invitation->email_address,
+            'role' => $role?->key,
+            'role_name' => $role?->name,
+            'inviter_user_id' => $invitation->inviter_user_id,
+            'redirect_url' => $invitation->redirect_url,
+            'status' => $invitation->status,
+            'public_metadata' => is_array($invitation->public_metadata) ? $invitation->public_metadata : [],
+            'url' => $url,
+            'expires_at' => $invitation->expires_at?->getTimestampMs(),
+            'created_at' => $invitation->created_at?->getTimestampMs(),
+            'updated_at' => $invitation->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/app/Models/Verification.php
+++ b/app/Models/Verification.php
@@ -75,6 +75,8 @@ class Verification extends Model
 
     public const STRATEGY_TICKET = 'ticket';
 
+    public const STRATEGY_DOMAIN_DNS_TXT = 'domain_dns_txt';
+
     public const V0_1_STRATEGIES = [
         self::STRATEGY_PASSWORD,
         self::STRATEGY_EMAIL_CODE,

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -7,6 +7,8 @@ use App\Http\Controllers\Bapi\BlocklistIdentifiersController;
 use App\Http\Controllers\Bapi\InstanceController;
 use App\Http\Controllers\Bapi\InvitationsController;
 use App\Http\Controllers\Bapi\OrganizationController;
+use App\Http\Controllers\Bapi\OrganizationDomainController;
+use App\Http\Controllers\Bapi\OrganizationInvitationController;
 use App\Http\Controllers\Bapi\OrganizationMembershipController;
 use App\Http\Controllers\Bapi\PingController;
 use App\Http\Controllers\Bapi\RedirectUrlsController;
@@ -100,6 +102,18 @@ Route::get('/organizations/{organization_id}/memberships', [OrganizationMembersh
 Route::post('/organizations/{organization_id}/memberships', [OrganizationMembershipController::class, 'store'])->middleware(RateLimit::class.':orgs.members.create,60,60')->name('bapi.organizations.memberships.store');
 Route::patch('/organizations/{organization_id}/memberships/{user_id}', [OrganizationMembershipController::class, 'update'])->middleware(RateLimit::class.':orgs.members.update,60,60')->name('bapi.organizations.memberships.update');
 Route::delete('/organizations/{organization_id}/memberships/{user_id}', [OrganizationMembershipController::class, 'destroy'])->middleware(RateLimit::class.':orgs.members.destroy,60,60')->name('bapi.organizations.memberships.destroy');
+
+Route::get('/organizations/{organization_id}/invitations', [OrganizationInvitationController::class, 'index'])->middleware(RateLimit::class.':orgs.invites.list,300,60')->name('bapi.organizations.invitations.index');
+Route::post('/organizations/{organization_id}/invitations', [OrganizationInvitationController::class, 'store'])->middleware(RateLimit::class.':orgs.invites.create,60,60')->name('bapi.organizations.invitations.store');
+Route::post('/organizations/{organization_id}/invitations/bulk', [OrganizationInvitationController::class, 'bulkStore'])->middleware(RateLimit::class.':orgs.invites.bulk,5,60')->name('bapi.organizations.invitations.bulk');
+Route::post('/organizations/{organization_id}/invitations/{invitation_id}/revoke', [OrganizationInvitationController::class, 'revoke'])->middleware(RateLimit::class.':orgs.invites.action,60,60')->name('bapi.organizations.invitations.revoke');
+
+Route::get('/organizations/{organization_id}/domains', [OrganizationDomainController::class, 'index'])->middleware(RateLimit::class.':orgs.domains.list,300,60')->name('bapi.organizations.domains.index');
+Route::post('/organizations/{organization_id}/domains', [OrganizationDomainController::class, 'store'])->middleware(RateLimit::class.':orgs.domains.create,30,60')->name('bapi.organizations.domains.store');
+Route::get('/organizations/{organization_id}/domains/{domain_id}', [OrganizationDomainController::class, 'show'])->middleware(RateLimit::class.':orgs.domains.read,300,60')->name('bapi.organizations.domains.show');
+Route::patch('/organizations/{organization_id}/domains/{domain_id}', [OrganizationDomainController::class, 'update'])->middleware(RateLimit::class.':orgs.domains.update,60,60')->name('bapi.organizations.domains.update');
+Route::delete('/organizations/{organization_id}/domains/{domain_id}', [OrganizationDomainController::class, 'destroy'])->middleware(RateLimit::class.':orgs.domains.destroy,30,60')->name('bapi.organizations.domains.destroy');
+Route::post('/organizations/{organization_id}/domains/{domain_id}/verify', [OrganizationDomainController::class, 'verify'])->middleware(RateLimit::class.':orgs.domains.verify,30,60')->name('bapi.organizations.domains.verify');
 
 // Instance settings
 Route::get('/instance', [InstanceController::class, 'show'])->middleware(RateLimit::class.':instance.read,300,60');

--- a/tests/Feature/Http/Bapi/OrganizationDomainsTest.php
+++ b/tests/Feature/Http/Bapi/OrganizationDomainsTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\Organizations\OrganizationDomainCreated;
+use App\Events\Organizations\OrganizationDomainDeleted;
+use App\Events\Organizations\OrganizationDomainUpdated;
+use App\Models\Environment;
+use App\Models\OrganizationDomain;
+use App\Models\Verification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+use Tests\TestCase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * @return array{env: Environment, headers: array, org_id: string}
+ */
+function setupOrgForDomains(TestCase $testCase): array
+{
+    $f = BapiTestSupport::bootEnv();
+    $headers = BapiTestSupport::headers($f['token']);
+    $r = $testCase->withHeaders($headers)->postJson(BapiTestSupport::url('/organizations'), ['name' => 'Acme']);
+
+    return [
+        'env' => $f['env'],
+        'headers' => $headers,
+        'org_id' => $r->json('id'),
+    ];
+}
+
+it('POST /domains creates a domain, mints a domain_dns_txt Verification, fires the event', function (): void {
+    Event::fake([OrganizationDomainCreated::class]);
+    $ctx = setupOrgForDomains($this);
+
+    $r = $this->withHeaders($ctx['headers'])->postJson(
+        BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"),
+        ['name' => 'acme.test', 'enrollment_mode' => 'automatic_invitation', 'affiliation_email_address' => 'verify@acme.test'],
+    );
+
+    $r->assertStatus(201)
+        ->assertJsonPath('object', 'organization_domain')
+        ->assertJsonPath('name', 'acme.test')
+        ->assertJsonPath('enrollment_mode', 'automatic_invitation')
+        ->assertJsonPath('verified', false)
+        ->assertJsonPath('verification.strategy', 'domain_dns_txt')
+        ->assertJsonPath('verification.status', 'unverified');
+    expect($r->json('id'))->toStartWith('orgdom_');
+    expect($r->json('verification.nonce'))->toStartWith('authn-domain-verify=');
+
+    $verificationId = $r->json('verification.id');
+    expect(Verification::query()->withoutGlobalScopes()->where('id', $verificationId)->exists())->toBeTrue();
+
+    Event::assertDispatched(OrganizationDomainCreated::class, 1);
+});
+
+it('POST /domains 409s on a duplicate domain name in the same env', function (): void {
+    $ctx = setupOrgForDomains($this);
+    $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'dup.test'])->assertStatus(201);
+    $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'dup.test'])->assertStatus(409);
+});
+
+it('POST /domains 422s on a malformed name', function (): void {
+    $ctx = setupOrgForDomains($this);
+    $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'not a domain'])->assertStatus(422);
+});
+
+it('GET /domains lists rows scoped to the org', function (): void {
+    $ctx = setupOrgForDomains($this);
+    foreach (['a.test', 'b.test'] as $name) {
+        $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => $name])->assertStatus(201);
+    }
+    $r = $this->withHeaders($ctx['headers'])->getJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"));
+    $r->assertOk()->assertJsonPath('total_count', 2);
+});
+
+it('GET /domains/{id} returns the verification block', function (): void {
+    $ctx = setupOrgForDomains($this);
+    $created = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'show.test']);
+    $id = $created->json('id');
+
+    $r = $this->withHeaders($ctx['headers'])->getJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}"));
+    $r->assertOk()->assertJsonPath('verification.strategy', 'domain_dns_txt');
+});
+
+it('PATCH /domains/{id} updates enrollment_mode and fires the event', function (): void {
+    Event::fake([OrganizationDomainUpdated::class]);
+    $ctx = setupOrgForDomains($this);
+    $created = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'patch.test']);
+    $id = $created->json('id');
+
+    $r = $this->withHeaders($ctx['headers'])->patchJson(
+        BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}"),
+        ['enrollment_mode' => 'automatic_suggestion'],
+    );
+    $r->assertOk()->assertJsonPath('enrollment_mode', 'automatic_suggestion');
+    Event::assertDispatched(OrganizationDomainUpdated::class, 1);
+});
+
+it('POST /domains/{id}/verify re-issues a fresh Verification with a new nonce', function (): void {
+    $ctx = setupOrgForDomains($this);
+    $created = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'verify.test']);
+    $id = $created->json('id');
+    $firstVerificationId = $created->json('verification.id');
+    $firstNonce = $created->json('verification.nonce');
+
+    $r = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}/verify"));
+    $r->assertOk();
+    expect($r->json('verification.id'))->not->toBe($firstVerificationId);
+    expect($r->json('verification.nonce'))->not->toBe($firstNonce);
+    expect($r->json('verification.strategy'))->toBe('domain_dns_txt');
+});
+
+it('DELETE /domains/{id} removes the row and fires the event', function (): void {
+    Event::fake([OrganizationDomainDeleted::class]);
+    $ctx = setupOrgForDomains($this);
+    $created = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'delete.test']);
+    $id = $created->json('id');
+
+    $r = $this->withHeaders($ctx['headers'])->deleteJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}"));
+    $r->assertOk()->assertJsonPath('deleted', true);
+    expect(OrganizationDomain::query()->withoutGlobalScopes()->where('id', $id)->exists())->toBeFalse();
+    Event::assertDispatched(OrganizationDomainDeleted::class, 1);
+});
+
+it('GET /domains/{id} 404s across env boundaries', function (): void {
+    $a = BapiTestSupport::bootEnv('aaa');
+    $r = $this->withHeaders(BapiTestSupport::headers($a['token']))
+        ->postJson(BapiTestSupport::url('/organizations'), ['name' => 'Only A']);
+    $orgId = $r->json('id');
+    $created = $this->withHeaders(BapiTestSupport::headers($a['token']))
+        ->postJson(BapiTestSupport::url("/organizations/{$orgId}/domains"), ['name' => 'only-a.test']);
+    $domainId = $created->json('id');
+
+    $b = BapiTestSupport::bootEnv('bbb');
+    $this->withHeaders(BapiTestSupport::headers($b['token']))
+        ->getJson(BapiTestSupport::url("/organizations/{$orgId}/domains/{$domainId}"))->assertStatus(404);
+});

--- a/tests/Feature/Http/Bapi/OrganizationInvitationsTest.php
+++ b/tests/Feature/Http/Bapi/OrganizationInvitationsTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\Organizations\OrganizationInvitationCreated;
+use App\Events\Organizations\OrganizationInvitationRevoked;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationInvitation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+use Tests\TestCase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * @return array{env: Environment, headers: array, org_id: string}
+ */
+function setupOrgForInvitations(TestCase $testCase): array
+{
+    $f = BapiTestSupport::bootEnv();
+    $headers = BapiTestSupport::headers($f['token']);
+    $r = $testCase->withHeaders($headers)->postJson(BapiTestSupport::url('/organizations'), ['name' => 'Acme']);
+
+    return [
+        'env' => $f['env'],
+        'headers' => $headers,
+        'org_id' => $r->json('id'),
+    ];
+}
+
+it('POST /invitations creates a pending invitation, fires the event, returns a ticket url', function (): void {
+    Event::fake([OrganizationInvitationCreated::class]);
+    $ctx = setupOrgForInvitations($this);
+
+    $r = $this->withHeaders($ctx['headers'])->postJson(
+        BapiTestSupport::url("/organizations/{$ctx['org_id']}/invitations"),
+        [
+            'email_address' => 'invitee@example.com',
+            'role' => 'org:member',
+            'redirect_url' => 'https://app.example.com/welcome',
+            'public_metadata' => ['team' => 'engineering'],
+        ],
+    );
+
+    $r->assertStatus(201)
+        ->assertJsonPath('object', 'organization_invitation')
+        ->assertJsonPath('email_address', 'invitee@example.com')
+        ->assertJsonPath('role', 'org:member')
+        ->assertJsonPath('status', 'pending')
+        ->assertJsonPath('public_metadata.team', 'engineering');
+    expect($r->json('id'))->toStartWith('orginv_');
+    expect($r->json('url'))->toContain('__authn_ticket=')->toContain('__authn_status=sign_up');
+
+    $org = Organization::query()->withoutGlobalScopes()->where('id', $ctx['org_id'])->firstOrFail();
+    expect($org->pending_invitations_count)->toBe(1);
+
+    Event::assertDispatched(OrganizationInvitationCreated::class, 1);
+});
+
+it('POST /invitations 422s on unknown role key', function (): void {
+    $ctx = setupOrgForInvitations($this);
+    $this->withHeaders($ctx['headers'])->postJson(
+        BapiTestSupport::url("/organizations/{$ctx['org_id']}/invitations"),
+        ['email_address' => 'a@example.com', 'role' => 'org:nonsense'],
+    )->assertStatus(422);
+});
+
+it('POST /invitations 409s on duplicate active invitation for the same email', function (): void {
+    $ctx = setupOrgForInvitations($this);
+    $body = ['email_address' => 'dup@example.com', 'role' => 'org:member'];
+
+    $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/invitations"), $body)->assertStatus(201);
+    $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/invitations"), $body)->assertStatus(409);
+});
+
+it('GET /invitations supports status + query filters', function (): void {
+    $ctx = setupOrgForInvitations($this);
+    foreach (['alpha@example.com', 'beta@example.com'] as $email) {
+        $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/invitations"), [
+            'email_address' => $email,
+            'role' => 'org:member',
+        ])->assertStatus(201);
+    }
+
+    $r = $this->withHeaders($ctx['headers'])->getJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/invitations?status=pending&query=alpha"));
+    $r->assertOk()->assertJsonPath('total_count', 1);
+});
+
+it('POST /invitations/{id}/revoke flips status, fires the event, idempotent on re-revoke', function (): void {
+    Event::fake([OrganizationInvitationRevoked::class]);
+    $ctx = setupOrgForInvitations($this);
+    $created = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/invitations"), [
+        'email_address' => 'revoke-me@example.com',
+        'role' => 'org:member',
+    ]);
+    $id = $created->json('id');
+
+    $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/invitations/{$id}/revoke"))
+        ->assertOk()->assertJsonPath('status', 'revoked');
+
+    $org = Organization::query()->withoutGlobalScopes()->where('id', $ctx['org_id'])->firstOrFail();
+    expect($org->pending_invitations_count)->toBe(0);
+
+    // Re-revoke is a no-op (still 200).
+    $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/invitations/{$id}/revoke"))
+        ->assertOk()->assertJsonPath('status', 'revoked');
+
+    Event::assertDispatched(OrganizationInvitationRevoked::class, 1);
+});
+
+it('POST /invitations/bulk creates all rows atomically', function (): void {
+    Event::fake([OrganizationInvitationCreated::class]);
+    $ctx = setupOrgForInvitations($this);
+
+    $r = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/invitations/bulk"), [
+        'invitations' => [
+            ['email_address' => 'one@example.com', 'role' => 'org:member'],
+            ['email_address' => 'two@example.com', 'role' => 'org:admin'],
+            ['email_address' => 'three@example.com', 'role' => 'org:member'],
+        ],
+    ]);
+    $r->assertStatus(201)
+        ->assertJsonPath('total', 3)
+        ->assertJsonPath('created', 3);
+
+    $org = Organization::query()->withoutGlobalScopes()->where('id', $ctx['org_id'])->firstOrFail();
+    expect($org->pending_invitations_count)->toBe(3);
+    Event::assertDispatched(OrganizationInvitationCreated::class, 3);
+});
+
+it('POST /invitations/bulk rolls everything back when one row fails', function (): void {
+    Event::fake([OrganizationInvitationCreated::class]);
+    $ctx = setupOrgForInvitations($this);
+
+    $r = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/invitations/bulk"), [
+        'invitations' => [
+            ['email_address' => 'good@example.com', 'role' => 'org:member'],
+            ['email_address' => 'bad@example.com', 'role' => 'org:nonsense'], // unknown role key
+        ],
+    ]);
+    $r->assertStatus(422);
+
+    expect(OrganizationInvitation::query()->where('organization_id', $ctx['org_id'])->count())->toBe(0);
+    Event::assertNotDispatched(OrganizationInvitationCreated::class);
+});
+
+it('POST /invitations 401s without a key', function (): void {
+    BapiTestSupport::bootEnv();
+    $this->withHeaders(['Host' => 'api.authn.local', 'Accept' => 'application/json'])
+        ->postJson(BapiTestSupport::url('/organizations/org_doesnotexist/invitations'), ['email_address' => 'a@example.com', 'role' => 'org:member'])
+        ->assertStatus(401);
+});
+
+it('POST /invitations 404s for an org that lives in a different env', function (): void {
+    $a = BapiTestSupport::bootEnv('aaa');
+    $r = $this->withHeaders(BapiTestSupport::headers($a['token']))
+        ->postJson(BapiTestSupport::url('/organizations'), ['name' => 'Only A']);
+    $orgId = $r->json('id');
+
+    $b = BapiTestSupport::bootEnv('bbb');
+    $this->withHeaders(BapiTestSupport::headers($b['token']))
+        ->postJson(BapiTestSupport::url("/organizations/{$orgId}/invitations"), ['email_address' => 'x@example.com', 'role' => 'org:member'])
+        ->assertStatus(404);
+});


### PR DESCRIPTION
## Summary

Second slice of the privileged org-admin BAPI surface — 10 new routes:

**Invitations (4):**
- `index / store / bulkStore / revoke` under `/v1/organizations/{org}/invitations`.
- `store` mints a `__authn_ticket` JWT (purpose=`organization_invitation`) via the existing TicketIssuer, embeds it in the response `url` with `__authn_status=sign_up`, dispatches `OrganizationInvitationCreated` carrying the URL so AU-14's email worker doesn't re-issue.
- `bulkStore` is wholesale-atomic: pre-validate every row, run inserts inside a single DB transaction, roll back on any failure.
- `revoke` flips `pending → revoked`, decrements `pending_invitations_count`, idempotent on re-revoke.
- 409 `organization_invitation_already_exists` for duplicate active invitations on the same `(org, email)`.

**Domains (6):**
- `index / store / show / update / destroy / verify` under `/v1/organizations/{org}/domains`.
- `store` and `verify` mint a `Verification` row with the new `STRATEGY_DOMAIN_DNS_TXT` strategy and a fresh nonce (`authn-domain-verify=…`). The DNS lookup itself is AU-9.
- 409 on duplicate `(env, name)` and 422 on a malformed FQDN.

Events (`OrganizationInvitationCreated|Revoked`, `OrganizationDomainCreated|Updated|Deleted`) are plain Dispatchable holders for AU-11.

## Test plan

- [x] `OrganizationInvitationsTest`: happy-path create + url shape + counter cache; unknown role 422; duplicate-active 409; status + query filters; revoke (idempotent) + counter decrement; bulk happy + atomic rollback; 401 without key; cross-env 404. 9 tests.
- [x] `OrganizationDomainsTest`: create mints a domain_dns_txt Verification with a fresh nonce; duplicate-name 409; malformed-name 422; index scope; show; update enrollment_mode + event; verify re-issues a fresh Verification (new id + nonce); delete + cascade; cross-env 404. 9 tests.
- [x] Full Pest suite passes (361 tests).
- [x] `vendor/bin/pint --test` clean.

Closes #38