### PR TITLE
Domain enrollment automation: DNS verification + sign-up matching (AU-9)

### DIFF
--- a/app/Events/Organizations/OrganizationDomainVerified.php
+++ b/app/Events/Organizations/OrganizationDomainVerified.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Organizations;
+
+use App\Models\OrganizationDomain;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class OrganizationDomainVerified
+{
+    use Dispatchable;
+
+    public function __construct(public readonly OrganizationDomain $domain) {}
+}

--- a/app/Http/Controllers/Bapi/OrganizationDomainController.php
+++ b/app/Http/Controllers/Bapi/OrganizationDomainController.php
@@ -10,6 +10,7 @@ use App\Events\Organizations\OrganizationDomainUpdated;
 use App\Http\Requests\Bapi\Organizations\CreateDomainRequest;
 use App\Http\Requests\Bapi\Organizations\UpdateDomainRequest;
 use App\Http\Resources\OrganizationDomainResource;
+use App\Jobs\Organizations\VerifyOrganizationDomain;
 use App\Models\Environment;
 use App\Models\Organization;
 use App\Models\OrganizationDomain;
@@ -159,6 +160,7 @@ final class OrganizationDomainController
         }
 
         $verification = $this->issueDnsTxtVerification($env, $domain);
+        VerifyOrganizationDomain::dispatch($domain->id);
 
         return response()->json(OrganizationDomainResource::from($domain->fresh(), $verification));
     }

--- a/app/Http/Controllers/Fapi/SignUpController.php
+++ b/app/Http/Controllers/Fapi/SignUpController.php
@@ -24,6 +24,7 @@ use App\Models\User;
 use App\Models\Verification;
 use App\Models\VerificationCode;
 use App\Services\Client\ClientResolver;
+use App\Services\Domains\DomainEnroller;
 use App\Services\Sessions\SessionLifecycle;
 use App\Services\Sessions\SessionTokenIssuer;
 use App\Services\Verification\VerificationManager;
@@ -407,6 +408,11 @@ final class SignUpController
                     'redeemed_by_user_id' => $user->id,
                 ], $env);
             }
+
+            // AU-9: domain enrollment automation. Match the freshly-verified
+            // primary email against verified OrganizationDomain rows and
+            // create the right invitation / membership-request rows.
+            app(DomainEnroller::class)->enroll($env, $email->fresh());
 
             return $this->envelope($client, $attempt->fresh(), 200, $session, $attachClientCookie);
         });

--- a/app/Jobs/Maintenance/RecheckVerifiedDomains.php
+++ b/app/Jobs/Maintenance/RecheckVerifiedDomains.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Maintenance;
+
+use App\Jobs\Organizations\VerifyOrganizationDomain;
+use App\Models\OrganizationDomain;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Daily fan-out: re-check every verified OrganizationDomain so a TXT
+ * record that disappears flips back to `verified=false`. AU-13's
+ * dashboard surfaces the demoted state next to a "verify again" button.
+ */
+final class RecheckVerifiedDomains implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function handle(): void
+    {
+        OrganizationDomain::query()
+            ->withoutGlobalScopes()
+            ->where('verified', true)
+            ->whereNotNull('verification_id')
+            ->orderBy('id')
+            ->chunk(200, function ($domains): void {
+                foreach ($domains as $domain) {
+                    VerifyOrganizationDomain::dispatch($domain->id);
+                }
+            });
+    }
+}

