### PR TITLE
BAPI roles + permissions endpoints (AU-5)

### DIFF
--- a/app/Events/Organizations/RoleCreated.php
+++ b/app/Events/Organizations/RoleCreated.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\Role;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class RoleCreated
+{
+    use Dispatchable;
+
+    public function __construct(public readonly Role $role) {}
+}

--- a/app/Events/Organizations/RoleDeleted.php
+++ b/app/Events/Organizations/RoleDeleted.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\Role;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class RoleDeleted
+{
+    use Dispatchable;
+
+    public function __construct(public readonly Role $role) {}
+}

--- a/app/Events/Organizations/RolePermissionsChanged.php
+++ b/app/Events/Organizations/RolePermissionsChanged.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\Role;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class RolePermissionsChanged
+{
+    use Dispatchable;
+
+    /**
+     * @param  list<string>  $permissionKeys
+     */
+    public function __construct(
+        public readonly Role $role,
+        public readonly array $permissionKeys,
+    ) {}
+}

--- a/app/Events/Organizations/RoleUpdated.php
+++ b/app/Events/Organizations/RoleUpdated.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\Role;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class RoleUpdated
+{
+    use Dispatchable;
+
+    public function __construct(public readonly Role $role) {}
+}

--- a/app/Http/Controllers/Bapi/PermissionController.php
+++ b/app/Http/Controllers/Bapi/PermissionController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Http\Resources\PermissionResource;
+use App\Models\Environment;
+use App\Models\Permission;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Read-only BAPI permissions surface — v0.2 only ships system-defined
+ * permissions (seeded by AU-2). Operator-defined permissions are out of
+ * scope; every Permission row carries `is_system: true`.
+ *
+ *   GET /v1/permissions
+ */
+final class PermissionController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $query = Permission::query()->withoutGlobalScopes()->where('environment_id', $env->id);
+        if ($request->has('is_system')) {
+            $query->where('is_system', $request->boolean('is_system'));
+        }
+        $query->orderBy('key');
+
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (Permission $p) => PermissionResource::from($p))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+}

