### PR TITLE
Active organization on Session + org JWT claim (AU-8)

### DIFF
--- a/app/Http/Controllers/Fapi/MeOrganizationController.php
+++ b/app/Http/Controllers/Fapi/MeOrganizationController.php
@@ -168,7 +168,12 @@ final class MeOrganizationController
 
         $organizationId = $request->input('organization_id');
         if ($organizationId === null) {
-            $session->forceFill(['last_active_organization_id' => null])->save();
+            if ($session->last_active_organization_id !== null) {
+                $session->forceFill([
+                    'last_active_organization_id' => null,
+                    'token_version' => (int) $session->token_version + 1,
+                ])->save();
+            }
 
             return $this->envelope([
                 'object' => 'active_organization',
@@ -186,7 +191,12 @@ final class MeOrganizationController
             return $this->error(404, 'organization_not_found', 'No membership matches that organization for this user.');
         }
 
-        $session->forceFill(['last_active_organization_id' => $organizationId])->save();
+        if ($session->last_active_organization_id !== $organizationId) {
+            $session->forceFill([
+                'last_active_organization_id' => $organizationId,
+                'token_version' => (int) $session->token_version + 1,
+            ])->save();
+        }
 
         return $this->envelope([
             'object' => 'active_organization',

--- a/app/Http/Controllers/Fapi/SessionsController.php
+++ b/app/Http/Controllers/Fapi/SessionsController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Fapi;
 
 use App\Http\Resources\ClientResource;
 use App\Models\Client;
+use App\Models\OrganizationMembership;
 use App\Models\Session;
 use App\Services\Sessions\SessionLifecycle;
 use Illuminate\Http\JsonResponse;
@@ -46,12 +47,30 @@ final class SessionsController
             return $this->error(409, 'session_not_live', "Session is in status {$session->status}.");
         }
 
-        // Forward-compat capture: orgs land in v0.2 and `last_active_organization_id`
-        // is already on the Session row. Storing the value now lets the SDK keep
-        // sending it without a flag flip later.
-        $org = $request->input('active_organization_id');
-        if (is_string($org) && $org !== '' && $session->last_active_organization_id !== $org) {
-            $session->forceFill(['last_active_organization_id' => $org])->saveQuietly();
+        // Active-org switching (AU-8). The body either names a new org id or
+        // sends `null` to clear it. On any change we bump `token_version` so
+        // the SDK's in-flight token cache invalidates and the next mint
+        // picks up the right `org` claim.
+        if ($request->has('active_organization_id')) {
+            $candidate = $request->input('active_organization_id');
+            $next = is_string($candidate) && $candidate !== '' ? $candidate : null;
+
+            if ($next !== null) {
+                $isMember = OrganizationMembership::query()
+                    ->where('user_id', $session->user_id)
+                    ->where('organization_id', $next)
+                    ->exists();
+                if (! $isMember) {
+                    return $this->error(422, 'organization_not_a_member', 'User is not a member of that organization.');
+                }
+            }
+
+            if ($session->last_active_organization_id !== $next) {
+                $session->forceFill([
+                    'last_active_organization_id' => $next,
+                    'token_version' => (int) $session->token_version + 1,
+                ])->saveQuietly();
+            }
         }
 
         $this->lifecycle->touch($session->fresh(), $request);

--- a/app/Models/Session.php
+++ b/app/Models/Session.php
@@ -118,6 +118,7 @@ class Session extends Model
         'expire_at',
         'abandon_at',
         'last_active_organization_id',
+        'token_version',
         'actor',
         'was_test',
     ];

--- a/app/Services/Sessions/SessionTokenIssuer.php
+++ b/app/Services/Sessions/SessionTokenIssuer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Sessions;
 
 use App\Models\Environment;
+use App\Models\OrganizationMembership;
 use App\Models\Session;
 use App\Models\SigningKey;
 use App\Support\Url;
@@ -74,6 +75,11 @@ final class SessionTokenIssuer
 
         if ($azp !== null) {
             $builder = $builder->withClaim('azp', $azp);
+        }
+
+        $orgClaim = $this->orgClaim($session);
+        if ($orgClaim !== null) {
+            $builder = $builder->withClaim('org', $orgClaim);
         }
 
         if ($shape === 'flat') {
@@ -146,6 +152,38 @@ final class SessionTokenIssuer
         $origin = $request->headers->get('Origin');
 
         return is_string($origin) && $origin !== '' ? $origin : null;
+    }
+
+    /**
+     * Compact `org` claim populated from the active membership when the
+     * Session has `last_active_organization_id` set. Returns null when the
+     * session has no active org or when the row has been deleted between
+     * the touch and the mint.
+     *
+     * @return array{id: string, slg: string, rol: string, per: list<string>}|null
+     */
+    private function orgClaim(Session $session): ?array
+    {
+        $orgId = $session->last_active_organization_id;
+        if (! is_string($orgId) || $orgId === '') {
+            return null;
+        }
+
+        $membership = OrganizationMembership::query()
+            ->where('organization_id', $orgId)
+            ->where('user_id', $session->user_id)
+            ->with(['organization', 'role.permissions'])
+            ->first();
+        if ($membership === null || $membership->organization === null || $membership->role === null) {
+            return null;
+        }
+
+        return [
+            'id' => $membership->organization->id,
+            'slg' => $membership->organization->slug,
+            'rol' => $membership->role->key,
+            'per' => $membership->role->permissions->pluck('key')->unique()->values()->all(),
+        ];
     }
 
     /**

--- a/database/migrations/0013_01_01_000000_add_token_version_to_sessions.php
+++ b/database/migrations/0013_01_01_000000_add_token_version_to_sessions.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds the `token_version` counter so the session-token issuer can
+ * invalidate any in-flight token cache the SDK keeps after the operator
+ * switches active organization (or any other claim-affecting state).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sessions', function (Blueprint $table): void {
+            $table->unsignedInteger('token_version')->default(0)->after('last_active_organization_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sessions', function (Blueprint $table): void {
+            $table->dropColumn('token_version');
+        });
+    }
+};

--- a/tests/Feature/Http/Sessions/ActiveOrganizationTest.php
+++ b/tests/Feature/Http/Sessions/ActiveOrganizationTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\Session;
+use App\Models\User;
+use App\Services\Client\ClientResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+uses(RefreshDatabase::class);
+
+function activeOrgFapiReq(string $method, string $path, string $jwt, array $body = []): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+function setupSessionWithMembership(): array
+{
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme-touch']);
+    $admin = Role::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('key', 'org:admin')
+        ->firstOrFail();
+    OrganizationMembership::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'user_id' => $auth['user']->id,
+        'role_id' => $admin->id,
+    ]);
+
+    return ['env' => $f['env'], 'auth' => $auth, 'org' => $org];
+}
+
+it('PUT /me/active_organization bumps Session.token_version on change', function (): void {
+    $ctx = setupSessionWithMembership();
+    $session = $ctx['auth']['session'];
+    $beforeVersion = (int) $session->fresh()->token_version;
+
+    activeOrgFapiReq('PUT', '/me/active_organization', $ctx['auth']['jwt'], [
+        'organization_id' => $ctx['org']->id,
+    ])->assertOk();
+
+    $after = Session::query()->withoutGlobalScopes()->where('id', $session->id)->firstOrFail();
+    expect($after->token_version)->toBe($beforeVersion + 1);
+    expect($after->last_active_organization_id)->toBe($ctx['org']->id);
+});
+
+it('PUT /me/active_organization is a no-op when the org is already active', function (): void {
+    $ctx = setupSessionWithMembership();
+    $session = $ctx['auth']['session'];
+    $session->forceFill(['last_active_organization_id' => $ctx['org']->id, 'token_version' => 7])->save();
+
+    activeOrgFapiReq('PUT', '/me/active_organization', $ctx['auth']['jwt'], [
+        'organization_id' => $ctx['org']->id,
+    ])->assertOk();
+
+    $after = Session::query()->withoutGlobalScopes()->where('id', $session->id)->firstOrFail();
+    expect($after->token_version)->toBe(7);
+});
+
+it('POST /client/sessions/{sid}/touch with active_organization_id validates membership', function (): void {
+    $ctx = setupSessionWithMembership();
+
+    // Org the user is NOT in.
+    $other = new User(['environment_id' => $ctx['env']->id, 'username' => 'other']);
+    $other->save();
+    $otherOrg = Organization::create(['environment_id' => $ctx['env']->id, 'name' => 'Foreign', 'slug' => 'foreign']);
+    $admin = Role::query()->withoutGlobalScopes()
+        ->where('environment_id', $ctx['env']->id)
+        ->where('key', 'org:admin')
+        ->firstOrFail();
+    OrganizationMembership::create([
+        'environment_id' => $ctx['env']->id,
+        'organization_id' => $otherOrg->id,
+        'user_id' => $other->id,
+        'role_id' => $admin->id,
+    ]);
+
+    $cookie = app(ClientResolver::class)->mintCookieValue($ctx['auth']['client']);
+
+    test()->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+        ])
+        ->json('POST', "https://acme.authn.local/v1/client/sessions/{$ctx['auth']['session']->id}/touch", [
+            'active_organization_id' => $otherOrg->id,
+        ])->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'organization_not_a_member');
+});
+
+it('POST /client/sessions/{sid}/touch with valid active_organization_id bumps token_version', function (): void {
+    $ctx = setupSessionWithMembership();
+    $beforeVersion = (int) $ctx['auth']['session']->fresh()->token_version;
+
+    $cookie = app(ClientResolver::class)->mintCookieValue($ctx['auth']['client']);
+
+    test()->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+        ])
+        ->json('POST', "https://acme.authn.local/v1/client/sessions/{$ctx['auth']['session']->id}/touch", [
+            'active_organization_id' => $ctx['org']->id,
+        ])->assertOk();
+
+    $after = Session::query()->withoutGlobalScopes()->where('id', $ctx['auth']['session']->id)->firstOrFail();
+    expect($after->last_active_organization_id)->toBe($ctx['org']->id);
+    expect($after->token_version)->toBe($beforeVersion + 1);
+});

--- a/tests/Feature/Services/Sessions/SessionTokenIssuerOrgClaimTest.php
+++ b/tests/Feature/Services/Sessions/SessionTokenIssuerOrgClaimTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\Session;
+use App\Services\Sessions\SessionTokenIssuer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+uses(RefreshDatabase::class);
+
+function decodeJwtClaims(string $jwt): array
+{
+    $config = Configuration::forSymmetricSigner(
+        new Sha256,
+        InMemory::plainText(str_repeat('x', 64)),
+    );
+    $token = $config->parser()->parse($jwt);
+
+    return $token->claims()->all();
+}
+
+it('omits the org claim when Session has no active organization', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeJwtClaims($minted['jwt']);
+
+    expect($claims)->not->toHaveKey('org');
+});
+
+it('embeds the org claim with id, slg, rol, per when active org is set', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    $admin = Role::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('key', 'org:admin')
+        ->firstOrFail();
+    OrganizationMembership::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'user_id' => $auth['user']->id,
+        'role_id' => $admin->id,
+    ]);
+    $auth['session']->forceFill(['last_active_organization_id' => $org->id])->save();
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeJwtClaims($minted['jwt']);
+
+    expect($claims)->toHaveKey('org');
+    $orgClaim = $claims['org'];
+    expect($orgClaim['id'])->toBe($org->id);
+    expect($orgClaim['slg'])->toBe('acme');
+    expect($orgClaim['rol'])->toBe('org:admin');
+    // Admin has every system permission (13 from AU-2).
+    expect($orgClaim['per'])->toContain(
+        'org:sys_profile:manage',
+        'org:sys_memberships:manage',
+        'org:sys_billing:manage',
+    );
+    expect(count($orgClaim['per']))->toBe(13);
+});
+
+it('reflects role permission changes on the next mint', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    $member = Role::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('key', 'org:member')
+        ->firstOrFail();
+    OrganizationMembership::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'user_id' => $auth['user']->id,
+        'role_id' => $member->id,
+    ]);
+    $auth['session']->forceFill(['last_active_organization_id' => $org->id])->save();
+
+    $first = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $firstClaims = decodeJwtClaims($first['jwt']);
+    expect($firstClaims['org']['per'])->not->toContain('org:sys_memberships:manage');
+
+    // Operator grants the member role the manage permission.
+    $managePerm = Permission::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('key', 'org:sys_memberships:manage')
+        ->firstOrFail();
+    $member->permissions()->attach($managePerm->id);
+
+    $second = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $secondClaims = decodeJwtClaims($second['jwt']);
+    expect($secondClaims['org']['per'])->toContain('org:sys_memberships:manage');
+});
+
+it('omits the org claim when the user has no membership in the active org', function (): void {
+    // Edge case: session.last_active_organization_id was set, but the
+    // membership was deleted. The mint should defensively omit `org` instead
+    // of throwing or surfacing stale data.
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $auth['session']->forceFill(['last_active_organization_id' => 'org_'.str_repeat('A', 26)])->save();
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeJwtClaims($minted['jwt']);
+
+    expect($claims)->not->toHaveKey('org');
+});


### PR DESCRIPTION
## Summary

Wires the active-org context into the existing v0.1 session JWT. After this lands, every `getSessionToken` / `getClientSessionToken` call returns a token with an `org` claim populated when the session has an active org, and absent otherwise — exactly the shape sdk-php's `TokenVerifier` (SP-3 v0.2) parses.

- New `sessions.token_version` column — incremented on every active-org change so the SDK's in-flight token cache invalidates.
- `SessionsController::touch` now honors `active_organization_id` from the body: validates membership (422 `organization_not_a_member`), updates `last_active_organization_id`, increments `token_version`. `null` clears the field.
- `MeOrganizationController::setActiveOrganization` (AU-7) gets the same `token_version` bump.
- `SessionTokenIssuer::mint` reads `Session.last_active_organization_id` and adds an `org` claim with the compact shape:
  ```json
  { "id": "org_…", "slg": "acme", "rol": "org:admin", "per": ["org:sys_profile:manage", …] }
  ```
  The claim is omitted entirely when no active org, or defensively when the membership has been deleted between the touch and the mint.

## Test plan

- [x] `SessionTokenIssuerOrgClaimTest`: omits org claim when no active org; embeds `{id,slg,rol,per}` on active org; reflects role permission changes on next mint; defensively omits when membership is missing. 4 tests.
- [x] `ActiveOrganizationTest`: PUT /me/active_organization bumps token_version on change; no-op when same; touch validates membership (422); touch with valid org bumps token_version. 4 tests.
- [x] Full Pest suite passes (413 tests).
- [x] `vendor/bin/pint --test` clean.

Closes #42