--- a/app/Jobs/Organizations/VerifyOrganizationDomain.php
+++ b/app/Jobs/Organizations/VerifyOrganizationDomain.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Organizations;
+
+use App\Events\Organizations\OrganizationDomainUpdated;
+use App\Events\Organizations\OrganizationDomainVerified;
+use App\Models\OrganizationDomain;
+use App\Models\Verification;
+use App\Services\Domains\DnsTxtResolver;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Polls the `_authn-verification.<domain>` TXT record looking for the
+ * Verification.nonce. On match: flip OrganizationDomain.verified=true +
+ * Verification.status=verified and fire OrganizationDomainVerified.
+ *
+ * On miss: increment Verification.attempts and re-enqueue with a
+ * capped backoff. Used both as the imperative trigger from
+ * `POST /v1/organizations/{org}/domains/{dom}/verify` (via
+ * `VerifyOrganizationDomain::dispatch`) and on a scheduled cron so a
+ * verified domain whose TXT record disappears flips back to unverified.
+ */
+final class VerifyOrganizationDomain implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** Attempts beyond this point stop the imperative retry loop. */
+    public const MAX_ATTEMPTS = 24;
+
+    /**
+     * Backoff schedule (seconds) for the imperative path. Index = attempt#.
+     * After ~24h we stop retrying and the cron re-checks.
+     *
+     * @var list<int>
+     */
+    public const BACKOFF_SCHEDULE = [
+        60, 60, 120, 120, 300, 300, 600, 600, 900, 900,
+        1800, 1800, 3600, 3600, 3600, 3600,
+        7200, 7200, 14400, 14400, 14400, 14400, 14400, 14400,
+    ];
+
+    public int $tries = 1;
+
+    public function __construct(public readonly string $domainId)
+    {
+        $this->onQueue('default');
+    }
+
+    public function handle(DnsTxtResolver $resolver): void
+    {
+        $domain = OrganizationDomain::query()->withoutGlobalScopes()->where('id', $this->domainId)->first();
+        if ($domain === null) {
+            return;
+        }
+        $verification = $domain->verification_id !== null
+            ? Verification::query()->withoutGlobalScopes()->where('id', $domain->verification_id)->first()
+            : null;
+        if ($verification === null) {
+            Log::info('domain_verification_no_challenge', ['domain_id' => $domain->id]);
+
+            return;
+        }
+
+        $expected = (string) $verification->nonce;
+        if ($expected === '') {
+            return;
+        }
+
+        $records = $resolver->resolve('_authn-verification.'.$domain->name);
+        $matched = false;
+        foreach ($records as $record) {
+            if (str_contains($record, $expected)) {
+                $matched = true;
+
+                break;
+            }
+        }
+
+        if ($matched) {
+            $this->flipToVerified($domain, $verification);
+
+            return;
+        }
+
+        $this->recordMiss($domain, $verification);
+    }
+
+    private function flipToVerified(OrganizationDomain $domain, Verification $verification): void
+    {
+        $wasVerified = (bool) $domain->verified;
+        $verification->forceFill([
+            'status' => Verification::STATUS_VERIFIED,
+            'verified_at' => now(),
+        ])->save();
+        $domain->forceFill(['verified' => true])->save();
+
+        if (! $wasVerified) {
+            OrganizationDomainVerified::dispatch($domain->fresh());
+        }
+        OrganizationDomainUpdated::dispatch($domain->fresh());
+    }
+
+    private function recordMiss(OrganizationDomain $domain, Verification $verification): void
+    {
+        $attempt = (int) $verification->attempts + 1;
+        $verification->forceFill(['attempts' => $attempt])->save();
+
+        // If the domain was previously verified and the TXT record is gone,
+        // demote it. The org admin can `/verify` again to re-issue.
+        if ($domain->verified) {
+            $domain->forceFill(['verified' => false])->save();
+            OrganizationDomainUpdated::dispatch($domain->fresh());
+        }
+
+        if ($attempt >= self::MAX_ATTEMPTS) {
+            return;
+        }
+
+        $delay = self::BACKOFF_SCHEDULE[$attempt - 1] ?? end(self::BACKOFF_SCHEDULE);
+        self::dispatch($domain->id)->delay(now()->addSeconds((int) $delay));
+    }
+}