--- a/app/Http/Controllers/Bapi/RoleController.php
+++ b/app/Http/Controllers/Bapi/RoleController.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Events\Organizations\RoleCreated;
+use App\Events\Organizations\RoleDeleted;
+use App\Events\Organizations\RolePermissionsChanged;
+use App\Events\Organizations\RoleUpdated;
+use App\Http\Requests\Bapi\Roles\CreateRoleRequest;
+use App\Http\Requests\Bapi\Roles\SetPermissionsRequest;
+use App\Http\Requests\Bapi\Roles\UpdateRoleRequest;
+use App\Http\Resources\RoleResource;
+use App\Models\Environment;
+use App\Models\OrganizationMembership;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Services\Tenancy\RoleSeeder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * BAPI roles surface (PLAN §4.5, OA-2). System rows seeded by AU-2 are
+ * read-only here; operators can mint custom roles and bind any subset
+ * of system permissions to them.
+ *
+ *   GET    /v1/roles
+ *   POST   /v1/roles
+ *   GET    /v1/roles/{role_id}
+ *   PATCH  /v1/roles/{role_id}
+ *   DELETE /v1/roles/{role_id}
+ *   PUT    /v1/roles/{role_id}/permissions
+ */
+final class RoleController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $query = Role::query()->withoutGlobalScopes()->where('environment_id', $env->id);
+
+        if ($request->has('is_system')) {
+            $query->where('is_system', $request->boolean('is_system'));
+        }
+        $query->orderBy('is_system', 'desc')->orderBy('key');
+
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->with('permissions')->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (Role $r) => RoleResource::from($r))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(CreateRoleRequest $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $key = (string) $request->input('key');
+
+        if (in_array($key, [RoleSeeder::ROLE_ADMIN, RoleSeeder::ROLE_MEMBER], true)) {
+            return $this->error(409, 'role_key_reserved', 'That role key is reserved for system roles.');
+        }
+        $duplicate = Role::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('key', $key)
+            ->exists();
+        if ($duplicate) {
+            return $this->error(409, 'form_identifier_exists', 'A role with that key already exists in this environment.');
+        }
+
+        $permissionIds = $this->resolvePermissionIds($env, (array) $request->input('permissions', []));
+        if ($permissionIds === false) {
+            return $this->error(422, 'form_param_value_invalid', 'One or more permission keys are unknown in this environment.');
+        }
+
+        $role = DB::transaction(function () use ($env, $key, $request, $permissionIds): Role {
+            $row = Role::create([
+                'environment_id' => $env->id,
+                'key' => $key,
+                'name' => (string) $request->input('name'),
+                'description' => $request->input('description'),
+                'is_creator_eligible' => $request->boolean('is_creator_eligible', false),
+                'is_default' => false,
+                'is_system' => false,
+            ]);
+            if (! empty($permissionIds)) {
+                $row->permissions()->sync($permissionIds);
+            }
+
+            return $row;
+        });
+
+        RoleCreated::dispatch($role->fresh());
+
+        return response()->json(RoleResource::from($role->fresh()->load('permissions')), 201);
+    }
+
+    public function show(string $roleId): JsonResponse
+    {
+        $role = $this->find($roleId);
+        if ($role === null) {
+            return $this->error(404, 'role_not_found', 'No role matches that id in this environment.');
+        }
+
+        return response()->json(RoleResource::from($role->load('permissions')))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function update(UpdateRoleRequest $request, string $roleId): JsonResponse
+    {
+        $role = $this->find($roleId);
+        if ($role === null) {
+            return $this->error(404, 'role_not_found', 'No role matches that id in this environment.');
+        }
+        if ($role->is_system) {
+            return $this->error(422, 'role_is_system', 'System roles are read-only.');
+        }
+
+        if ($request->has('name')) {
+            $role->name = (string) $request->input('name');
+        }
+        if ($request->has('description')) {
+            $role->description = $request->input('description');
+        }
+        if ($request->has('is_creator_eligible')) {
+            $role->is_creator_eligible = $request->boolean('is_creator_eligible');
+        }
+        $role->save();
+
+        RoleUpdated::dispatch($role->fresh());
+
+        return response()->json(RoleResource::from($role->fresh()->load('permissions')));
+    }
+
+    public function destroy(string $roleId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $role = $this->find($roleId);
+        if ($role === null) {
+            return $this->error(404, 'role_not_found', 'No role matches that id in this environment.');
+        }
+        if ($role->is_system) {
+            return $this->error(422, 'role_is_system', 'System roles cannot be deleted.');
+        }
+        if ($role->is_default) {
+            return $this->error(422, 'role_is_default', 'The default role cannot be deleted (would orphan the default).');
+        }
+
+        $defaultRole = Role::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('is_default', true)
+            ->first();
+        if ($defaultRole === null) {
+            return $this->error(422, 'role_no_default', 'Environment has no default role to reassign memberships to.');
+        }
+
+        DB::transaction(function () use ($role, $defaultRole): void {
+            OrganizationMembership::query()
+                ->where('role_id', $role->id)
+                ->update(['role_id' => $defaultRole->id]);
+            $role->delete();
+        });
+
+        RoleDeleted::dispatch($role);
+
+        return response()->json([
+            'object' => 'deleted_object',
+            'id' => $roleId,
+            'deleted' => true,
+        ]);
+    }
+
+    public function setPermissions(SetPermissionsRequest $request, string $roleId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $role = $this->find($roleId);
+        if ($role === null) {
+            return $this->error(404, 'role_not_found', 'No role matches that id in this environment.');
+        }
+        if ($role->is_system) {
+            return $this->error(422, 'role_is_system', 'System roles are read-only.');
+        }
+
+        $permissionIds = $this->resolvePermissionIds($env, (array) $request->input('permissions', []));
+        if ($permissionIds === false) {
+            return $this->error(422, 'form_param_value_invalid', 'One or more permission keys are unknown in this environment.');
+        }
+
+        DB::transaction(function () use ($role, $permissionIds): void {
+            $role->permissions()->sync($permissionIds);
+        });
+
+        $fresh = $role->fresh()->load('permissions');
+        RolePermissionsChanged::dispatch($fresh, $fresh->permissions->pluck('key')->all());
+
+        return response()->json(RoleResource::from($fresh));
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    private function find(string $id): ?Role
+    {
+        $env = app(Environment::class);
+
+        return Role::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $id)
+            ->first();
+    }
+
+    /**
+     * @param  list<string>  $keys
+     * @return list<string>|false list of Permission ids, or false when any key is unknown.
+     */
+    private function resolvePermissionIds(Environment $env, array $keys): array|false
+    {
+        if (empty($keys)) {
+            return [];
+        }
+        $rows = Permission::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->whereIn('key', $keys)
+            ->get();
+        if ($rows->count() !== count(array_unique($keys))) {
+            return false;
+        }
+
+        return $rows->pluck('id')->all();
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Requests/Bapi/Roles/CreateRoleRequest.php
+++ b/app/Http/Requests/Bapi/Roles/CreateRoleRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\Roles;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class CreateRoleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'key' => ['required', 'string', 'regex:/^org:[a-z][a-z0-9_]{2,63}$/'],
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:512'],
+            'is_creator_eligible' => ['nullable', 'boolean'],
+            'permissions' => ['nullable', 'array'],
+            'permissions.*' => ['string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Bapi/Roles/SetPermissionsRequest.php
+++ b/app/Http/Requests/Bapi/Roles/SetPermissionsRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\Roles;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class SetPermissionsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'permissions' => ['present', 'array'],
+            'permissions.*' => ['string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Bapi/Roles/UpdateRoleRequest.php
+++ b/app/Http/Requests/Bapi/Roles/UpdateRoleRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\Roles;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class UpdateRoleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'string', 'max:255'],
+            'description' => ['sometimes', 'nullable', 'string', 'max:512'],
+            'is_creator_eligible' => ['sometimes', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Resources/PermissionResource.php
+++ b/app/Http/Resources/PermissionResource.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Permission;
+
+final class PermissionResource
+{
+    public static function from(Permission $permission): array
+    {
+        return [
+            'object' => 'permission',
+            'id' => $permission->id,
+            'key' => $permission->key,
+            'name' => $permission->name,
+            'description' => $permission->description,
+            'is_system' => (bool) $permission->is_system,
+            'created_at' => $permission->created_at?->getTimestampMs(),
+            'updated_at' => $permission->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/app/Http/Resources/RoleResource.php
+++ b/app/Http/Resources/RoleResource.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Role;
+
+final class RoleResource
+{
+    public static function from(Role $role): array
+    {
+        return [
+            'object' => 'role',
+            'id' => $role->id,
+            'key' => $role->key,
+            'name' => $role->name,
+            'description' => $role->description,
+            'is_creator_eligible' => (bool) $role->is_creator_eligible,
+            'is_default' => (bool) $role->is_default,
+            'is_system' => (bool) $role->is_system,
+            'permissions' => $role->permissions->pluck('key')->values()->all(),
+            'created_at' => $role->created_at?->getTimestampMs(),
+            'updated_at' => $role->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -10,8 +10,10 @@ use App\Http\Controllers\Bapi\OrganizationController;
 use App\Http\Controllers\Bapi\OrganizationDomainController;
 use App\Http\Controllers\Bapi\OrganizationInvitationController;
 use App\Http\Controllers\Bapi\OrganizationMembershipController;
+use App\Http\Controllers\Bapi\PermissionController;
 use App\Http\Controllers\Bapi\PingController;
 use App\Http\Controllers\Bapi\RedirectUrlsController;
+use App\Http\Controllers\Bapi\RoleController;
 use App\Http\Controllers\Bapi\SessionsController;
 use App\Http\Controllers\Bapi\UsersController;
 use App\Http\Controllers\Bapi\WebhookDeliveriesController;
@@ -114,6 +116,16 @@ Route::get('/organizations/{organization_id}/domains/{domain_id}', [Organization
 Route::patch('/organizations/{organization_id}/domains/{domain_id}', [OrganizationDomainController::class, 'update'])->middleware(RateLimit::class.':orgs.domains.update,60,60')->name('bapi.organizations.domains.update');
 Route::delete('/organizations/{organization_id}/domains/{domain_id}', [OrganizationDomainController::class, 'destroy'])->middleware(RateLimit::class.':orgs.domains.destroy,30,60')->name('bapi.organizations.domains.destroy');
 Route::post('/organizations/{organization_id}/domains/{domain_id}/verify', [OrganizationDomainController::class, 'verify'])->middleware(RateLimit::class.':orgs.domains.verify,30,60')->name('bapi.organizations.domains.verify');
+
+// Roles + Permissions
+Route::get('/roles', [RoleController::class, 'index'])->middleware(RateLimit::class.':roles.list,300,60')->name('bapi.roles.index');
+Route::post('/roles', [RoleController::class, 'store'])->middleware(RateLimit::class.':roles.create,30,60')->name('bapi.roles.store');
+Route::get('/roles/{role_id}', [RoleController::class, 'show'])->middleware(RateLimit::class.':roles.read,300,60')->name('bapi.roles.show');
+Route::patch('/roles/{role_id}', [RoleController::class, 'update'])->middleware(RateLimit::class.':roles.update,60,60')->name('bapi.roles.update');
+Route::delete('/roles/{role_id}', [RoleController::class, 'destroy'])->middleware(RateLimit::class.':roles.destroy,30,60')->name('bapi.roles.destroy');
+Route::put('/roles/{role_id}/permissions', [RoleController::class, 'setPermissions'])->middleware(RateLimit::class.':roles.permissions,60,60')->name('bapi.roles.permissions.set');
+
+Route::get('/permissions', [PermissionController::class, 'index'])->middleware(RateLimit::class.':permissions.list,300,60')->name('bapi.permissions.index');
 
 // Instance settings
 Route::get('/instance', [InstanceController::class, 'show'])->middleware(RateLimit::class.':instance.read,300,60');

--- a/tests/Feature/Http/Bapi/RolesTest.php
+++ b/tests/Feature/Http/Bapi/RolesTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\Organizations\RoleCreated;
+use App\Events\Organizations\RoleDeleted;
+use App\Events\Organizations\RolePermissionsChanged;
+use App\Events\Organizations\RoleUpdated;
+use App\Models\Environment;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+
+uses(RefreshDatabase::class);
+
+it('GET /v1/roles lists system roles seeded by AU-2', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))->getJson(BapiTestSupport::url('/roles'));
+    $r->assertOk();
+    $keys = array_column($r->json('data'), 'key');
+    expect($keys)->toContain('org:admin', 'org:member');
+});
+
+it('GET /v1/roles?is_system=false returns nothing on a fresh env', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))->getJson(BapiTestSupport::url('/roles?is_system=false'));
+    $r->assertOk()->assertJsonPath('total_count', 0);
+});
+
+it('POST /v1/roles creates a custom role with permissions and fires RoleCreated', function (): void {
+    Event::fake([RoleCreated::class]);
+    $f = BapiTestSupport::bootEnv();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))->postJson(BapiTestSupport::url('/roles'), [
+        'key' => 'org:billing_admin',
+        'name' => 'Billing admin',
+        'description' => 'Manages org billing',
+        'permissions' => ['org:sys_billing:read', 'org:sys_billing:manage'],
+    ]);
+    $r->assertStatus(201)
+        ->assertJsonPath('object', 'role')
+        ->assertJsonPath('key', 'org:billing_admin')
+        ->assertJsonPath('is_system', false);
+    expect($r->json('permissions'))->toContain('org:sys_billing:read', 'org:sys_billing:manage');
+    Event::assertDispatched(RoleCreated::class, 1);
+});
+
+it('POST /v1/roles 409s when key is reserved (org:admin / org:member)', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $headers = BapiTestSupport::headers($f['token']);
+
+    $this->withHeaders($headers)->postJson(BapiTestSupport::url('/roles'), [
+        'key' => 'org:admin', 'name' => 'X',
+    ])->assertStatus(409);
+    $this->withHeaders($headers)->postJson(BapiTestSupport::url('/roles'), [
+        'key' => 'org:member', 'name' => 'X',
+    ])->assertStatus(409);
+});
+
+it('POST /v1/roles 422s on a malformed key', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $this->withHeaders(BapiTestSupport::headers($f['token']))->postJson(BapiTestSupport::url('/roles'), [
+        'key' => 'BAD', 'name' => 'X',
+    ])->assertStatus(422);
+});
+
+it('POST /v1/roles 422s on unknown permission keys', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $this->withHeaders(BapiTestSupport::headers($f['token']))->postJson(BapiTestSupport::url('/roles'), [
+        'key' => 'org:custom_one', 'name' => 'X',
+        'permissions' => ['org:sys_billing:read', 'org:nonsense:thing'],
+    ])->assertStatus(422);
+});
+
+it('PATCH /v1/roles/{id} updates name + description, fires RoleUpdated', function (): void {
+    Event::fake([RoleUpdated::class]);
+    $f = BapiTestSupport::bootEnv();
+    $headers = BapiTestSupport::headers($f['token']);
+    $created = $this->withHeaders($headers)->postJson(BapiTestSupport::url('/roles'), [
+        'key' => 'org:custom', 'name' => 'Old',
+    ]);
+    $id = $created->json('id');
+
+    $r = $this->withHeaders($headers)->patchJson(BapiTestSupport::url("/roles/{$id}"), [
+        'name' => 'New',
+        'description' => 'Custom role',
+    ]);
+    $r->assertOk()->assertJsonPath('name', 'New')->assertJsonPath('description', 'Custom role');
+    Event::assertDispatched(RoleUpdated::class, 1);
+});
+
+it('PATCH refuses to mutate system roles', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $admin = Role::withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:admin')->firstOrFail();
+    $this->withHeaders(BapiTestSupport::headers($f['token']))->patchJson(BapiTestSupport::url("/roles/{$admin->id}"), [
+        'name' => 'Hacked',
+    ])->assertStatus(422);
+});
+
+it('DELETE refuses to delete system roles', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $admin = Role::withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:admin')->firstOrFail();
+    $this->withHeaders(BapiTestSupport::headers($f['token']))->deleteJson(BapiTestSupport::url("/roles/{$admin->id}"))->assertStatus(422);
+});
+
+it('DELETE reassigns memberships to the env default role', function (): void {
+    Event::fake([RoleDeleted::class]);
+    /** @var Environment $env */
+    $f = BapiTestSupport::bootEnv();
+    $env = $f['env'];
+    $headers = BapiTestSupport::headers($f['token']);
+
+    $created = $this->withHeaders($headers)->postJson(BapiTestSupport::url('/roles'), [
+        'key' => 'org:custom_role', 'name' => 'Custom',
+    ]);
+    $customRoleId = $created->json('id');
+
+    $org = $this->withHeaders($headers)->postJson(BapiTestSupport::url('/organizations'), ['name' => 'Acme'])->json('id');
+    $user = new User(['environment_id' => $env->id, 'username' => 'reassign']);
+    $user->save();
+    $membership = OrganizationMembership::create([
+        'environment_id' => $env->id,
+        'organization_id' => $org,
+        'user_id' => $user->id,
+        'role_id' => $customRoleId,
+    ]);
+
+    $this->withHeaders($headers)->deleteJson(BapiTestSupport::url("/roles/{$customRoleId}"))
+        ->assertOk()->assertJsonPath('deleted', true);
+
+    $defaultRole = Role::withoutGlobalScopes()->where('environment_id', $env->id)->where('is_default', true)->firstOrFail();
+    expect($membership->fresh()->role_id)->toBe($defaultRole->id);
+    Event::assertDispatched(RoleDeleted::class, 1);
+});
+
+it('PUT /v1/roles/{id}/permissions replaces the permission set in one transaction', function (): void {
+    Event::fake([RolePermissionsChanged::class]);
+    $f = BapiTestSupport::bootEnv();
+    $headers = BapiTestSupport::headers($f['token']);
+    $created = $this->withHeaders($headers)->postJson(BapiTestSupport::url('/roles'), [
+        'key' => 'org:permset', 'name' => 'PermSet',
+        'permissions' => ['org:sys_billing:read'],
+    ]);
+    $id = $created->json('id');
+
+    $r = $this->withHeaders($headers)->putJson(BapiTestSupport::url("/roles/{$id}/permissions"), [
+        'permissions' => ['org:sys_profile:read', 'org:sys_profile:manage'],
+    ]);
+    $r->assertOk();
+    expect($r->json('permissions'))
+        ->toContain('org:sys_profile:read', 'org:sys_profile:manage')
+        ->not->toContain('org:sys_billing:read');
+    Event::assertDispatched(RolePermissionsChanged::class, 1);
+});
+
+it('PUT /permissions on a system role 422s', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $admin = Role::withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:admin')->firstOrFail();
+    $this->withHeaders(BapiTestSupport::headers($f['token']))->putJson(BapiTestSupport::url("/roles/{$admin->id}/permissions"), [
+        'permissions' => [],
+    ])->assertStatus(422);
+});
+
+it('GET /v1/permissions returns the seeded system permissions', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))->getJson(BapiTestSupport::url('/permissions'));
+    $r->assertOk()->assertJsonPath('total_count', 13);
+    expect(array_column($r->json('data'), 'key'))->toContain(
+        'org:sys_profile:read', 'org:sys_profile:manage', 'org:sys_profile:delete',
+        'org:sys_memberships:manage', 'org:sys_billing:manage',
+    );
+});
+
+it('GET /v1/permissions?is_system=false returns nothing on a fresh env', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))->getJson(BapiTestSupport::url('/permissions?is_system=false'));
+    $r->assertOk()->assertJsonPath('total_count', 0);
+});


