### PR TITLE
FAPI /me org collections + invitation/request endpoints (AU-7)

### DIFF
--- a/app/Events/Organizations/OrganizationInvitationAccepted.php
+++ b/app/Events/Organizations/OrganizationInvitationAccepted.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationInvitation;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationInvitationAccepted
+{
+    use Dispatchable;
+
+    public function __construct(public readonly OrganizationInvitation $invitation) {}
+}

--- a/app/Events/Organizations/OrganizationMembershipRequestApproved.php
+++ b/app/Events/Organizations/OrganizationMembershipRequestApproved.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationMembershipRequest;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationMembershipRequestApproved
+{
+    use Dispatchable;
+
+    public function __construct(public readonly OrganizationMembershipRequest $request) {}
+}

--- a/app/Events/Organizations/OrganizationMembershipRequestCreated.php
+++ b/app/Events/Organizations/OrganizationMembershipRequestCreated.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationMembershipRequest;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationMembershipRequestCreated
+{
+    use Dispatchable;
+
+    public function __construct(public readonly OrganizationMembershipRequest $request) {}
+}

--- a/app/Events/Organizations/OrganizationMembershipRequestRejected.php
+++ b/app/Events/Organizations/OrganizationMembershipRequestRejected.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationMembershipRequest;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationMembershipRequestRejected
+{
+    use Dispatchable;
+
+    public function __construct(public readonly OrganizationMembershipRequest $request) {}
+}