--- a/app/Services/Domains/DnsTxtResolver.php
+++ b/app/Services/Domains/DnsTxtResolver.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Domains;
+
+/**
+ * Indirection over the system DNS resolver so AU-9's verification job can
+ * be unit-tested without hitting the wider internet. The default
+ * implementation uses PHP's `dns_get_record` and is rebound with a fake
+ * in tests via `app()->instance(DnsTxtResolver::class, …)`.
+ */
+class DnsTxtResolver
+{
+    /**
+     * Returns every TXT record value under `<host>`. Each TXT record's
+     * fragment list is concatenated (per the DNS strings-as-rope rule).
+     *
+     * @return list<string>
+     */
+    public function resolve(string $host): array
+    {
+        $records = @dns_get_record($host, DNS_TXT);
+        if (! is_array($records)) {
+            return [];
+        }
+        $out = [];
+        foreach ($records as $record) {
+            if (! is_array($record)) {
+                continue;
+            }
+            if (isset($record['txt']) && is_string($record['txt'])) {
+                $out[] = $record['txt'];
+
+                continue;
+            }
+            if (isset($record['entries']) && is_array($record['entries'])) {
+                $out[] = implode('', array_filter($record['entries'], 'is_string'));
+            }
+        }
+
+        return $out;
+    }
+}

