### PR TITLE
FAPI organizations + memberships endpoints (AU-6)

### DIFF
--- a/app/Http/Controllers/Fapi/OrganizationController.php
+++ b/app/Http/Controllers/Fapi/OrganizationController.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Events\Organizations\OrganizationCreated;
+use App\Events\Organizations\OrganizationDeleted;
+use App\Events\Organizations\OrganizationMembershipCreated;
+use App\Events\Organizations\OrganizationMembershipDeleted;
+use App\Events\Organizations\OrganizationUpdated;
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\OrganizationResource;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\User;
+use App\Services\Tenancy\RoleSeeder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * FAPI organization surface (PLAN §4.4, OA-3). End-user-facing CRUD scoped
+ * to the authenticated session.
+ *
+ *   POST   /v1/organizations
+ *   GET    /v1/organizations/{organization_id}            (member only)
+ *   PATCH  /v1/organizations/{organization_id}            (org:sys_profile:manage)
+ *   DELETE /v1/organizations/{organization_id}            (org:sys_profile:delete)
+ *   POST   /v1/organizations/{organization_id}/leave
+ */
+final class OrganizationController
+{
+    public function store(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $user = app(User::class);
+
+        $orgSettings = $this->organizationSettings($env);
+        if (($orgSettings['allow_user_created_organizations'] ?? true) === false) {
+            return $this->error(403, 'organization_creation_disabled', 'User-created organizations are disabled in this environment.');
+        }
+        $maxPerUser = $orgSettings['max_organizations_per_user'] ?? null;
+        if (is_int($maxPerUser) && $maxPerUser >= 0) {
+            $owned = $user->memberships()
+                ->whereHas('role', fn ($q) => $q->where('key', RoleSeeder::ROLE_ADMIN))
+                ->count();
+            if ($owned >= $maxPerUser) {
+                return $this->error(422, 'organization_quota_exceeded', 'You have reached the maximum number of organizations.');
+            }
+        }
+
+        $name = $request->input('name');
+        if (! is_string($name) || $name === '') {
+            return $this->error(422, 'form_param_nil', 'name is required.');
+        }
+        $slug = $request->filled('slug') ? (string) $request->input('slug') : $this->slugify($name);
+        if (! preg_match('/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/', $slug)) {
+            return $this->error(422, 'form_param_format_invalid', 'slug must be lowercase alphanumeric with dashes.');
+        }
+
+        $duplicate = Organization::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('slug', $slug)
+            ->exists();
+        if ($duplicate) {
+            return $this->error(409, 'form_identifier_exists', 'An organization with that slug already exists.');
+        }
+
+        $creatorRoleKey = $orgSettings['creator_role'] ?? RoleSeeder::ROLE_ADMIN;
+        $creatorRole = Role::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('key', $creatorRoleKey)
+            ->first();
+        if ($creatorRole === null) {
+            return $this->error(422, 'organization_creator_role_missing', "The configured creator_role `{$creatorRoleKey}` is not seeded.");
+        }
+
+        [$org, $membership] = DB::transaction(function () use ($env, $user, $name, $slug, $request, $creatorRole): array {
+            $org = Organization::create([
+                'environment_id' => $env->id,
+                'name' => $name,
+                'slug' => $slug,
+                'created_by_user_id' => $user->id,
+                'public_metadata' => $request->input('public_metadata') ?? [],
+                'private_metadata' => $request->input('private_metadata') ?? [],
+            ]);
+            $membership = OrganizationMembership::create([
+                'environment_id' => $env->id,
+                'organization_id' => $org->id,
+                'user_id' => $user->id,
+                'role_id' => $creatorRole->id,
+            ]);
+            $org->increment('members_count');
+
+            return [$org->fresh(), $membership];
+        });
+
+        OrganizationCreated::dispatch($org);
+        OrganizationMembershipCreated::dispatch($membership);
+
+        return $this->envelope(OrganizationResource::from($org), 201);
+    }
+
+    public function show(): JsonResponse
+    {
+        // EnsureOrgPermission(:org:sys_profile:read) already gated this and bound Organization.
+        $org = app(Organization::class);
+
+        return response()->json(OrganizationResource::from($org))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function update(Request $request): JsonResponse
+    {
+        $org = app(Organization::class);
+        $env = app(Environment::class);
+
+        if ($request->has('name') && is_string($request->input('name'))) {
+            $org->name = (string) $request->input('name');
+        }
+        if ($request->has('slug')) {
+            $newSlug = (string) $request->input('slug');
+            if (! preg_match('/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/', $newSlug)) {
+                return $this->error(422, 'form_param_format_invalid', 'slug must be lowercase alphanumeric with dashes.');
+            }
+            if ($newSlug !== $org->slug) {
+                $duplicate = Organization::query()
+                    ->withoutGlobalScopes()
+                    ->where('environment_id', $env->id)
+                    ->where('slug', $newSlug)
+                    ->where('id', '!=', $org->id)
+                    ->exists();
+                if ($duplicate) {
+                    return $this->error(409, 'form_identifier_exists', 'An organization with that slug already exists.');
+                }
+                $org->slug = $newSlug;
+            }
+        }
+        if ($request->has('public_metadata') && is_array($request->input('public_metadata'))) {
+            $org->public_metadata = $request->input('public_metadata');
+        }
+        $org->save();
+
+        OrganizationUpdated::dispatch($org->fresh());
+
+        return $this->envelope(OrganizationResource::from($org->fresh()));
+    }
+
+    public function destroy(): JsonResponse
+    {
+        $org = app(Organization::class);
+        if (! $org->admin_delete_enabled) {
+            return $this->error(422, 'organization_admin_delete_disabled', 'Admin delete is disabled for this organization.');
+        }
+
+        $copy = $org->replicate();
+        $copy->setRawAttributes($org->getAttributes(), sync: true);
+        $org->delete();
+
+        OrganizationDeleted::dispatch($copy);
+
+        return $this->envelope([
+            'object' => 'deleted_object',
+            'id' => $org->id,
+            'deleted' => true,
+        ]);
+    }
+
+    public function leave(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $user = app(User::class);
+        $organizationId = (string) $request->route('organization_id');
+
+        $org = Organization::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $organizationId)
+            ->first();
+        if ($org === null) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id.');
+        }
+
+        $membership = OrganizationMembership::query()
+            ->where('organization_id', $org->id)
+            ->where('user_id', $user->id)
+            ->first();
+        if ($membership === null) {
+            return $this->error(404, 'organization_membership_not_found', 'You are not a member of this organization.');
+        }
+
+        if (
+            $membership->role?->key === RoleSeeder::ROLE_ADMIN
+            && $this->countAdmins($org) <= 1
+        ) {
+            return $this->error(422, 'organization_last_admin', 'Cannot leave as the last admin of an organization.');
+        }
+
+        DB::transaction(function () use ($org, $membership): void {
+            $membership->delete();
+            $org->decrement('members_count');
+        });
+
+        OrganizationMembershipDeleted::dispatch($membership);
+
+        return $this->envelope([
+            'object' => 'deleted_object',
+            'id' => $membership->id,
+            'deleted' => true,
+        ]);
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    private function organizationSettings(Environment $env): array
+    {
+        $settings = is_array($env->user_settings) ? $env->user_settings : [];
+        $org = $settings['organization_settings'] ?? [];
+
+        return is_array($org) ? $org : [];
+    }
+
+    private function countAdmins(Organization $org): int
+    {
+        return OrganizationMembership::query()
+            ->where('organization_id', $org->id)
+            ->whereHas('role', fn ($q) => $q->where('key', RoleSeeder::ROLE_ADMIN))
+            ->count();
+    }
+
+    private function slugify(string $name): string
+    {
+        $slug = Str::slug($name);
+        if ($slug === '') {
+            $slug = 'org-'.Str::lower(Str::random(8));
+        }
+
+        return Str::limit($slug, 60, '');
+    }
+
+    private function envelope(mixed $response, int $status = 200): JsonResponse
+    {
+        $client = app()->bound(Client::class) ? app(Client::class) : null;
+
+        return response()->json([
+            'response' => $response,
+            'client' => ClientResource::from($client?->fresh()),
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Controllers/Fapi/OrganizationMembershipController.php
+++ b/app/Http/Controllers/Fapi/OrganizationMembershipController.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Events\Organizations\OrganizationInvitationCreated;
+use App\Events\Organizations\OrganizationMembershipDeleted;
+use App\Events\Organizations\OrganizationMembershipUpdated;
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\OrganizationInvitationResource;
+use App\Http\Resources\OrganizationMembershipResource;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationInvitation;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\User;
+use App\Services\Tenancy\RoleSeeder;
+use App\Services\Tickets\TicketIssuer;
+use App\Support\Url;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * FAPI organization-memberships surface (PLAN §4.4, OA-3).
+ *
+ *   GET    /v1/organizations/{organization_id}/memberships
+ *   POST   /v1/organizations/{organization_id}/memberships    (issues an invitation)
+ *   PATCH  /v1/organizations/{organization_id}/memberships/{user_id}
+ *   DELETE /v1/organizations/{organization_id}/memberships/{user_id}
+ */
+final class OrganizationMembershipController
+{
+    public const INVITATION_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+    public function __construct(private readonly TicketIssuer $tickets) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $org = app(Organization::class);
+
+        $query = OrganizationMembership::query()->where('organization_id', $org->id);
+        $orderBy = (string) $request->input('order_by', '-created_at');
+        $direction = str_starts_with($orderBy, '-') ? 'desc' : 'asc';
+        $column = ltrim($orderBy, '-+');
+        $query->orderBy(in_array($column, ['created_at', 'updated_at'], true) ? $column : 'created_at', $direction);
+
+        $limit = max(1, min(500, (int) $request->input('limit', 10)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->with(['user', 'role.permissions'])->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (OrganizationMembership $m) => OrganizationMembershipResource::from($m))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = app(Organization::class);
+        $user = app(User::class);
+
+        $email = $request->input('email_address');
+        $roleKey = $request->input('role');
+        if (! is_string($email) || $email === '') {
+            return $this->error(422, 'form_param_nil', 'email_address is required.');
+        }
+        if (! is_string($roleKey) || $roleKey === '') {
+            return $this->error(422, 'form_param_nil', 'role is required.');
+        }
+
+        $role = Role::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('key', $roleKey)
+            ->first();
+        if ($role === null) {
+            return $this->error(422, 'form_param_value_invalid', 'role is not a known role key in this environment.');
+        }
+
+        $email = strtolower($email);
+        $duplicate = OrganizationInvitation::query()
+            ->where('organization_id', $org->id)
+            ->where('email_address', $email)
+            ->where('status', OrganizationInvitation::STATUS_PENDING)
+            ->exists();
+        if ($duplicate) {
+            return $this->error(409, 'organization_invitation_already_exists', 'A pending invitation for this email already exists.');
+        }
+
+        $expiresAt = now()->addSeconds(self::INVITATION_TTL_SECONDS);
+
+        $invitation = DB::transaction(function () use ($env, $org, $user, $email, $role, $expiresAt, $request): OrganizationInvitation {
+            $row = OrganizationInvitation::query()->withoutGlobalScopes()->create([
+                'environment_id' => $env->id,
+                'organization_id' => $org->id,
+                'email_address' => $email,
+                'role_id' => $role->id,
+                'inviter_user_id' => $user->id,
+                'redirect_url' => $request->input('redirect_url'),
+                'status' => OrganizationInvitation::STATUS_PENDING,
+                'public_metadata' => $request->input('public_metadata') ?? [],
+                'expires_at' => $expiresAt,
+            ]);
+            $org->increment('pending_invitations_count');
+
+            return $row;
+        });
+
+        $jwt = $this->tickets->issue($env, max(60, $expiresAt->getTimestamp() - now()->getTimestamp()), [
+            'sub' => $email,
+            'sid' => $invitation->id,
+            'purpose' => 'organization_invitation',
+            'metadata' => is_array($invitation->public_metadata) ? $invitation->public_metadata : [],
+            'redirect_url' => $invitation->redirect_url,
+        ]);
+        $url = $this->ticketUrl($env, $jwt, $invitation->redirect_url);
+
+        OrganizationInvitationCreated::dispatch($invitation, $url);
+
+        return $this->envelope(OrganizationInvitationResource::from($invitation->fresh()->load('role'), $url), 201);
+    }
+
+    public function update(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = app(Organization::class);
+        $userId = (string) $request->route('user_id');
+
+        $membership = OrganizationMembership::query()
+            ->where('organization_id', $org->id)
+            ->where('user_id', $userId)
+            ->first();
+        if ($membership === null) {
+            return $this->error(404, 'organization_membership_not_found', 'No membership matches that user in this organization.');
+        }
+
+        $roleKey = $request->input('role');
+        if (! is_string($roleKey) || $roleKey === '') {
+            return $this->error(422, 'form_param_nil', 'role is required.');
+        }
+        $role = Role::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('key', $roleKey)
+            ->first();
+        if ($role === null) {
+            return $this->error(422, 'form_param_value_invalid', 'role is not a known role key in this environment.');
+        }
+
+        if (
+            $membership->role?->key === RoleSeeder::ROLE_ADMIN
+            && $role->key !== RoleSeeder::ROLE_ADMIN
+            && $this->countAdmins($org) <= 1
+        ) {
+            return $this->error(422, 'organization_last_admin', 'Cannot demote the last admin of an organization.');
+        }
+
+        $membership->role_id = $role->id;
+        $membership->save();
+
+        OrganizationMembershipUpdated::dispatch($membership->fresh());
+
+        return $this->envelope(OrganizationMembershipResource::from(
+            $membership->fresh()->load(['user', 'role.permissions']),
+        ));
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $org = app(Organization::class);
+        $userId = (string) $request->route('user_id');
+        $membership = OrganizationMembership::query()
+            ->where('organization_id', $org->id)
+            ->where('user_id', $userId)
+            ->first();
+        if ($membership === null) {
+            return $this->error(404, 'organization_membership_not_found', 'No membership matches that user in this organization.');
+        }
+
+        if (
+            $membership->role?->key === RoleSeeder::ROLE_ADMIN
+            && $this->countAdmins($org) <= 1
+        ) {
+            return $this->error(422, 'organization_last_admin', 'Cannot remove the last admin of an organization.');
+        }
+
+        DB::transaction(function () use ($org, $membership): void {
+            $membership->delete();
+            $org->decrement('members_count');
+        });
+
+        OrganizationMembershipDeleted::dispatch($membership);
+
+        return $this->envelope([
+            'object' => 'deleted_object',
+            'id' => $membership->id,
+            'deleted' => true,
+        ]);
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    private function countAdmins(Organization $org): int
+    {
+        return OrganizationMembership::query()
+            ->where('organization_id', $org->id)
+            ->whereHas('role', fn ($q) => $q->where('key', RoleSeeder::ROLE_ADMIN))
+            ->count();
+    }
+
+    private function ticketUrl(Environment $env, string $jwt, ?string $redirect): string
+    {
+        $base = Url::fapi($env, '');
+        $query = http_build_query(array_filter([
+            '__authn_ticket' => $jwt,
+            '__authn_status' => 'sign_up',
+            'redirect_url' => $redirect,
+        ], fn ($v) => $v !== null && $v !== ''));
+
+        return rtrim($base, '/').'/sign-up?'.$query;
+    }
+
+    private function envelope(mixed $response, int $status = 200): JsonResponse
+    {
+        $client = app()->bound(Client::class) ? app(Client::class) : null;
+
+        return response()->json([
+            'response' => $response,
+            'client' => ClientResource::from($client?->fresh()),
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Middleware/EnsureOrgPermission.php
+++ b/app/Http/Middleware/EnsureOrgPermission.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * FAPI permission gate: requires the bound User to hold a system
+ * permission (e.g. `org:sys_memberships:manage`) inside the Organization
+ * named by the `organization_id` route parameter.
+ *
+ * Usage in route definitions:
+ *
+ *   Route::patch('/organizations/{organization_id}', ...)
+ *       ->middleware(EnsureOrgPermission::class.':org:sys_profile:manage');
+ *
+ * Resolution order:
+ *   1. Resolve the Organization from the route param. Non-member callers
+ *      get a 404 organization_not_found instead of a 403 to avoid
+ *      leaking the existence of a private org (PLAN §4.4 privacy default).
+ *   2. Run User::hasOrgPermission(); on miss return 403.
+ *
+ * Binds the resolved Organization into the container so controllers can
+ * read it via `app(Organization::class)` without a second lookup.
+ */
+final class EnsureOrgPermission
+{
+    public function handle(Request $request, Closure $next, string $permission): Response
+    {
+        $env = app()->bound(Environment::class) ? app(Environment::class) : null;
+        $user = app()->bound(User::class) ? app(User::class) : null;
+        if (! $env instanceof Environment || ! $user instanceof User) {
+            return $this->error(401, 'authentication_required', 'Authentication required.');
+        }
+
+        $organizationId = $request->route('organization_id');
+        if (! is_string($organizationId) || $organizationId === '') {
+            return $this->error(400, 'organization_id_required', 'Route is missing the organization_id parameter.');
+        }
+
+        $org = Organization::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $organizationId)
+            ->first();
+
+        if ($org === null || ! $user->memberships()->where('organization_id', $org->id)->exists()) {
+            return $this->error(404, 'organization_not_found', 'No organization matches that id.');
+        }
+
+        if (! $user->hasOrgPermission($permission, $org)) {
+            return $this->error(403, 'authorization_invalid', 'You do not have permission to perform this action on this organization.');
+        }
+
+        app()->instance(Organization::class, $org);
+
+        return $next($request);
+    }
+
+    private function error(int $status, string $code, string $message): Response
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\AccountPortal\AccountPortalController;
 use App\Http\Controllers\Fapi\ClientController;
 use App\Http\Controllers\Fapi\EnvironmentController;
 use App\Http\Controllers\Fapi\MeController;
+use App\Http\Controllers\Fapi\OrganizationController as FapiOrganizationController;
+use App\Http\Controllers\Fapi\OrganizationMembershipController as FapiOrganizationMembershipController;
 use App\Http\Controllers\Fapi\PingController;
 use App\Http\Controllers\Fapi\SessionsController;
 use App\Http\Controllers\Fapi\SessionTokenController;
@@ -15,6 +17,7 @@ use App\Http\Controllers\WellKnown\JwksController;
 use App\Http\Controllers\WellKnown\OpenIdConfigurationController;
 use App\Http\Middleware\AuthenticateSessionToken;
 use App\Http\Middleware\EnforceFapiOrigin;
+use App\Http\Middleware\EnsureOrgPermission;
 use App\Http\Middleware\HandleAccountPortalInertia;
 use App\Http\Middleware\ResolveClientFromCookie;
 use App\Models\Environment;
@@ -100,6 +103,32 @@ Route::prefix('v1')->group(function (): void {
 
         Route::get('/me/sessions', [MeController::class, 'listSessions'])->name('fapi.me.sessions.list');
         Route::post('/me/change_password', [MeController::class, 'changePassword'])->name('fapi.me.change_password');
+
+        // Organizations — user-scoped CRUD (PLAN §4.4 / OA-3 / AU-6).
+        Route::post('/organizations', [FapiOrganizationController::class, 'store'])->name('fapi.organizations.store');
+        Route::post('/organizations/{organization_id}/leave', [FapiOrganizationController::class, 'leave'])->name('fapi.organizations.leave');
+        Route::get('/organizations/{organization_id}', [FapiOrganizationController::class, 'show'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_profile:read')
+            ->name('fapi.organizations.show');
+        Route::patch('/organizations/{organization_id}', [FapiOrganizationController::class, 'update'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_profile:manage')
+            ->name('fapi.organizations.update');
+        Route::delete('/organizations/{organization_id}', [FapiOrganizationController::class, 'destroy'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_profile:delete')
+            ->name('fapi.organizations.destroy');
+
+        Route::get('/organizations/{organization_id}/memberships', [FapiOrganizationMembershipController::class, 'index'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_memberships:read')
+            ->name('fapi.organizations.memberships.index');
+        Route::post('/organizations/{organization_id}/memberships', [FapiOrganizationMembershipController::class, 'store'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_memberships:manage')
+            ->name('fapi.organizations.memberships.store');
+        Route::patch('/organizations/{organization_id}/memberships/{user_id}', [FapiOrganizationMembershipController::class, 'update'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_memberships:manage')
+            ->name('fapi.organizations.memberships.update');
+        Route::delete('/organizations/{organization_id}/memberships/{user_id}', [FapiOrganizationMembershipController::class, 'destroy'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_memberships:manage')
+            ->name('fapi.organizations.memberships.destroy');
     });
 });
 

--- a/tests/Feature/Http/Fapi/OrganizationsTest.php
+++ b/tests/Feature/Http/Fapi/OrganizationsTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\Organizations\OrganizationCreated;
+use App\Events\Organizations\OrganizationDeleted;
+use App\Events\Organizations\OrganizationMembershipDeleted;
+use App\Events\Organizations\OrganizationMembershipUpdated;
+use App\Events\Organizations\OrganizationUpdated;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+uses(RefreshDatabase::class);
+
+function fapiOrgReq(string $method, string $path, string $jwt, array $body = [], string $origin = 'https://app.example.com'): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => $origin,
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+function fapiAddMembership(Environment $env, string $orgId, User $user, string $roleKey): OrganizationMembership
+{
+    $role = Role::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('key', $roleKey)
+        ->firstOrFail();
+
+    $row = OrganizationMembership::create([
+        'environment_id' => $env->id,
+        'organization_id' => $orgId,
+        'user_id' => $user->id,
+        'role_id' => $role->id,
+    ]);
+    Organization::query()->withoutGlobalScopes()->where('id', $orgId)->increment('members_count');
+
+    return $row;
+}
+
+it('POST /v1/organizations creates an org + admin membership and wraps the response in {client, response}', function (): void {
+    Event::fake([OrganizationCreated::class]);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = fapiOrgReq('POST', '/organizations', $auth['jwt'], [
+        'name' => 'Acme Inc',
+        'slug' => 'acme-fapi',
+    ]);
+
+    $r->assertStatus(201)
+        ->assertJsonPath('response.object', 'organization')
+        ->assertJsonPath('response.name', 'Acme Inc')
+        ->assertJsonPath('response.slug', 'acme-fapi')
+        ->assertJsonPath('client.object', 'client');
+    expect($r->json('response.id'))->toStartWith('org_');
+
+    // Creator is auto-bound to the org:admin role.
+    $orgId = $r->json('response.id');
+    $membership = OrganizationMembership::query()->where('organization_id', $orgId)->firstOrFail();
+    expect($membership->user_id)->toBe($auth['user']->id);
+    expect($membership->role->key)->toBe('org:admin');
+
+    Event::assertDispatched(OrganizationCreated::class, 1);
+});
+
+it('POST /v1/organizations 403s when allow_user_created_organizations is false', function (): void {
+    $f = MeTestSupport::bootEnv(userSettings: [
+        'organization_settings' => ['allow_user_created_organizations' => false],
+    ]);
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    fapiOrgReq('POST', '/organizations', $auth['jwt'], ['name' => 'Acme'])
+        ->assertStatus(403)
+        ->assertJsonPath('errors.0.code', 'organization_creation_disabled');
+});
+
+it('POST /v1/organizations 422s when max_organizations_per_user is reached', function (): void {
+    $f = MeTestSupport::bootEnv(userSettings: [
+        'organization_settings' => ['max_organizations_per_user' => 1],
+    ]);
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    fapiOrgReq('POST', '/organizations', $auth['jwt'], ['name' => 'First'])->assertStatus(201);
+    fapiOrgReq('POST', '/organizations', $auth['jwt'], ['name' => 'Second'])
+        ->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'organization_quota_exceeded');
+});
+
+it('GET /v1/organizations/{id} returns 404 to non-members (privacy default)', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    // Create an org that the auth user is NOT a member of.
+    $other = new User(['environment_id' => $f['env']->id, 'username' => 'other']);
+    $other->save();
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Private', 'slug' => 'private']);
+    fapiAddMembership($f['env'], $org->id, $other, 'org:admin');
+
+    fapiOrgReq('GET', "/organizations/{$org->id}", $auth['jwt'])
+        ->assertStatus(404)
+        ->assertJsonPath('errors.0.code', 'organization_not_found');
+});
+
+it('GET /v1/organizations/{id} returns the org for a member', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    fapiAddMembership($f['env'], $org->id, $auth['user'], 'org:member');
+
+    fapiOrgReq('GET', "/organizations/{$org->id}", $auth['jwt'])
+        ->assertOk()
+        ->assertJsonPath('object', 'organization')
+        ->assertJsonPath('id', $org->id);
+});
+
+it('PATCH /v1/organizations/{id} 403s without org:sys_profile:manage (member only)', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    fapiAddMembership($f['env'], $org->id, $auth['user'], 'org:member');
+
+    fapiOrgReq('PATCH', "/organizations/{$org->id}", $auth['jwt'], ['name' => 'Hacked'])
+        ->assertStatus(403)
+        ->assertJsonPath('errors.0.code', 'authorization_invalid');
+});
+
+it('PATCH /v1/organizations/{id} succeeds for an admin and fires OrganizationUpdated', function (): void {
+    Event::fake([OrganizationUpdated::class]);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    fapiAddMembership($f['env'], $org->id, $auth['user'], 'org:admin');
+
+    $r = fapiOrgReq('PATCH', "/organizations/{$org->id}", $auth['jwt'], ['name' => 'Renamed']);
+    $r->assertOk()->assertJsonPath('response.name', 'Renamed');
+    Event::assertDispatched(OrganizationUpdated::class, 1);
+});
+
+it('DELETE /v1/organizations/{id} succeeds for an admin', function (): void {
+    Event::fake([OrganizationDeleted::class]);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    fapiAddMembership($f['env'], $org->id, $auth['user'], 'org:admin');
+
+    $r = fapiOrgReq('DELETE', "/organizations/{$org->id}", $auth['jwt']);
+    $r->assertOk()->assertJsonPath('response.deleted', true);
+    expect(Organization::query()->withoutGlobalScopes()->where('id', $org->id)->exists())->toBeFalse();
+    Event::assertDispatched(OrganizationDeleted::class, 1);
+});
+
+it('POST /v1/organizations/{id}/leave removes the caller membership', function (): void {
+    Event::fake([OrganizationMembershipDeleted::class]);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $admin = new User(['environment_id' => $f['env']->id, 'username' => 'other-admin']);
+    $admin->save();
+
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    fapiAddMembership($f['env'], $org->id, $admin, 'org:admin');
+    fapiAddMembership($f['env'], $org->id, $auth['user'], 'org:member');
+
+    $r = fapiOrgReq('POST', "/organizations/{$org->id}/leave", $auth['jwt']);
+    $r->assertOk()->assertJsonPath('response.deleted', true);
+    expect(OrganizationMembership::query()->where('organization_id', $org->id)->where('user_id', $auth['user']->id)->exists())->toBeFalse();
+    Event::assertDispatched(OrganizationMembershipDeleted::class, 1);
+});
+
+it('POST /v1/organizations/{id}/leave 422s for the last admin', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    fapiAddMembership($f['env'], $org->id, $auth['user'], 'org:admin');
+
+    fapiOrgReq('POST', "/organizations/{$org->id}/leave", $auth['jwt'])
+        ->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'organization_last_admin');
+});
+
+it('POST /v1/organizations/{id}/memberships issues an invitation (not a direct membership)', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    fapiAddMembership($f['env'], $org->id, $auth['user'], 'org:admin');
+
+    $r = fapiOrgReq('POST', "/organizations/{$org->id}/memberships", $auth['jwt'], [
+        'email_address' => 'invitee@example.com',
+        'role' => 'org:member',
+    ]);
+    $r->assertStatus(201)
+        ->assertJsonPath('response.object', 'organization_invitation')
+        ->assertJsonPath('response.email_address', 'invitee@example.com');
+    expect($r->json('response.url'))->toContain('__authn_ticket=');
+});
+
+it('PATCH /v1/organizations/{id}/memberships/{user_id} updates role', function (): void {
+    Event::fake([OrganizationMembershipUpdated::class]);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $other = new User(['environment_id' => $f['env']->id, 'username' => 'other']);
+    $other->save();
+
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    fapiAddMembership($f['env'], $org->id, $auth['user'], 'org:admin');
+    fapiAddMembership($f['env'], $org->id, $other, 'org:member');
+
+    $r = fapiOrgReq('PATCH', "/organizations/{$org->id}/memberships/{$other->id}", $auth['jwt'], [
+        'role' => 'org:admin',
+    ]);
+    $r->assertOk()->assertJsonPath('response.role', 'org:admin');
+    Event::assertDispatched(OrganizationMembershipUpdated::class, 1);
+});
+
+it('DELETE /v1/organizations/{id}/memberships/{user_id} 422s on the last admin', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    fapiAddMembership($f['env'], $org->id, $auth['user'], 'org:admin');
+
+    fapiOrgReq('DELETE', "/organizations/{$org->id}/memberships/{$auth['user']->id}", $auth['jwt'])
+        ->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'organization_last_admin');
+});


### PR DESCRIPTION
## Summary

User-scoped FAPI counterpart to AU-3. Nine routes under `/v1/organizations` authenticated by `__session` JWT (`AuthenticateSessionToken`):

- `POST /v1/organizations` — honors `organization_settings.allow_user_created_organizations` (403 when off) and `max_organizations_per_user` (422). Creates the org + the creator's membership at the env's `creator_role` (default `org:admin`) atomically.
- `GET / PATCH / DELETE /v1/organizations/{id}` — gated by `EnsureOrgPermission` per system permission key. Non-members see 404 `organization_not_found` rather than 403 (privacy default).
- `POST /v1/organizations/{id}/leave` — removes the caller's own membership; refuses with 422 `organization_last_admin`.
- `GET / POST / PATCH / DELETE /v1/organizations/{id}/memberships[/{user_id}]` — POST always issues an invitation (never a direct membership). PATCH / DELETE require `org:sys_memberships:manage` and honor the last-admin guard.

`EnsureOrgPermission` is the new shared gate: takes a permission-key parameter, resolves the Organization from `{organization_id}`, refuses with 404 if the caller is not a member, then 403 if they don't carry the required permission via `User::hasOrgPermission`.

All writes return the `{response, client}` envelope so SDKs can patch their cached Client snapshot from the response.

## Test plan

- [x] `OrganizationsTest`: create + envelope shape; `allow_user_created_organizations: false` → 403; `max_organizations_per_user` → 422; non-member privacy 404; member GET; non-admin PATCH 403; admin PATCH succeeds; admin DELETE; leave; last-admin leave 422; POST /memberships issues an invitation; PATCH /memberships/{user_id}; DELETE last-admin 422. 13 tests.
- [x] Full Pest suite passes (388 tests).
- [x] `vendor/bin/pint --test` clean.

Closes #40