--- a/app/Http/Controllers/Fapi/MeOrganizationController.php
+++ b/app/Http/Controllers/Fapi/MeOrganizationController.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Events\Organizations\OrganizationInvitationAccepted;
+use App\Events\Organizations\OrganizationMembershipCreated;
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\OrganizationInvitationResource;
+use App\Http\Resources\OrganizationMembershipRequestResource;
+use App\Http\Resources\OrganizationMembershipResource;
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationInvitation;
+use App\Models\OrganizationMembership;
+use App\Models\OrganizationMembershipRequest;
+use App\Models\Session;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * `/v1/me` org-related collections (PLAN §4.4 / OA-3 / AU-7). All endpoints
+ * are scoped to the authenticated user.
+ *
+ *   GET    /v1/me/organization_memberships
+ *   GET    /v1/me/organization_invitations
+ *   POST   /v1/me/organization_invitations/{invitation_id}/accept
+ *   GET    /v1/me/organization_membership_requests
+ *   PUT    /v1/me/active_organization
+ */
+final class MeOrganizationController
+{
+    public function listMemberships(Request $request): JsonResponse
+    {
+        $user = app(User::class);
+
+        $query = OrganizationMembership::query()->where('user_id', $user->id);
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->with(['user', 'role.permissions', 'organization'])
+            ->latest('created_at')
+            ->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (OrganizationMembership $m) => OrganizationMembershipResource::from($m))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function listInvitations(Request $request): JsonResponse
+    {
+        $user = app(User::class);
+
+        $emails = $this->userEmails($user);
+        if ($emails === []) {
+            return response()->json(['data' => [], 'total_count' => 0])->header('Cache-Control', 'no-store');
+        }
+
+        $query = OrganizationInvitation::query()
+            ->whereIn('email_address', $emails);
+        if ($request->has('status')) {
+            $query->whereIn('status', (array) $request->input('status'));
+        } else {
+            $query->where('status', OrganizationInvitation::STATUS_PENDING);
+        }
+
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->with('role')->latest('created_at')->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (OrganizationInvitation $i) => OrganizationInvitationResource::from($i))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function acceptInvitation(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $user = app(User::class);
+        $invitationId = (string) $request->route('invitation_id');
+
+        $invitation = OrganizationInvitation::query()
+            ->where('id', $invitationId)
+            ->first();
+        if ($invitation === null) {
+            return $this->error(404, 'organization_invitation_not_found', 'No invitation matches that id.');
+        }
+
+        $emails = $this->userEmails($user);
+        if (! in_array(strtolower($invitation->email_address), $emails, true)) {
+            return $this->error(404, 'organization_invitation_not_found', 'No invitation matches that id.');
+        }
+
+        if ($invitation->status === OrganizationInvitation::STATUS_ACCEPTED) {
+            return $this->error(409, 'organization_invitation_already_accepted', 'This invitation has already been accepted.');
+        }
+        if ($invitation->status !== OrganizationInvitation::STATUS_PENDING) {
+            return $this->error(409, 'organization_invitation_not_pending', "This invitation is {$invitation->status}.");
+        }
+        if ($invitation->expires_at !== null && $invitation->expires_at->isPast()) {
+            return $this->error(410, 'organization_invitation_expired', 'This invitation has expired.');
+        }
+        if ($invitation->role_id === null) {
+            return $this->error(422, 'organization_invitation_role_missing', 'Invitation has no associated role.');
+        }
+
+        $duplicate = OrganizationMembership::query()
+            ->where('organization_id', $invitation->organization_id)
+            ->where('user_id', $user->id)
+            ->exists();
+        if ($duplicate) {
+            return $this->error(409, 'organization_membership_already_exists', 'You are already a member of this organization.');
+        }
+
+        $membership = DB::transaction(function () use ($env, $invitation, $user): OrganizationMembership {
+            $invitation->forceFill(['status' => OrganizationInvitation::STATUS_ACCEPTED])->save();
+            $org = Organization::query()->withoutGlobalScopes()->where('id', $invitation->organization_id)->first();
+            $row = OrganizationMembership::create([
+                'environment_id' => $env->id,
+                'organization_id' => $invitation->organization_id,
+                'user_id' => $user->id,
+                'role_id' => $invitation->role_id,
+            ]);
+            if ($org !== null) {
+                $org->increment('members_count');
+                $org->decrement('pending_invitations_count');
+            }
+
+            return $row;
+        });
+
+        OrganizationInvitationAccepted::dispatch($invitation->fresh());
+        OrganizationMembershipCreated::dispatch($membership);
+
+        return $this->envelope(OrganizationMembershipResource::from(
+            $membership->fresh()->load(['user', 'role.permissions']),
+        ));
+    }
+
+    public function listMembershipRequests(Request $request): JsonResponse
+    {
+        $user = app(User::class);
+        $query = OrganizationMembershipRequest::query()->where('user_id', $user->id);
+
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->latest('created_at')->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (OrganizationMembershipRequest $r) => OrganizationMembershipRequestResource::from($r))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function setActiveOrganization(Request $request): JsonResponse
+    {
+        $user = app(User::class);
+        $session = app(Session::class);
+
+        $organizationId = $request->input('organization_id');
+        if ($organizationId === null) {
+            $session->forceFill(['last_active_organization_id' => null])->save();
+
+            return $this->envelope([
+                'object' => 'active_organization',
+                'organization_id' => null,
+            ]);
+        }
+        if (! is_string($organizationId) || $organizationId === '') {
+            return $this->error(422, 'form_param_format_invalid', 'organization_id must be an org_… string or null.');
+        }
+
+        $isMember = $user->memberships()
+            ->where('organization_id', $organizationId)
+            ->exists();
+        if (! $isMember) {
+            return $this->error(404, 'organization_not_found', 'No membership matches that organization for this user.');
+        }
+
+        $session->forceFill(['last_active_organization_id' => $organizationId])->save();
+
+        return $this->envelope([
+            'object' => 'active_organization',
+            'organization_id' => $organizationId,
+        ]);
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    /**
+     * @return list<string>
+     */
+    private function userEmails(User $user): array
+    {
+        return EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->pluck('email_address')
+            ->map(fn (string $e) => strtolower($e))
+            ->values()
+            ->all();
+    }
+
+    private function envelope(mixed $response, int $status = 200): JsonResponse
+    {
+        $client = app()->bound(Client::class) ? app(Client::class) : null;
+
+        return response()->json([
+            'response' => $response,
+            'client' => ClientResource::from($client?->fresh()),
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Controllers/Fapi/OrganizationInvitationController.php
+++ b/app/Http/Controllers/Fapi/OrganizationInvitationController.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Events\Organizations\OrganizationInvitationCreated;
+use App\Events\Organizations\OrganizationInvitationRevoked;
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\OrganizationInvitationResource;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationInvitation;
+use App\Models\Role;
+use App\Models\User;
+use App\Services\Tickets\TicketIssuer;
+use App\Support\Url;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * FAPI per-org invitation surface (PLAN §4.4 / OA-3 / AU-7). Mirrors
+ * the BAPI shape from AU-4, gated by EnsureOrgPermission middleware.
+ *
+ *   GET    /v1/organizations/{organization_id}/invitations
+ *   POST   /v1/organizations/{organization_id}/invitations
+ *   POST   /v1/organizations/{organization_id}/invitations/bulk
+ *   POST   /v1/organizations/{organization_id}/invitations/{invitation_id}/revoke
+ */
+final class OrganizationInvitationController
+{
+    public const DEFAULT_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+    public function __construct(private readonly TicketIssuer $tickets) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $org = app(Organization::class);
+
+        $query = OrganizationInvitation::query()->where('organization_id', $org->id);
+        if ($request->has('status')) {
+            $query->whereIn('status', (array) $request->input('status'));
+        }
+        $query->latest('created_at');
+
+        $limit = max(1, min(500, (int) $request->input('limit', 10)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->with('role')->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (OrganizationInvitation $i) => OrganizationInvitationResource::from($i, $this->ticketUrl($i)))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = app(Organization::class);
+        $user = app(User::class);
+
+        $err = $this->validatePayload($env, $org, $request->all());
+        if (is_array($err)) {
+            return $this->error($err['status'], $err['code'], $err['message']);
+        }
+
+        [$invitation, $url] = $this->createOne($env, $org, $user, $request->all());
+        OrganizationInvitationCreated::dispatch($invitation, $url);
+
+        return $this->envelope(OrganizationInvitationResource::from($invitation->fresh()->load('role'), $url), 201);
+    }
+
+    public function bulkStore(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = app(Organization::class);
+        $user = app(User::class);
+        $rows = (array) $request->input('invitations', []);
+        if (count($rows) === 0 || count($rows) > 100) {
+            return $this->error(422, 'form_param_value_invalid', 'invitations must contain between 1 and 100 entries.');
+        }
+
+        foreach ($rows as $i => $row) {
+            $err = $this->validatePayload($env, $org, (array) $row);
+            if (is_array($err)) {
+                return $this->error($err['status'], $err['code'], "Row {$i}: ".$err['message']);
+            }
+        }
+
+        try {
+            $created = DB::transaction(function () use ($env, $org, $user, $rows): array {
+                $out = [];
+                foreach ($rows as $row) {
+                    $out[] = $this->createOne($env, $org, $user, (array) $row);
+                }
+
+                return $out;
+            });
+        } catch (Throwable $e) {
+            return $this->error(422, 'bulk_invitation_failed', $e->getMessage());
+        }
+
+        foreach ($created as [$invitation, $url]) {
+            OrganizationInvitationCreated::dispatch($invitation, $url);
+        }
+
+        return $this->envelope([
+            'object' => 'bulk_organization_invitation_result',
+            'total' => count($created),
+            'created' => count($created),
+            'data' => array_map(
+                fn (array $entry) => OrganizationInvitationResource::from($entry[0]->fresh()->load('role'), $entry[1]),
+                $created,
+            ),
+        ], 201);
+    }
+
+    public function revoke(Request $request): JsonResponse
+    {
+        $org = app(Organization::class);
+        $invitationId = (string) $request->route('invitation_id');
+
+        $invitation = OrganizationInvitation::query()
+            ->where('organization_id', $org->id)
+            ->where('id', $invitationId)
+            ->first();
+        if ($invitation === null) {
+            return $this->error(404, 'organization_invitation_not_found', 'No invitation matches that id in this organization.');
+        }
+
+        if ($invitation->status === OrganizationInvitation::STATUS_PENDING) {
+            DB::transaction(function () use ($invitation, $org): void {
+                $invitation->forceFill(['status' => OrganizationInvitation::STATUS_REVOKED])->save();
+                $org->decrement('pending_invitations_count');
+            });
+            OrganizationInvitationRevoked::dispatch($invitation->fresh());
+        }
+
+        return $this->envelope(OrganizationInvitationResource::from($invitation->fresh()->load('role')));
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    /**
+     * @return array{0: OrganizationInvitation, 1: string}
+     */
+    private function createOne(Environment $env, Organization $org, User $user, array $data): array
+    {
+        $email = strtolower((string) ($data['email_address'] ?? ''));
+        $expiresAt = isset($data['expires_at'])
+            ? Carbon::parse($data['expires_at'])
+            : now()->addSeconds(self::DEFAULT_TTL_SECONDS);
+
+        $role = Role::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('key', (string) $data['role'])
+            ->first();
+
+        $invitation = OrganizationInvitation::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'organization_id' => $org->id,
+            'email_address' => $email,
+            'role_id' => $role?->id,
+            'inviter_user_id' => $user->id,
+            'redirect_url' => $data['redirect_url'] ?? null,
+            'status' => OrganizationInvitation::STATUS_PENDING,
+            'public_metadata' => $data['public_metadata'] ?? [],
+            'expires_at' => $expiresAt,
+        ]);
+        $org->increment('pending_invitations_count');
+
+        $jwt = $this->tickets->issue($env, max(60, $expiresAt->getTimestamp() - now()->getTimestamp()), [
+            'sub' => $email,
+            'sid' => $invitation->id,
+            'purpose' => 'organization_invitation',
+            'metadata' => is_array($invitation->public_metadata) ? $invitation->public_metadata : [],
+            'redirect_url' => $invitation->redirect_url,
+        ]);
+
+        return [$invitation, $this->ticketUrlWithJwt($env, $jwt, $invitation->redirect_url)];
+    }
+
+    /**
+     * @return array{status:int,code:string,message:string}|null
+     */
+    private function validatePayload(Environment $env, Organization $org, array $data): ?array
+    {
+        $email = strtolower((string) ($data['email_address'] ?? ''));
+        if ($email === '' || ! str_contains($email, '@')) {
+            return ['status' => 422, 'code' => 'form_param_format_invalid', 'message' => 'email_address is required and must be a valid email.'];
+        }
+        $roleKey = (string) ($data['role'] ?? '');
+        if ($roleKey === '') {
+            return ['status' => 422, 'code' => 'form_param_nil', 'message' => 'role is required.'];
+        }
+        $role = Role::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('key', $roleKey)
+            ->first();
+        if ($role === null) {
+            return ['status' => 422, 'code' => 'form_param_value_invalid', 'message' => 'role is not a known role key in this environment.'];
+        }
+        $duplicate = OrganizationInvitation::query()
+            ->where('organization_id', $org->id)
+            ->where('email_address', $email)
+            ->where('status', OrganizationInvitation::STATUS_PENDING)
+            ->exists();
+        if ($duplicate) {
+            return ['status' => 409, 'code' => 'organization_invitation_already_exists', 'message' => 'A pending invitation for this email already exists.'];
+        }
+
+        return null;
+    }
+
+    private function ticketUrl(OrganizationInvitation $invitation): string
+    {
+        $env = app(Environment::class);
+        $ttl = $invitation->expires_at !== null
+            ? max(60, $invitation->expires_at->getTimestamp() - now()->getTimestamp())
+            : self::DEFAULT_TTL_SECONDS;
+        $jwt = $this->tickets->issue($env, $ttl, [
+            'sub' => strtolower($invitation->email_address),
+            'sid' => $invitation->id,
+            'purpose' => 'organization_invitation',
+            'metadata' => is_array($invitation->public_metadata) ? $invitation->public_metadata : [],
+            'redirect_url' => $invitation->redirect_url,
+        ]);
+
+        return $this->ticketUrlWithJwt($env, $jwt, $invitation->redirect_url);
+    }
+
+    private function ticketUrlWithJwt(Environment $env, string $jwt, ?string $redirect): string
+    {
+        $base = Url::fapi($env, '');
+        $query = http_build_query(array_filter([
+            '__authn_ticket' => $jwt,
+            '__authn_status' => 'sign_up',
+            'redirect_url' => $redirect,
+        ], fn ($v) => $v !== null && $v !== ''));
+
+        return rtrim($base, '/').'/sign-up?'.$query;
+    }
+
+    private function envelope(mixed $response, int $status = 200): JsonResponse
+    {
+        $client = app()->bound(Client::class) ? app(Client::class) : null;
+
+        return response()->json([
+            'response' => $response,
+            'client' => ClientResource::from($client?->fresh()),
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Controllers/Fapi/OrganizationMembershipRequestController.php
+++ b/app/Http/Controllers/Fapi/OrganizationMembershipRequestController.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Events\Organizations\OrganizationMembershipCreated;
+use App\Events\Organizations\OrganizationMembershipRequestApproved;
+use App\Events\Organizations\OrganizationMembershipRequestRejected;
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\OrganizationMembershipRequestResource;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\OrganizationMembershipRequest;
+use App\Models\Role;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * FAPI per-org admin surface for membership requests (PLAN §4.4 / OA-3 / AU-7).
+ *
+ *   GET    /v1/organizations/{organization_id}/membership_requests
+ *   POST   /v1/organizations/{organization_id}/membership_requests/{request_id}/accept
+ *   POST   /v1/organizations/{organization_id}/membership_requests/{request_id}/reject
+ */
+final class OrganizationMembershipRequestController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $org = app(Organization::class);
+        $query = OrganizationMembershipRequest::query()->where('organization_id', $org->id);
+        if ($request->has('status')) {
+            $query->whereIn('status', (array) $request->input('status'));
+        }
+        $query->latest('created_at');
+
+        $limit = max(1, min(500, (int) $request->input('limit', 10)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (OrganizationMembershipRequest $r) => OrganizationMembershipRequestResource::from($r))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function accept(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = app(Organization::class);
+        $requestId = (string) $request->route('request_id');
+
+        $row = OrganizationMembershipRequest::query()
+            ->where('organization_id', $org->id)
+            ->where('id', $requestId)
+            ->first();
+        if ($row === null) {
+            return $this->error(404, 'organization_membership_request_not_found', 'No membership request matches that id.');
+        }
+        if ($row->status !== OrganizationMembershipRequest::STATUS_PENDING) {
+            return $this->error(409, 'organization_membership_request_not_pending', 'This request has already been resolved.');
+        }
+
+        $defaultRole = Role::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('is_default', true)
+            ->first();
+        if ($defaultRole === null) {
+            return $this->error(422, 'role_no_default', 'Environment has no default role.');
+        }
+
+        $duplicateMembership = OrganizationMembership::query()
+            ->where('organization_id', $org->id)
+            ->where('user_id', $row->user_id)
+            ->exists();
+        if ($duplicateMembership) {
+            return $this->error(409, 'organization_membership_already_exists', 'User is already a member of this organization.');
+        }
+
+        $membership = DB::transaction(function () use ($env, $org, $row, $defaultRole): OrganizationMembership {
+            $row->forceFill(['status' => OrganizationMembershipRequest::STATUS_ACCEPTED])->save();
+            $membership = OrganizationMembership::create([
+                'environment_id' => $env->id,
+                'organization_id' => $org->id,
+                'user_id' => $row->user_id,
+                'role_id' => $defaultRole->id,
+            ]);
+            $org->increment('members_count');
+
+            return $membership;
+        });
+
+        OrganizationMembershipRequestApproved::dispatch($row->fresh());
+        OrganizationMembershipCreated::dispatch($membership);
+
+        return $this->envelope(OrganizationMembershipRequestResource::from($row->fresh()));
+    }
+
+    public function reject(Request $request): JsonResponse
+    {
+        $org = app(Organization::class);
+        $requestId = (string) $request->route('request_id');
+
+        $row = OrganizationMembershipRequest::query()
+            ->where('organization_id', $org->id)
+            ->where('id', $requestId)
+            ->first();
+        if ($row === null) {
+            return $this->error(404, 'organization_membership_request_not_found', 'No membership request matches that id.');
+        }
+        if ($row->status !== OrganizationMembershipRequest::STATUS_PENDING) {
+            return $this->error(409, 'organization_membership_request_not_pending', 'This request has already been resolved.');
+        }
+
+        $row->forceFill(['status' => OrganizationMembershipRequest::STATUS_REVOKED])->save();
+        OrganizationMembershipRequestRejected::dispatch($row->fresh());
+
+        return $this->envelope(OrganizationMembershipRequestResource::from($row->fresh()));
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    private function envelope(mixed $response, int $status = 200): JsonResponse
+    {
+        $client = app()->bound(Client::class) ? app(Client::class) : null;
+
+        return response()->json([
+            'response' => $response,
+            'client' => ClientResource::from($client?->fresh()),
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Resources/OrganizationMembershipRequestResource.php
+++ b/app/Http/Resources/OrganizationMembershipRequestResource.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\OrganizationMembershipRequest;
+
+final class OrganizationMembershipRequestResource
+{
+    public static function from(OrganizationMembershipRequest $request): array
+    {
+        return [
+            'object' => 'organization_membership_request',
+            'id' => $request->id,
+            'organization_id' => $request->organization_id,
+            'user_id' => $request->user_id,
+            'status' => $request->status,
+            'created_at' => $request->created_at?->getTimestampMs(),
+            'updated_at' => $request->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -6,8 +6,11 @@ use App\Http\Controllers\AccountPortal\AccountPortalController;
 use App\Http\Controllers\Fapi\ClientController;
 use App\Http\Controllers\Fapi\EnvironmentController;
 use App\Http\Controllers\Fapi\MeController;
+use App\Http\Controllers\Fapi\MeOrganizationController;
 use App\Http\Controllers\Fapi\OrganizationController as FapiOrganizationController;
+use App\Http\Controllers\Fapi\OrganizationInvitationController as FapiOrganizationInvitationController;
 use App\Http\Controllers\Fapi\OrganizationMembershipController as FapiOrganizationMembershipController;
+use App\Http\Controllers\Fapi\OrganizationMembershipRequestController as FapiOrganizationMembershipRequestController;
 use App\Http\Controllers\Fapi\PingController;
 use App\Http\Controllers\Fapi\SessionsController;
 use App\Http\Controllers\Fapi\SessionTokenController;
@@ -129,6 +132,38 @@ Route::prefix('v1')->group(function (): void {
         Route::delete('/organizations/{organization_id}/memberships/{user_id}', [FapiOrganizationMembershipController::class, 'destroy'])
             ->middleware(EnsureOrgPermission::class.':org:sys_memberships:manage')
             ->name('fapi.organizations.memberships.destroy');
+
+        // Per-org admin invitation surface (AU-7).
+        Route::get('/organizations/{organization_id}/invitations', [FapiOrganizationInvitationController::class, 'index'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_memberships:read')
+            ->name('fapi.organizations.invitations.index');
+        Route::post('/organizations/{organization_id}/invitations', [FapiOrganizationInvitationController::class, 'store'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_memberships:manage')
+            ->name('fapi.organizations.invitations.store');
+        Route::post('/organizations/{organization_id}/invitations/bulk', [FapiOrganizationInvitationController::class, 'bulkStore'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_memberships:manage')
+            ->name('fapi.organizations.invitations.bulk');
+        Route::post('/organizations/{organization_id}/invitations/{invitation_id}/revoke', [FapiOrganizationInvitationController::class, 'revoke'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_memberships:manage')
+            ->name('fapi.organizations.invitations.revoke');
+
+        // Per-org membership-request approve/reject (AU-7).
+        Route::get('/organizations/{organization_id}/membership_requests', [FapiOrganizationMembershipRequestController::class, 'index'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_memberships:read')
+            ->name('fapi.organizations.membership_requests.index');
+        Route::post('/organizations/{organization_id}/membership_requests/{request_id}/accept', [FapiOrganizationMembershipRequestController::class, 'accept'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_memberships:manage')
+            ->name('fapi.organizations.membership_requests.accept');
+        Route::post('/organizations/{organization_id}/membership_requests/{request_id}/reject', [FapiOrganizationMembershipRequestController::class, 'reject'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_memberships:manage')
+            ->name('fapi.organizations.membership_requests.reject');
+
+        // /v1/me org-related collections + active-org switching (AU-7).
+        Route::get('/me/organization_memberships', [MeOrganizationController::class, 'listMemberships'])->name('fapi.me.organization_memberships');
+        Route::get('/me/organization_invitations', [MeOrganizationController::class, 'listInvitations'])->name('fapi.me.organization_invitations');
+        Route::post('/me/organization_invitations/{invitation_id}/accept', [MeOrganizationController::class, 'acceptInvitation'])->name('fapi.me.organization_invitations.accept');
+        Route::get('/me/organization_membership_requests', [MeOrganizationController::class, 'listMembershipRequests'])->name('fapi.me.organization_membership_requests');
+        Route::put('/me/active_organization', [MeOrganizationController::class, 'setActiveOrganization'])->name('fapi.me.active_organization');
     });
 });
 

--- a/tests/Feature/Http/Fapi/MeOrganizationsTest.php
+++ b/tests/Feature/Http/Fapi/MeOrganizationsTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\Organizations\OrganizationInvitationAccepted;
+use App\Events\Organizations\OrganizationInvitationCreated;
+use App\Events\Organizations\OrganizationInvitationRevoked;
+use App\Events\Organizations\OrganizationMembershipCreated;
+use App\Events\Organizations\OrganizationMembershipRequestApproved;
+use App\Events\Organizations\OrganizationMembershipRequestRejected;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationInvitation;
+use App\Models\OrganizationMembership;
+use App\Models\OrganizationMembershipRequest;
+use App\Models\Role;
+use App\Models\Session;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+uses(RefreshDatabase::class);
+
+function meOrgReq(string $method, string $path, string $jwt, array $body = [], string $origin = 'https://app.example.com'): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => $origin,
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+function makeOrgWithMembership(Environment $env, User $user, string $roleKey, string $slug = 'acme'): Organization
+{
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => $slug]);
+    $role = Role::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('key', $roleKey)
+        ->firstOrFail();
+    OrganizationMembership::create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'user_id' => $user->id,
+        'role_id' => $role->id,
+    ]);
+    Organization::query()->withoutGlobalScopes()->where('id', $org->id)->increment('members_count');
+
+    return $org->fresh();
+}
+
+it('GET /v1/me/organization_memberships lists the caller memberships', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    makeOrgWithMembership($f['env'], $auth['user'], 'org:admin', 'a');
+    makeOrgWithMembership($f['env'], $auth['user'], 'org:member', 'b');
+
+    $r = meOrgReq('GET', '/me/organization_memberships', $auth['jwt']);
+    $r->assertOk()->assertJsonPath('total_count', 2);
+});
+
+it('GET /v1/me/organization_invitations lists pending invitations addressed to the caller', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'A', 'slug' => 'a']);
+    $role = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:member')->firstOrFail();
+    OrganizationInvitation::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'email_address' => 'alice@example.com',
+        'role_id' => $role->id,
+        'status' => OrganizationInvitation::STATUS_PENDING,
+    ]);
+
+    $r = meOrgReq('GET', '/me/organization_invitations', $auth['jwt']);
+    $r->assertOk()->assertJsonPath('total_count', 1)->assertJsonPath('data.0.email_address', 'alice@example.com');
+});
+
+it('POST /v1/me/organization_invitations/{id}/accept creates a membership and fires events', function (): void {
+    Event::fake([OrganizationInvitationAccepted::class, OrganizationMembershipCreated::class]);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'A', 'slug' => 'a']);
+    $role = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:member')->firstOrFail();
+    $invitation = OrganizationInvitation::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'email_address' => 'alice@example.com',
+        'role_id' => $role->id,
+        'status' => OrganizationInvitation::STATUS_PENDING,
+    ]);
+    Organization::query()->withoutGlobalScopes()->where('id', $org->id)->increment('pending_invitations_count');
+
+    $r = meOrgReq('POST', "/me/organization_invitations/{$invitation->id}/accept", $auth['jwt']);
+    $r->assertOk()->assertJsonPath('response.object', 'organization_membership');
+    expect(OrganizationMembership::query()->where('organization_id', $org->id)->where('user_id', $auth['user']->id)->exists())->toBeTrue();
+    expect($invitation->fresh()->status)->toBe('accepted');
+
+    Event::assertDispatched(OrganizationInvitationAccepted::class, 1);
+    Event::assertDispatched(OrganizationMembershipCreated::class, 1);
+});
+
+it('POST /accept on an already-accepted invitation 409s', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'A', 'slug' => 'a']);
+    $role = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:member')->firstOrFail();
+    $invitation = OrganizationInvitation::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'email_address' => 'alice@example.com',
+        'role_id' => $role->id,
+        'status' => OrganizationInvitation::STATUS_ACCEPTED,
+    ]);
+
+    meOrgReq('POST', "/me/organization_invitations/{$invitation->id}/accept", $auth['jwt'])
+        ->assertStatus(409)
+        ->assertJsonPath('errors.0.code', 'organization_invitation_already_accepted');
+});
+
+it('POST /accept on an invitation for someone else 404s', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'A', 'slug' => 'a']);
+    $role = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:member')->firstOrFail();
+    $invitation = OrganizationInvitation::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'email_address' => 'someone-else@example.com',
+        'role_id' => $role->id,
+        'status' => OrganizationInvitation::STATUS_PENDING,
+    ]);
+
+    meOrgReq('POST', "/me/organization_invitations/{$invitation->id}/accept", $auth['jwt'])
+        ->assertStatus(404);
+});
+
+it('GET /v1/me/organization_membership_requests lists my requests', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'A', 'slug' => 'a']);
+    OrganizationMembershipRequest::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'user_id' => $auth['user']->id,
+        'status' => 'pending',
+    ]);
+
+    meOrgReq('GET', '/me/organization_membership_requests', $auth['jwt'])
+        ->assertOk()->assertJsonPath('total_count', 1);
+});
+
+it('PUT /v1/me/active_organization updates Session.last_active_organization_id', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = makeOrgWithMembership($f['env'], $auth['user'], 'org:member');
+
+    $r = meOrgReq('PUT', '/me/active_organization', $auth['jwt'], ['organization_id' => $org->id]);
+    $r->assertOk()->assertJsonPath('response.organization_id', $org->id);
+
+    $session = Session::query()->withoutGlobalScopes()->where('id', $auth['session']->id)->firstOrFail();
+    expect($session->last_active_organization_id)->toBe($org->id);
+});
+
+it('PUT /v1/me/active_organization with null clears the active org', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = makeOrgWithMembership($f['env'], $auth['user'], 'org:admin');
+    Session::query()->withoutGlobalScopes()->where('id', $auth['session']->id)->update(['last_active_organization_id' => $org->id]);
+
+    $r = meOrgReq('PUT', '/me/active_organization', $auth['jwt'], ['organization_id' => null]);
+    $r->assertOk()->assertJsonPath('response.organization_id', null);
+});
+
+it('PUT /v1/me/active_organization 404s for an org the user is not in', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $other = new User(['environment_id' => $f['env']->id, 'username' => 'other']);
+    $other->save();
+    $org = makeOrgWithMembership($f['env'], $other, 'org:admin');
+
+    meOrgReq('PUT', '/me/active_organization', $auth['jwt'], ['organization_id' => $org->id])
+        ->assertStatus(404);
+});
+
+it('GET /v1/organizations/{id}/invitations gates on org:sys_memberships:read', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = makeOrgWithMembership($f['env'], $auth['user'], 'org:admin');
+
+    meOrgReq('GET', "/organizations/{$org->id}/invitations", $auth['jwt'])->assertOk();
+});
+
+it('POST /v1/organizations/{id}/invitations creates an invitation and fires the event', function (): void {
+    Event::fake([OrganizationInvitationCreated::class]);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = makeOrgWithMembership($f['env'], $auth['user'], 'org:admin');
+
+    $r = meOrgReq('POST', "/organizations/{$org->id}/invitations", $auth['jwt'], [
+        'email_address' => 'newbie@example.com',
+        'role' => 'org:member',
+    ]);
+    $r->assertStatus(201)->assertJsonPath('response.object', 'organization_invitation');
+    expect($r->json('response.url'))->toContain('__authn_ticket=');
+    Event::assertDispatched(OrganizationInvitationCreated::class, 1);
+});
+
+it('POST /v1/organizations/{id}/invitations/bulk creates atomically', function (): void {
+    Event::fake([OrganizationInvitationCreated::class]);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = makeOrgWithMembership($f['env'], $auth['user'], 'org:admin');
+
+    $r = meOrgReq('POST', "/organizations/{$org->id}/invitations/bulk", $auth['jwt'], [
+        'invitations' => [
+            ['email_address' => 'one@example.com', 'role' => 'org:member'],
+            ['email_address' => 'two@example.com', 'role' => 'org:member'],
+        ],
+    ]);
+    $r->assertStatus(201)->assertJsonPath('response.created', 2);
+    Event::assertDispatched(OrganizationInvitationCreated::class, 2);
+});
+
+it('POST /v1/organizations/{id}/invitations/{id}/revoke flips status', function (): void {
+    Event::fake([OrganizationInvitationRevoked::class]);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = makeOrgWithMembership($f['env'], $auth['user'], 'org:admin');
+    $role = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:member')->firstOrFail();
+    $invitation = OrganizationInvitation::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'email_address' => 'revoke-me@example.com',
+        'role_id' => $role->id,
+        'status' => 'pending',
+    ]);
+    Organization::query()->withoutGlobalScopes()->where('id', $org->id)->increment('pending_invitations_count');
+
+    $r = meOrgReq('POST', "/organizations/{$org->id}/invitations/{$invitation->id}/revoke", $auth['jwt']);
+    $r->assertOk()->assertJsonPath('response.status', 'revoked');
+    Event::assertDispatched(OrganizationInvitationRevoked::class, 1);
+});
+
+it('POST /v1/organizations/{id}/membership_requests/{rid}/accept creates a membership', function (): void {
+    Event::fake([OrganizationMembershipRequestApproved::class, OrganizationMembershipCreated::class]);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = makeOrgWithMembership($f['env'], $auth['user'], 'org:admin');
+
+    $applicant = new User(['environment_id' => $f['env']->id, 'username' => 'applicant']);
+    $applicant->save();
+    $req = OrganizationMembershipRequest::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'user_id' => $applicant->id,
+        'status' => 'pending',
+    ]);
+
+    $r = meOrgReq('POST', "/organizations/{$org->id}/membership_requests/{$req->id}/accept", $auth['jwt']);
+    $r->assertOk()->assertJsonPath('response.status', 'accepted');
+    expect(OrganizationMembership::query()->where('organization_id', $org->id)->where('user_id', $applicant->id)->exists())->toBeTrue();
+
+    Event::assertDispatched(OrganizationMembershipRequestApproved::class, 1);
+    Event::assertDispatched(OrganizationMembershipCreated::class, 1);
+});
+
+it('POST /v1/organizations/{id}/membership_requests/{rid}/reject flips status', function (): void {
+    Event::fake([OrganizationMembershipRequestRejected::class]);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = makeOrgWithMembership($f['env'], $auth['user'], 'org:admin');
+
+    $applicant = new User(['environment_id' => $f['env']->id, 'username' => 'applicant']);
+    $applicant->save();
+    $req = OrganizationMembershipRequest::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'user_id' => $applicant->id,
+        'status' => 'pending',
+    ]);
+
+    $r = meOrgReq('POST', "/organizations/{$org->id}/membership_requests/{$req->id}/reject", $auth['jwt']);
+    $r->assertOk()->assertJsonPath('response.status', 'revoked');
+    Event::assertDispatched(OrganizationMembershipRequestRejected::class, 1);
+});
+
+it('non-admin members cannot create invitations on an org (sys_memberships:manage required)', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = makeOrgWithMembership($f['env'], $auth['user'], 'org:member');
+
+    meOrgReq('POST', "/organizations/{$org->id}/invitations", $auth['jwt'], [
+        'email_address' => 'someone@example.com', 'role' => 'org:member',
+    ])->assertStatus(403);
+});
+
+it('non-members cannot list invitations (404, privacy default)', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $other = new User(['environment_id' => $f['env']->id, 'username' => 'other']);
+    $other->save();
+    $org = makeOrgWithMembership($f['env'], $other, 'org:admin');
+
+    meOrgReq('GET', "/organizations/{$org->id}/invitations", $auth['jwt'])
+        ->assertStatus(404);
+});