--- a/app/Services/Domains/DomainEnroller.php
+++ b/app/Services/Domains/DomainEnroller.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Domains;
+
+use App\Events\Organizations\OrganizationInvitationCreated;
+use App\Events\Organizations\OrganizationMembershipRequestCreated;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\OrganizationDomain;
+use App\Models\OrganizationInvitation;
+use App\Models\OrganizationMembership;
+use App\Models\OrganizationMembershipRequest;
+use App\Models\Role;
+use App\Services\Tickets\TicketIssuer;
+use App\Support\Url;
+
+/**
+ * Runs the domain-match step of sign-up promotion (AU-9). Given a verified
+ * EmailAddress, finds every verified `OrganizationDomain` matching the
+ * email's host part and creates the appropriate `OrganizationInvitation`
+ * (`automatic_invitation`) or `OrganizationMembershipRequest`
+ * (`automatic_suggestion`) per domain.
+ *
+ * `manual_invitation` is a no-op here — the org admin issues invitations
+ * through the BAPI / FAPI surface explicitly.
+ */
+final class DomainEnroller
+{
+    public function __construct(private readonly TicketIssuer $tickets) {}
+
+    public function enroll(Environment $environment, EmailAddress $email): void
+    {
+        $host = $this->extractHost((string) $email->email_address);
+        if ($host === null) {
+            return;
+        }
+
+        $domains = OrganizationDomain::query()
+            ->where('environment_id', $environment->id)
+            ->where('verified', true)
+            ->where('name', $host)
+            ->whereIn('enrollment_mode', [
+                OrganizationDomain::MODE_AUTOMATIC_INVITATION,
+                OrganizationDomain::MODE_AUTOMATIC_SUGGESTION,
+            ])
+            ->with('organization')
+            ->get();
+
+        foreach ($domains as $domain) {
+            if ($domain->enrollment_mode === OrganizationDomain::MODE_AUTOMATIC_INVITATION) {
+                $this->autoInvite($environment, $email, $domain);
+            } else {
+                $this->autoSuggest($environment, $email, $domain);
+            }
+        }
+    }
+
+    private function autoInvite(Environment $env, EmailAddress $email, OrganizationDomain $domain): void
+    {
+        $org = $domain->organization;
+        if ($org === null) {
+            return;
+        }
+        if ($org->max_allowed_memberships !== null && $org->members_count >= $org->max_allowed_memberships) {
+            return;
+        }
+
+        $duplicate = OrganizationInvitation::query()
+            ->where('organization_id', $org->id)
+            ->where('email_address', strtolower((string) $email->email_address))
+            ->where('status', OrganizationInvitation::STATUS_PENDING)
+            ->exists();
+        if ($duplicate) {
+            return;
+        }
+
+        $defaultRole = Role::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('is_default', true)
+            ->first();
+        if ($defaultRole === null) {
+            return;
+        }
+
+        $expiresAt = now()->addSeconds(30 * 24 * 60 * 60);
+        $invitation = OrganizationInvitation::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'organization_id' => $org->id,
+            'email_address' => strtolower((string) $email->email_address),
+            'role_id' => $defaultRole->id,
+            'inviter_user_id' => null,
+            'redirect_url' => null,
+            'status' => OrganizationInvitation::STATUS_PENDING,
+            'public_metadata' => ['source' => 'domain_enrollment'],
+            'expires_at' => $expiresAt,
+        ]);
+        $org->increment('pending_invitations_count');
+        $domain->increment('total_pending_invitations');
+
+        $jwt = $this->tickets->issue($env, max(60, $expiresAt->getTimestamp() - now()->getTimestamp()), [
+            'sub' => $invitation->email_address,
+            'sid' => $invitation->id,
+            'purpose' => 'organization_invitation',
+            'metadata' => is_array($invitation->public_metadata) ? $invitation->public_metadata : [],
+            'redirect_url' => null,
+        ]);
+        $url = $this->ticketUrl($env, $jwt);
+
+        OrganizationInvitationCreated::dispatch($invitation, $url);
+    }
+
+    private function autoSuggest(Environment $env, EmailAddress $email, OrganizationDomain $domain): void
+    {
+        $org = $domain->organization;
+        if ($org === null || $email->user_id === null) {
+            return;
+        }
+
+        $alreadyMember = OrganizationMembership::query()
+            ->where('organization_id', $org->id)
+            ->where('user_id', $email->user_id)
+            ->exists();
+        if ($alreadyMember) {
+            return;
+        }
+
+        $duplicate = OrganizationMembershipRequest::query()
+            ->where('organization_id', $org->id)
+            ->where('user_id', $email->user_id)
+            ->where('status', OrganizationMembershipRequest::STATUS_PENDING)
+            ->exists();
+        if ($duplicate) {
+            return;
+        }
+
+        $req = OrganizationMembershipRequest::create([
+            'environment_id' => $env->id,
+            'organization_id' => $org->id,
+            'user_id' => $email->user_id,
+            'status' => OrganizationMembershipRequest::STATUS_PENDING,
+        ]);
+        $domain->increment('total_pending_suggestions');
+
+        OrganizationMembershipRequestCreated::dispatch($req);
+    }
+
+    private function extractHost(string $emailAddress): ?string
+    {
+        $at = strrpos($emailAddress, '@');
+        if ($at === false) {
+            return null;
+        }
+        $host = strtolower(substr($emailAddress, $at + 1));
+
+        return $host === '' ? null : $host;
+    }
+
+    private function ticketUrl(Environment $env, string $jwt): string
+    {
+        $base = Url::fapi($env, '');
+        $query = http_build_query([
+            '__authn_ticket' => $jwt,
+            '__authn_status' => 'sign_up',
+        ]);
+
+        return rtrim($base, '/').'/sign-up?'.$query;
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,6 +3,7 @@
 use App\Jobs\Maintenance\ExpireSessions;
 use App\Jobs\Maintenance\PruneVerificationCodes;
 use App\Jobs\Maintenance\ReapAbandonedAttempts;
+use App\Jobs\Maintenance\RecheckVerifiedDomains;
 use App\Jobs\Maintenance\RotateSigningKey;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
@@ -36,4 +37,8 @@ Schedule::job(PruneVerificationCodes::class)
 
 Schedule::job(RotateSigningKey::class)
     ->everyFiveMinutes()
+    ->withoutOverlapping();
+
+Schedule::job(RecheckVerifiedDomains::class)
+    ->daily()
     ->withoutOverlapping();

--- a/tests/Feature/Http/Bapi/OrganizationDomainsTest.php
+++ b/tests/Feature/Http/Bapi/OrganizationDomainsTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 use App\Events\Organizations\OrganizationDomainCreated;
 use App\Events\Organizations\OrganizationDomainDeleted;
 use App\Events\Organizations\OrganizationDomainUpdated;
+use App\Jobs\Organizations\VerifyOrganizationDomain;
 use App\Models\Environment;
 use App\Models\OrganizationDomain;
 use App\Models\Verification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
 use Tests\Feature\Http\Bapi\BapiTestSupport;
 use Tests\TestCase;
@@ -100,6 +102,7 @@ it('PATCH /domains/{id} updates enrollment_mode and fires the event', function (
 });
 
 it('POST /domains/{id}/verify re-issues a fresh Verification with a new nonce', function (): void {
+    Bus::fake([VerifyOrganizationDomain::class]);
     $ctx = setupOrgForDomains($this);
     $created = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'verify.test']);
     $id = $created->json('id');
@@ -111,6 +114,7 @@ it('POST /domains/{id}/verify re-issues a fresh Verification with a new nonce', 
     expect($r->json('verification.id'))->not->toBe($firstVerificationId);
     expect($r->json('verification.nonce'))->not->toBe($firstNonce);
     expect($r->json('verification.strategy'))->toBe('domain_dns_txt');
+    Bus::assertDispatched(VerifyOrganizationDomain::class, 1);
 });
 
 it('DELETE /domains/{id} removes the row and fires the event', function (): void {

--- a/tests/Feature/Jobs/Organizations/VerifyOrganizationDomainTest.php
+++ b/tests/Feature/Jobs/Organizations/VerifyOrganizationDomainTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\Organizations\OrganizationDomainVerified;
+use App\Jobs\Organizations\VerifyOrganizationDomain;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationDomain;
+use App\Models\Project;
+use App\Models\Verification;
+use App\Services\Domains\DnsTxtResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+
+uses(RefreshDatabase::class);
+
+class FakeDnsTxtResolver extends DnsTxtResolver
+{
+    /** @var array<string, list<string>> */
+    public array $records = [];
+
+    public function resolve(string $host): array
+    {
+        return $this->records[$host] ?? [];
+    }
+}
+
+function bootDomainEnv(): array
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-domain']);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'acme',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    return ['env' => $env];
+}
+
+function makeUnverifiedDomain(Environment $env, string $name = 'acme.test', string $mode = 'manual_invitation'): OrganizationDomain
+{
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => 'acme-'.$name]);
+    $domain = OrganizationDomain::create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'name' => $name,
+        'enrollment_mode' => $mode,
+    ]);
+    $verification = Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'verifiable_type' => $domain->getMorphClass(),
+        'verifiable_id' => $domain->id,
+        'strategy' => Verification::STRATEGY_DOMAIN_DNS_TXT,
+        'status' => Verification::STATUS_UNVERIFIED,
+        'attempts' => 0,
+        'expire_at' => now()->addDays(14),
+        'nonce' => 'authn-domain-verify=fixture-nonce-1234',
+    ]);
+    $domain->forceFill(['verification_id' => $verification->id])->save();
+
+    return $domain->fresh();
+}
+
+it('flips a domain to verified when the TXT record matches and fires OrganizationDomainVerified', function (): void {
+    Event::fake([OrganizationDomainVerified::class]);
+    $f = bootDomainEnv();
+    $domain = makeUnverifiedDomain($f['env']);
+
+    $resolver = new FakeDnsTxtResolver;
+    $resolver->records['_authn-verification.acme.test'] = ['authn-domain-verify=fixture-nonce-1234'];
+    app()->instance(DnsTxtResolver::class, $resolver);
+
+    (new VerifyOrganizationDomain($domain->id))->handle($resolver);
+
+    $fresh = $domain->fresh();
+    expect($fresh->verified)->toBeTrue();
+    $verification = Verification::query()->withoutGlobalScopes()->where('id', $fresh->verification_id)->firstOrFail();
+    expect($verification->status)->toBe('verified');
+    Event::assertDispatched(OrganizationDomainVerified::class, 1);
+});
+
+it('records a miss without flipping verified, increments attempts, re-enqueues', function (): void {
+    Bus::fake([VerifyOrganizationDomain::class]);
+    $f = bootDomainEnv();
+    $domain = makeUnverifiedDomain($f['env']);
+
+    $resolver = new FakeDnsTxtResolver;
+    // No matching TXT record present.
+    app()->instance(DnsTxtResolver::class, $resolver);
+
+    (new VerifyOrganizationDomain($domain->id))->handle($resolver);
+
+    $verification = Verification::query()->withoutGlobalScopes()->where('id', $domain->verification_id)->firstOrFail();
+    expect($verification->status)->toBe('unverified');
+    expect((int) $verification->attempts)->toBe(1);
+    expect($domain->fresh()->verified)->toBeFalse();
+    Bus::assertDispatched(VerifyOrganizationDomain::class, 1);
+});
+
+it('demotes a previously-verified domain when the TXT record disappears', function (): void {
+    Bus::fake([VerifyOrganizationDomain::class]);
+    $f = bootDomainEnv();
+    $domain = makeUnverifiedDomain($f['env']);
+    // Simulate already verified.
+    $domain->forceFill(['verified' => true])->save();
+    Verification::query()->withoutGlobalScopes()->where('id', $domain->verification_id)->update([
+        'status' => 'verified',
+        'verified_at' => now(),
+    ]);
+
+    $resolver = new FakeDnsTxtResolver;
+    // Record gone.
+    app()->instance(DnsTxtResolver::class, $resolver);
+
+    (new VerifyOrganizationDomain($domain->id))->handle($resolver);
+
+    expect($domain->fresh()->verified)->toBeFalse();
+});
+
+it('stops re-enqueueing after MAX_ATTEMPTS', function (): void {
+    Bus::fake([VerifyOrganizationDomain::class]);
+    $f = bootDomainEnv();
+    $domain = makeUnverifiedDomain($f['env']);
+    Verification::query()->withoutGlobalScopes()->where('id', $domain->verification_id)->update([
+        'attempts' => VerifyOrganizationDomain::MAX_ATTEMPTS - 1,
+    ]);
+
+    $resolver = new FakeDnsTxtResolver;
+    app()->instance(DnsTxtResolver::class, $resolver);
+
+    (new VerifyOrganizationDomain($domain->id))->handle($resolver);
+
+    Bus::assertNotDispatched(VerifyOrganizationDomain::class);
+});