### PR DESCRIPTION
## Summary

Closes the BAPI v0.2 surface with the seven roles/permissions routes:

- `GET /v1/roles` (filter: `is_system`)
- `POST /v1/roles` — custom roles only; rejects `org:admin` / `org:member` as reserved (409); enforces `^org:[a-z][a-z0-9_]{2,63}$` key shape
- `GET /v1/roles/{id}`
- `PATCH /v1/roles/{id}` — `name + description + is_creator_eligible` only; `key` is immutable; refuses system rows (422)
- `DELETE /v1/roles/{id}` — inside a transaction, reassigns every membership using the role to the env-default role (`org:member`) then deletes; refuses `is_system` / `is_default` rows
- `PUT /v1/roles/{id}/permissions` — replaces the permission set in one transaction; refuses system rows
- `GET /v1/permissions` — read-only (every `Permission` row is `is_system: true` in v0.2)

`RoleResource` exposes `permissions[]` (keys). Four new events (`RoleCreated|Updated|Deleted`, `RolePermissionsChanged` carrying the new key list) for AU-11.

## Test plan

- [x] `RolesTest`: list seeded system roles; filter by `is_system`; create custom role + permissions; reserved-key 409; malformed-key 422; unknown-permission 422; PATCH happy + system-row refusal; DELETE refuses system / default / reassigns memberships; PUT permissions replaces atomically; PUT on system role 422; GET /permissions returns 13 rows. 14 tests.
- [x] Full Pest suite passes (375 tests).
- [x] `vendor/bin/pint --test` clean.

Closes #39