### PR DESCRIPTION
## Summary

12 new FAPI routes for the org-related user surface (the issue lists 11; I added the inferred PUT shape for active_organization to match OA-3).

**Per-org admin (gated by EnsureOrgPermission from AU-6):**
- `GET / POST / POST /bulk / POST /{inv}/revoke` invitations
- `GET / POST /{req}/accept / POST /{req}/reject` membership_requests

**/me collections:**
- `GET /me/organization_memberships`
- `GET /me/organization_invitations` (defaults to status=pending)
- `POST /me/organization_invitations/{inv}/accept` — creates the membership atomically; fires `OrganizationInvitationAccepted` + `OrganizationMembershipCreated`; decrements `pending_invitations_count`, increments `members_count`
- `GET /me/organization_membership_requests`
- `PUT /me/active_organization` — `{ organization_id: org_… | null }`. Validates membership; updates `Session.last_active_organization_id`. The matching JWT claim refresh lands in AU-8.

All writes return `{response, client}`.

## Test plan

- [x] `MeOrganizationsTest`: list memberships / invitations / requests; accept invitation (creates membership + counters); already-accepted 409; foreign-recipient 404; active-org happy / clear / non-member 404; per-org admin invitation flow (index / store / bulk / revoke); membership-request accept / reject; non-member 404; non-admin write 403. 17 tests.
- [x] Full Pest suite passes (405 tests).
- [x] `vendor/bin/pint --test` clean.

Closes #41