--- a/tests/Feature/Services/Domains/DomainEnrollerTest.php
+++ b/tests/Feature/Services/Domains/DomainEnrollerTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\Organizations\OrganizationInvitationCreated;
+use App\Events\Organizations\OrganizationMembershipRequestCreated;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationDomain;
+use App\Models\OrganizationInvitation;
+use App\Models\OrganizationMembership;
+use App\Models\OrganizationMembershipRequest;
+use App\Models\Project;
+use App\Models\Role;
+use App\Models\User;
+use App\Services\Domains\DomainEnroller;
+use App\Services\Keys\SigningKeyGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+
+uses(RefreshDatabase::class);
+
+function makeEnrollerEnv(string $slug = 'enroller'): array
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+        'allowed_origins' => [],
+    ]);
+    (new SigningKeyGenerator)->generate($env);
+
+    return ['env' => $env];
+}
+
+function makeDomain(Environment $env, string $name, string $mode, bool $verified = true): OrganizationDomain
+{
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme '.$name, 'slug' => 'acme-'.str_replace('.', '-', $name)]);
+
+    return OrganizationDomain::create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'name' => $name,
+        'enrollment_mode' => $mode,
+        'verified' => $verified,
+    ]);
+}
+
+function makeUserWithEmail(Environment $env, string $email): array
+{
+    $user = new User(['environment_id' => $env->id, 'username' => substr($email, 0, strpos($email, '@'))]);
+    $user->save();
+    $row = EmailAddress::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'email_address' => $email,
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    return ['user' => $user, 'email' => $row];
+}
+
+it('manual_invitation domains do nothing on sign-up', function (): void {
+    Event::fake([OrganizationInvitationCreated::class, OrganizationMembershipRequestCreated::class]);
+    $f = makeEnrollerEnv();
+    makeDomain($f['env'], 'acme.test', OrganizationDomain::MODE_MANUAL_INVITATION);
+    $u = makeUserWithEmail($f['env'], 'newbie@acme.test');
+
+    app(DomainEnroller::class)->enroll($f['env'], $u['email']);
+
+    expect(OrganizationInvitation::query()->count())->toBe(0);
+    Event::assertNotDispatched(OrganizationInvitationCreated::class);
+    Event::assertNotDispatched(OrganizationMembershipRequestCreated::class);
+});
+
+it('automatic_invitation domains create a pending invitation in the env-default role', function (): void {
+    Event::fake([OrganizationInvitationCreated::class]);
+    $f = makeEnrollerEnv();
+    $domain = makeDomain($f['env'], 'auto.test', OrganizationDomain::MODE_AUTOMATIC_INVITATION);
+    $u = makeUserWithEmail($f['env'], 'newbie@auto.test');
+
+    app(DomainEnroller::class)->enroll($f['env'], $u['email']);
+
+    $invitation = OrganizationInvitation::query()->where('organization_id', $domain->organization_id)->firstOrFail();
+    expect($invitation->email_address)->toBe('newbie@auto.test');
+    expect($invitation->status)->toBe('pending');
+
+    $defaultRole = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('is_default', true)->firstOrFail();
+    expect($invitation->role_id)->toBe($defaultRole->id);
+
+    expect((int) $domain->fresh()->total_pending_invitations)->toBe(1);
+    expect((int) Organization::query()->withoutGlobalScopes()->where('id', $domain->organization_id)->firstOrFail()->pending_invitations_count)->toBe(1);
+
+    Event::assertDispatched(OrganizationInvitationCreated::class, 1);
+});
+
+it('automatic_suggestion domains create a pending OrganizationMembershipRequest', function (): void {
+    Event::fake([OrganizationMembershipRequestCreated::class]);
+    $f = makeEnrollerEnv();
+    $domain = makeDomain($f['env'], 'sug.test', OrganizationDomain::MODE_AUTOMATIC_SUGGESTION);
+    $u = makeUserWithEmail($f['env'], 'newbie@sug.test');
+
+    app(DomainEnroller::class)->enroll($f['env'], $u['email']);
+
+    $req = OrganizationMembershipRequest::query()->where('organization_id', $domain->organization_id)->firstOrFail();
+    expect($req->user_id)->toBe($u['user']->id);
+    expect($req->status)->toBe('pending');
+    expect((int) $domain->fresh()->total_pending_suggestions)->toBe(1);
+    Event::assertDispatched(OrganizationMembershipRequestCreated::class, 1);
+});
+
+it('respects max_allowed_memberships and skips auto-invite when at the cap', function (): void {
+    Event::fake([OrganizationInvitationCreated::class]);
+    $f = makeEnrollerEnv();
+    $domain = makeDomain($f['env'], 'cap.test', OrganizationDomain::MODE_AUTOMATIC_INVITATION);
+    Organization::query()->withoutGlobalScopes()->where('id', $domain->organization_id)->update([
+        'max_allowed_memberships' => 1,
+        'members_count' => 1,
+    ]);
+    $u = makeUserWithEmail($f['env'], 'newbie@cap.test');
+
+    app(DomainEnroller::class)->enroll($f['env'], $u['email']);
+
+    expect(OrganizationInvitation::query()->where('organization_id', $domain->organization_id)->count())->toBe(0);
+});
+
+it('multi-domain match — each matching domain produces its own row', function (): void {
+    Event::fake([OrganizationInvitationCreated::class, OrganizationMembershipRequestCreated::class]);
+    $f = makeEnrollerEnv();
+    $a = makeDomain($f['env'], 'multi.test', OrganizationDomain::MODE_AUTOMATIC_INVITATION);
+    $b = makeDomain($f['env'], 'multi.test2', OrganizationDomain::MODE_AUTOMATIC_INVITATION);
+    // Different host — should NOT match the email.
+    makeDomain($f['env'], 'unrelated.test', OrganizationDomain::MODE_AUTOMATIC_INVITATION);
+
+    $u = makeUserWithEmail($f['env'], 'newbie@multi.test');
+
+    app(DomainEnroller::class)->enroll($f['env'], $u['email']);
+
+    expect(OrganizationInvitation::query()->where('organization_id', $a->organization_id)->count())->toBe(1);
+    expect(OrganizationInvitation::query()->where('organization_id', $b->organization_id)->count())->toBe(0);
+    Event::assertDispatched(OrganizationInvitationCreated::class, 1);
+});
+
+it('skips when an unverified domain shares the email host', function (): void {
+    Event::fake([OrganizationInvitationCreated::class]);
+    $f = makeEnrollerEnv();
+    makeDomain($f['env'], 'unverified.test', OrganizationDomain::MODE_AUTOMATIC_INVITATION, verified: false);
+    $u = makeUserWithEmail($f['env'], 'newbie@unverified.test');
+
+    app(DomainEnroller::class)->enroll($f['env'], $u['email']);
+
+    expect(OrganizationInvitation::query()->count())->toBe(0);
+});
+
+it('does not create a duplicate invitation when one already pending', function (): void {
+    Event::fake([OrganizationInvitationCreated::class]);
+    $f = makeEnrollerEnv();
+    $domain = makeDomain($f['env'], 'dup.test', OrganizationDomain::MODE_AUTOMATIC_INVITATION);
+    $defaultRole = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('is_default', true)->firstOrFail();
+    OrganizationInvitation::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $domain->organization_id,
+        'email_address' => 'newbie@dup.test',
+        'role_id' => $defaultRole->id,
+        'status' => 'pending',
+    ]);
+
+    $u = makeUserWithEmail($f['env'], 'newbie@dup.test');
+    app(DomainEnroller::class)->enroll($f['env'], $u['email']);
+
+    expect(OrganizationInvitation::query()->where('organization_id', $domain->organization_id)->count())->toBe(1);
+    Event::assertNotDispatched(OrganizationInvitationCreated::class);
+});
+
+it('skips suggestion when user is already a member', function (): void {
+    Event::fake([OrganizationMembershipRequestCreated::class]);
+    $f = makeEnrollerEnv();
+    $domain = makeDomain($f['env'], 'already.test', OrganizationDomain::MODE_AUTOMATIC_SUGGESTION);
+    $u = makeUserWithEmail($f['env'], 'newbie@already.test');
+    $defaultRole = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('is_default', true)->firstOrFail();
+    OrganizationMembership::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $domain->organization_id,
+        'user_id' => $u['user']->id,
+        'role_id' => $defaultRole->id,
+    ]);
+
+    app(DomainEnroller::class)->enroll($f['env'], $u['email']);
+
+    expect(OrganizationMembershipRequest::query()->count())->toBe(0);
+    Event::assertNotDispatched(OrganizationMembershipRequestCreated::class);
+});


### PR DESCRIPTION
## Summary

Closes the loop on org domain verification and the auto-invitation / auto-suggestion sign-up paths.

**Verification:**
- `DnsTxtResolver` service indirects PHP's `dns_get_record` so the job is unit-testable with a fake.
- `VerifyOrganizationDomain` job: looks up `_authn-verification.<domain>` and matches against the linked `Verification.nonce`. On match: flips `OrganizationDomain.verified=true`, marks the `Verification.status=verified`, fires `OrganizationDomainVerified`. On miss: increments `Verification.attempts`, demotes a previously-verified row when the TXT record has disappeared, re-enqueues itself with a backoff schedule that tops out around 24h. Imperative trigger fires from the BAPI verify endpoint; a daily cron via `RecheckVerifiedDomains` re-checks every verified row.

**Sign-up matching:**
- `DomainEnroller` service runs after `SignUpController` finalises the User + EmailAddress. Matches the email's host against verified `OrganizationDomain` rows in the env and:
  - `automatic_invitation` → creates a pending `OrganizationInvitation` in the env-default role, increments `pending_invitations_count` + `domain.total_pending_invitations`, emits `OrganizationInvitationCreated` with the ticket URL.
  - `automatic_suggestion` → creates a pending `OrganizationMembershipRequest`, increments `domain.total_pending_suggestions`, emits `OrganizationMembershipRequestCreated`.
  - `manual_invitation` → no-op (admin issues invites explicitly).
- Honors `max_allowed_memberships`, dedupes against a pending invitation for the same email, and skips suggestion when the user is already a member.

## Test plan

- [x] `VerifyOrganizationDomainTest`: matched flip + event; missed records attempt + re-enqueue; demoted previously-verified; stops after `MAX_ATTEMPTS`. 4 tests with a `FakeDnsTxtResolver`.
- [x] `DomainEnrollerTest`: manual no-op; auto-invite happy + counter caches + default role + event; auto-suggest happy + counter cache + event; max-memberships ceiling; multi-domain; unverified domain skipped; duplicate-pending dedupe; already-a-member dedupe. 8 tests.
- [x] Full Pest suite passes (425 tests).
- [x] `vendor/bin/pint --test` clean.

Closes #43