### PR TITLE
Email magic-link strategy on sign-in + sign-up (AU-10)

### DIFF
--- a/app/Auth/Strategies/EmailLinkStrategy.php
+++ b/app/Auth/Strategies/EmailLinkStrategy.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Auth\ErrorCodes;
+use App\Jobs\Mail\SendMagicLinkEmail;
+use App\Models\EmailAddress;
+use App\Models\EmailTemplate;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Services\MagicLink\MagicLinkIssuer;
+use App\Services\Verification\VerificationManager;
+
+/**
+ * email_link first-factor for sign-in (AU-10). The originating device
+ * polls the SignInAttempt; the click device hits MagicLinkController
+ * which flips the Verification.status to verified, and the next poll
+ * promotes the attempt to complete.
+ *
+ * prepare:
+ *   - Resolves the EmailAddress (by id or by attempt.identifier).
+ *   - Starts a Verification(strategy=email_link, TTL 5m) attached to
+ *     the SignInAttempt itself so the click handler can resolve back
+ *     to the attempt without an extra lookup.
+ *   - Mints the magic-link JWT + persists its hash on a VerificationCode.
+ *   - Dispatches SendMagicLinkEmail.
+ *
+ * attempt:
+ *   - Returns success only when the polled Verification.status flipped
+ *     to verified. The actual flip happens out-of-band when the user
+ *     clicks the link.
+ */
+final class EmailLinkStrategy implements Strategy
+{
+    public const TTL_SECONDS = MagicLinkIssuer::TTL_SECONDS;
+
+    public function __construct(
+        private readonly VerificationManager $verifications,
+        private readonly MagicLinkIssuer $issuer,
+    ) {}
+
+    public function name(): string
+    {
+        return Verification::STRATEGY_EMAIL_LINK;
+    }
+
+    public function requiresPrepare(): bool
+    {
+        return true;
+    }
+
+    public function prepare(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $emailAddress = $this->resolveEmailAddress($attempt, $params);
+        if ($emailAddress === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'No email address matches this identifier.', 422);
+        }
+
+        // Open the Verification on the SignInAttempt itself — the click
+        // handler reads the verifiable to resolve the originating attempt
+        // without needing the EmailAddress id again.
+        $verification = $this->verifications->start(
+            $attempt,
+            Verification::STRATEGY_EMAIL_LINK,
+            self::TTL_SECONDS,
+        );
+
+        $minted = $this->issuer->issue($verification, isset($params['redirect_url']) && is_string($params['redirect_url']) ? $params['redirect_url'] : null);
+
+        SendMagicLinkEmail::dispatch(
+            $attempt->environment_id,
+            $emailAddress->email_address,
+            $minted['url'],
+            EmailTemplate::SLUG_MAGIC_LINK_SIGN_IN,
+            $verification->id,
+            $emailAddress->id,
+        );
+
+        $attempt->forceFill(['first_factor_verification_id' => $verification->id])->save();
+
+        return StrategyResult::ok($attempt);
+    }
+
+    public function attempt(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $verification = Verification::query()
+            ->withoutGlobalScopes()
+            ->where('id', (string) $attempt->first_factor_verification_id)
+            ->first();
+        if ($verification === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, 'No magic link is in flight for this attempt.', 422);
+        }
+
+        if ($verification->status === Verification::STATUS_UNVERIFIED) {
+            // Still pending — the user hasn't clicked the link yet. The SDK
+            // polls; we tell it to keep waiting.
+            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, 'Magic link not yet redeemed.', 422);
+        }
+        if ($verification->status === Verification::STATUS_EXPIRED) {
+            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_EXPIRED, 'Magic link expired.', 422);
+        }
+        if ($verification->status !== Verification::STATUS_VERIFIED) {
+            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, "Magic link verification is in status {$verification->status}.", 422);
+        }
+
+        // Verified — resolve the user via the email captured at prepare-time.
+        $email = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower((string) $attempt->identifier))
+            ->first();
+        $user = $email !== null
+            ? User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first()
+            : null;
+        if ($user === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'User not found.', 422);
+        }
+        if ($user->banned) {
+            return StrategyResult::fail($attempt, ErrorCodes::USER_BANNED, 'This user is banned.', 403);
+        }
+        if ($user->locked && $user->lockout_expires_at?->isFuture()) {
+            return StrategyResult::fail($attempt, ErrorCodes::USER_LOCKED, 'This user is temporarily locked.', 403);
+        }
+
+        return StrategyResult::ok($attempt, $user);
+    }
+
+    private function resolveEmailAddress(SignInAttempt $attempt, array $params): ?EmailAddress
+    {
+        $emailAddressId = $params['email_address_id'] ?? null;
+        if (is_string($emailAddressId) && $emailAddressId !== '') {
+            return EmailAddress::query()
+                ->withoutGlobalScopes()
+                ->where('id', $emailAddressId)
+                ->where('environment_id', $attempt->environment_id)
+                ->first();
+        }
+
+        return EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower((string) $attempt->identifier))
+            ->first();
+    }
+}

--- a/app/Auth/StrategyResolver.php
+++ b/app/Auth/StrategyResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Auth;
 
 use App\Auth\Strategies\EmailCodeStrategy;
+use App\Auth\Strategies\EmailLinkStrategy;
 use App\Auth\Strategies\PasswordStrategy;
 use App\Auth\Strategies\ResetPasswordEmailCodeStrategy;
 use App\Auth\Strategies\Strategy;
@@ -21,6 +22,7 @@ final class StrategyResolver
     public function __construct(
         private readonly PasswordStrategy $password,
         private readonly EmailCodeStrategy $emailCode,
+        private readonly EmailLinkStrategy $emailLink,
         private readonly ResetPasswordEmailCodeStrategy $resetPasswordEmailCode,
         private readonly TicketStrategy $ticket,
     ) {}
@@ -30,6 +32,7 @@ final class StrategyResolver
         return match ($name) {
             Verification::STRATEGY_PASSWORD => $this->password,
             Verification::STRATEGY_EMAIL_CODE => $this->emailCode,
+            Verification::STRATEGY_EMAIL_LINK => $this->emailLink,
             Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE => $this->resetPasswordEmailCode,
             Verification::STRATEGY_TICKET => $this->ticket,
             default => throw new InvalidArgumentException("Strategy {$name} is not enabled in v0.1."),

--- a/app/Http/Controllers/Fapi/MagicLinkController.php
+++ b/app/Http/Controllers/Fapi/MagicLinkController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\SignInAttempt;
+use App\Models\SignUpAttempt;
+use App\Services\MagicLink\MagicLinkVerifier;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Click-time handler for the email_link strategy.
+ *
+ *   GET /v1/client/magic_link/redeem?__authn_magic_link=<jwt>&redirect_url=<url>
+ *
+ * Verifies the JWT against the env's signing keys, marks the matching
+ * VerificationCode consumed (replay protection), flips the parent
+ * Verification.status to verified, increments the originating Client's
+ * token_version so its next /v1/client poll sees the updated state, and
+ * either redirects to the supplied `redirect_url` (if any) or returns a
+ * minimal JSON envelope. The originating device's polled SignIn/SignUp
+ * attempt picks up the verified Verification on its next call.
+ *
+ * Re-clicking the same link returns 410 — the consumed VerificationCode
+ * is the replay-protection guard.
+ */
+final class MagicLinkController
+{
+    public function redeem(Request $request, MagicLinkVerifier $verifier): JsonResponse|RedirectResponse
+    {
+        $env = app(Environment::class);
+        $jwt = $request->query('__authn_magic_link');
+        if (! is_string($jwt) || $jwt === '') {
+            return $this->error(400, 'magic_link_missing', 'A magic link token is required.');
+        }
+
+        $result = $verifier->verify($jwt, $env);
+        if ($result['error'] !== null) {
+            $status = match ($result['error']) {
+                'expired', 'consumed' => 410,
+                default => 400,
+            };
+
+            return $this->error($status, 'magic_link_'.$result['error'], 'The magic link is '.$result['error'].'.');
+        }
+
+        $attempt = $result['attempt'];
+        if ($attempt instanceof SignInAttempt || $attempt instanceof SignUpAttempt) {
+            Client::query()
+                ->withoutGlobalScopes()
+                ->where('id', (string) $attempt->client_id)
+                ->update([
+                    'token_version' => DB::raw('token_version + 1'),
+                    'last_active_at' => now(),
+                ]);
+        }
+
+        $redirectUrl = $request->query('redirect_url');
+        if (is_string($redirectUrl) && $redirectUrl !== '') {
+            return redirect()->away($redirectUrl);
+        }
+
+        return response()->json([
+            'object' => 'magic_link_redemption',
+            'verified' => true,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Controllers/Fapi/SignUpController.php
+++ b/app/Http/Controllers/Fapi/SignUpController.php
@@ -13,9 +13,11 @@ use App\Auth\SignUp\TicketRedeemer;
 use App\Auth\TestMode\Policy as TestModePolicy;
 use App\Http\Resources\ClientResource;
 use App\Http\Resources\SignUpResource;
+use App\Jobs\Mail\SendMagicLinkEmail;
 use App\Jobs\Mail\SendVerificationEmail;
 use App\Models\Client;
 use App\Models\EmailAddress;
+use App\Models\EmailTemplate;
 use App\Models\Environment;
 use App\Models\Invitation;
 use App\Models\Session;
@@ -25,6 +27,7 @@ use App\Models\Verification;
 use App\Models\VerificationCode;
 use App\Services\Client\ClientResolver;
 use App\Services\Domains\DomainEnroller;
+use App\Services\MagicLink\MagicLinkIssuer;
 use App\Services\Sessions\SessionLifecycle;
 use App\Services\Sessions\SessionTokenIssuer;
 use App\Services\Verification\VerificationManager;
@@ -151,15 +154,16 @@ final class SignUpController
         if ($strategy === '') {
             return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', $client, $attempt);
         }
-        if ($strategy === Verification::STRATEGY_EMAIL_LINK) {
-            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, 'email_link sign-up lands in v0.2.', $client, $attempt);
-        }
-        if ($strategy !== Verification::STRATEGY_EMAIL_CODE) {
+        if (! in_array($strategy, [Verification::STRATEGY_EMAIL_CODE, Verification::STRATEGY_EMAIL_LINK], true)) {
             return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategy} is not enabled in v0.1.", $client, $attempt);
         }
 
         if (! is_string($attempt->email_address) || $attempt->email_address === '') {
             return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'email_address is required before preparing email verification.', $client, $attempt);
+        }
+
+        if ($strategy === Verification::STRATEGY_EMAIL_LINK) {
+            return $this->prepareEmailLink($client, $attempt, $request);
         }
 
         // For sign-up the email isn't yet on an EmailAddress row — start the
@@ -184,6 +188,35 @@ final class SignUpController
         return $this->envelope($client, $attempt->fresh());
     }
 
+    private function prepareEmailLink(Client $client, SignUpAttempt $attempt, Request $request): JsonResponse
+    {
+        $verification = $this->verifications->start(
+            $attempt,
+            Verification::STRATEGY_EMAIL_LINK,
+            MagicLinkIssuer::TTL_SECONDS,
+        );
+        $redirectUrl = $request->input('redirect_url');
+        $minted = app(MagicLinkIssuer::class)->issue(
+            $verification,
+            is_string($redirectUrl) && $redirectUrl !== '' ? $redirectUrl : null,
+        );
+
+        SendMagicLinkEmail::dispatch(
+            $attempt->environment_id,
+            (string) $attempt->email_address,
+            $minted['url'],
+            EmailTemplate::SLUG_MAGIC_LINK_SIGN_UP,
+            $verification->id,
+        );
+
+        $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
+        $verifications['email_address'] = $verification->id;
+        $attempt->verifications = $verifications;
+        $attempt->save();
+
+        return $this->envelope($client, $attempt->fresh());
+    }
+
     public function attemptVerification(Request $request): JsonResponse
     {
         $sid = (string) $request->route('sid');
@@ -194,12 +227,8 @@ final class SignUpController
         }
 
         $strategy = (string) $request->input('strategy', '');
-        if ($strategy !== Verification::STRATEGY_EMAIL_CODE) {
+        if (! in_array($strategy, [Verification::STRATEGY_EMAIL_CODE, Verification::STRATEGY_EMAIL_LINK], true)) {
             return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategy} is not enabled in v0.1.", $client, $attempt);
-        }
-        $code = $request->input('code');
-        if (! is_string($code) || $code === '') {
-            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'code is required.', $client, $attempt);
         }
 
         $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
@@ -210,6 +239,28 @@ final class SignUpController
         $verification = Verification::query()->withoutGlobalScopes()->where('id', $vid)->first();
         if ($verification === null) {
             return $this->error(422, ErrorCodes::NO_VERIFICATION_IN_PROGRESS, 'No email verification has been prepared.', $client, $attempt);
+        }
+
+        if ($strategy === Verification::STRATEGY_EMAIL_LINK) {
+            // Polling shape: the click flips Verification.status out-of-band.
+            if ($verification->status === Verification::STATUS_UNVERIFIED) {
+                return $this->error(422, ErrorCodes::VERIFICATION_FAILED, 'Magic link not yet redeemed.', $client, $attempt);
+            }
+            if ($verification->status === Verification::STATUS_EXPIRED) {
+                return $this->error(422, ErrorCodes::VERIFICATION_EXPIRED, 'Magic link expired.', $client, $attempt);
+            }
+            if ($verification->status !== Verification::STATUS_VERIFIED) {
+                return $this->error(422, ErrorCodes::VERIFICATION_FAILED, "Magic link verification is in status {$verification->status}.", $client, $attempt);
+            }
+
+            $env = app(Environment::class);
+
+            return $this->finalizeIfReady($env, $client, $attempt, ['email_address' => true]);
+        }
+
+        $code = $request->input('code');
+        if (! is_string($code) || $code === '') {
+            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'code is required.', $client, $attempt);
         }
 
         $ok = $this->verifications->attempt($verification, $code);

--- a/app/Jobs/Mail/SendMagicLinkEmail.php
+++ b/app/Jobs/Mail/SendMagicLinkEmail.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Mail;
+
+use App\Mail\EmailPipeline;
+use App\Mail\Renderer;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\User;
+use App\Models\Verification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Sends the magic-link email for the email_link sign-in / sign-up flow
+ * (AU-10). Distinct from SendVerificationEmail so the template slug
+ * + payload can carry the action_url instead of an OTP code.
+ */
+final class SendMagicLinkEmail implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function __construct(
+        public readonly string $environmentId,
+        public readonly string $emailAddress,
+        public readonly string $actionUrl,
+        public readonly string $templateSlug,
+        public readonly ?string $verificationId = null,
+        public readonly ?string $emailAddressId = null,
+    ) {
+        $this->onQueue('mail');
+    }
+
+    public function backoff(): array
+    {
+        return [10, 60, 300];
+    }
+
+    public function handle(EmailPipeline $pipeline): void
+    {
+        $env = Environment::query()->withoutGlobalScopes()->where('id', $this->environmentId)->first();
+        if ($env === null) {
+            Log::warning('mail_environment_missing', ['environment_id' => $this->environmentId]);
+
+            return;
+        }
+
+        $emailRow = $this->emailAddressId !== null
+            ? EmailAddress::query()->withoutGlobalScopes()->where('id', $this->emailAddressId)->first()
+            : EmailAddress::query()->withoutGlobalScopes()
+                ->where('environment_id', $env->id)
+                ->where('email_address', strtolower($this->emailAddress))
+                ->first();
+        $verification = $this->verificationId !== null
+            ? Verification::query()->withoutGlobalScopes()->where('id', $this->verificationId)->first()
+            : null;
+        $user = $emailRow?->user_id !== null
+            ? User::query()->withoutGlobalScopes()->where('id', $emailRow->user_id)->first()
+            : null;
+
+        $pipeline->dispatch(
+            environment: $env,
+            templateSlug: $this->templateSlug,
+            toEmail: $this->emailAddress,
+            toName: $user?->first_name,
+            vars: [
+                'user' => [
+                    'first_name' => (string) ($user?->first_name ?? ''),
+                    'last_name' => (string) ($user?->last_name ?? ''),
+                    'email_address' => $this->emailAddress,
+                ],
+                'action_url' => $this->actionUrl,
+                'expires_at_human' => $verification !== null
+                    ? Renderer::humanExpires($verification->expire_at)
+                    : 'in 5 minutes',
+            ],
+            emailAddress: $emailRow,
+            verification: $verification,
+        );
+    }
+}

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -44,6 +44,7 @@ class Client extends Model
         'last_active_session_id',
         'current_sign_in_attempt_id',
         'current_sign_up_attempt_id',
+        'token_version',
         'device_fingerprint',
         'last_active_at',
     ];

--- a/app/Models/EmailTemplate.php
+++ b/app/Models/EmailTemplate.php
@@ -108,6 +108,16 @@ class EmailTemplate extends Model
             'body_markup' => "<mjml><mj-body><mj-section><mj-column><mj-text>Hi {{user.first_name}},</mj-text><mj-text>The primary email on your account was changed. If this wasn't you, contact {{app.support_email}}.</mj-text></mj-column></mj-section></mj-body></mjml>",
             'body_html' => "<!doctype html><html><body><p>Hi {{user.first_name}},</p><p>The primary email on your account was changed. If this wasn't you, contact {{app.support_email}}.</p></body></html>",
         ],
+        self::SLUG_MAGIC_LINK_SIGN_IN => [
+            'subject' => 'Sign in to {{app.name}}',
+            'body_markup' => '<mjml><mj-body><mj-section><mj-column><mj-text>Click the link below to sign in. It expires {{expires_at_human}}.</mj-text><mj-button href="{{action_url}}">Sign in</mj-button></mj-column></mj-section></mj-body></mjml>',
+            'body_html' => '<!doctype html><html><body><p>Click the link below to sign in. It expires {{expires_at_human}}.</p><p><a href="{{action_url}}">Sign in</a></p></body></html>',
+        ],
+        self::SLUG_MAGIC_LINK_SIGN_UP => [
+            'subject' => 'Finish creating your {{app.name}} account',
+            'body_markup' => '<mjml><mj-body><mj-section><mj-column><mj-text>Click the link below to finish creating your account. It expires {{expires_at_human}}.</mj-text><mj-button href="{{action_url}}">Continue</mj-button></mj-column></mj-section></mj-body></mjml>',
+            'body_html' => '<!doctype html><html><body><p>Click the link below to finish creating your account. It expires {{expires_at_human}}.</p><p><a href="{{action_url}}">Continue</a></p></body></html>',
+        ],
     ];
 
     protected string $idPrefix = 'tmpl_';

--- a/app/Services/MagicLink/MagicLinkIssuer.php
+++ b/app/Services/MagicLink/MagicLinkIssuer.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\MagicLink;
+
+use App\Models\Environment;
+use App\Models\SigningKey;
+use App\Models\Verification;
+use App\Models\VerificationCode;
+use App\Support\Url;
+use Illuminate\Support\Facades\DB;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use RuntimeException;
+
+/**
+ * Mints `__authn_magic_link` JWTs for the email_link strategy. The token
+ * carries `sub: <verification_id>`, `purpose: email_link`, `iat`, `exp`.
+ * The sha256 of the JWT is persisted on a new `VerificationCode` so the
+ * click-time handler can verify the JWT without storing plaintext, AND
+ * detect replay (consumed_at) on a second click.
+ */
+final class MagicLinkIssuer
+{
+    public const TTL_SECONDS = 5 * 60;
+
+    public const PURPOSE = 'email_link';
+
+    /**
+     * Mint a JWT for the supplied Verification, persist its hash as a
+     * VerificationCode, and return the click URL the email should embed.
+     *
+     * @return array{jwt: string, url: string}
+     */
+    public function issue(Verification $verification, ?string $redirectUrl = null): array
+    {
+        $env = $verification->environment;
+        if (! $env instanceof Environment) {
+            throw new RuntimeException('Verification has no resolvable environment.');
+        }
+
+        $signingKey = $env->signingKeys()
+            ->where('status', SigningKey::STATUS_ACTIVE)
+            ->latest('activated_at')
+            ->firstOrFail();
+        $config = Configuration::forAsymmetricSigner(
+            new Sha256,
+            InMemory::plainText($signingKey->privatePem()),
+            InMemory::plainText('public-not-needed-for-signing'),
+        );
+
+        $now = now();
+        $expiresAt = $now->copy()->addSeconds(self::TTL_SECONDS);
+
+        $token = $config->builder()
+            ->withHeader('kid', $signingKey->id)
+            ->issuedBy(Url::fapi($env, ''))
+            ->permittedFor('magic_link')
+            ->relatedTo($verification->id)
+            ->identifiedBy($this->mintJti())
+            ->issuedAt($now->toDateTimeImmutable())
+            ->canOnlyBeUsedAfter($now->toDateTimeImmutable())
+            ->expiresAt($expiresAt->toDateTimeImmutable())
+            ->withClaim('purpose', self::PURPOSE)
+            ->getToken($config->signer(), $config->signingKey())
+            ->toString();
+
+        DB::transaction(function () use ($verification, $token, $expiresAt): void {
+            VerificationCode::query()->create([
+                'verification_id' => $verification->id,
+                'code_hash' => hash('sha256', $token),
+                'purpose' => VerificationCode::PURPOSE_MAGIC_LINK,
+                'expires_at' => $expiresAt,
+                'created_at' => now(),
+            ]);
+        });
+
+        return [
+            'jwt' => $token,
+            'url' => $this->clickUrl($env, $token, $redirectUrl),
+        ];
+    }
+
+    private function clickUrl(Environment $env, string $jwt, ?string $redirectUrl): string
+    {
+        $base = Url::fapi($env, '');
+        $query = http_build_query(array_filter([
+            '__authn_magic_link' => $jwt,
+            'redirect_url' => $redirectUrl,
+        ], fn ($v): bool => $v !== null && $v !== ''));
+
+        return rtrim($base, '/').'/v1/client/magic_link/redeem?'.$query;
+    }
+
+    private function mintJti(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(16)), '+/', '-_'), '=');
+    }
+}

--- a/app/Services/MagicLink/MagicLinkVerifier.php
+++ b/app/Services/MagicLink/MagicLinkVerifier.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\MagicLink;
+
+use App\Models\Environment;
+use App\Models\SignInAttempt;
+use App\Models\SigningKey;
+use App\Models\SignUpAttempt;
+use App\Models\Verification;
+use App\Models\VerificationCode;
+use Illuminate\Support\Facades\DB;
+use Lcobucci\Clock\SystemClock;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Token\Plain;
+use Lcobucci\JWT\Validation\Constraint\PermittedFor;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Lcobucci\JWT\Validation\Constraint\StrictValidAt;
+
+/**
+ * Click-time companion to MagicLinkIssuer. Verifies the JWT against the
+ * env's signing keys, ensures `aud=magic_link`, checks expiry, and
+ * atomically:
+ *
+ *   - marks the matching VerificationCode consumed (replay protection),
+ *   - flips the parent Verification.status to verified,
+ *   - returns the parent attempt (SignInAttempt | SignUpAttempt) so the
+ *     controller can render the right redirect.
+ *
+ * Re-clicking the same link returns `consumed`.
+ */
+final class MagicLinkVerifier
+{
+    /**
+     * @return array{
+     *   verification: ?Verification,
+     *   attempt: SignInAttempt|SignUpAttempt|null,
+     *   error: ?string,
+     * }
+     */
+    public function verify(string $jwt, Environment $environment): array
+    {
+        $tokenHash = hash('sha256', $jwt);
+
+        $code = VerificationCode::query()
+            ->where('code_hash', $tokenHash)
+            ->where('purpose', VerificationCode::PURPOSE_MAGIC_LINK)
+            ->whereHas('verification', fn ($q) => $q->where('environment_id', $environment->id))
+            ->first();
+        if ($code === null) {
+            return $this->fail('invalid');
+        }
+        if ($code->consumed_at !== null) {
+            return $this->fail('consumed');
+        }
+        if ($code->expires_at->isPast()) {
+            return $this->fail('expired');
+        }
+
+        if (! $this->signatureMatches($jwt, $environment)) {
+            return $this->fail('invalid');
+        }
+
+        $verification = $code->verification;
+        if ($verification === null) {
+            return $this->fail('invalid');
+        }
+        if ($verification->status !== Verification::STATUS_UNVERIFIED) {
+            return $this->fail('consumed');
+        }
+
+        $attempt = $this->resolveAttempt($verification);
+
+        DB::transaction(function () use ($code, $verification): void {
+            $code->forceFill(['consumed_at' => now()])->save();
+            $verification->forceFill([
+                'status' => Verification::STATUS_VERIFIED,
+                'verified_at' => now(),
+            ])->save();
+        });
+
+        return [
+            'verification' => $verification->fresh(),
+            'attempt' => $attempt,
+            'error' => null,
+        ];
+    }
+
+    /**
+     * @return array{verification: null, attempt: null, error: string}
+     */
+    private function fail(string $error): array
+    {
+        return ['verification' => null, 'attempt' => null, 'error' => $error];
+    }
+
+    private function signatureMatches(string $jwt, Environment $environment): bool
+    {
+        try {
+            $config = Configuration::forSymmetricSigner(
+                new Sha256,
+                InMemory::plainText(str_repeat('x', 64)), // unused, parser only
+            );
+            $token = $config->parser()->parse($jwt);
+            if (! $token instanceof Plain) {
+                return false;
+            }
+            $kid = $token->headers()->get('kid');
+            if (! is_string($kid) || $kid === '') {
+                return false;
+            }
+        } catch (\Throwable) {
+            return false;
+        }
+
+        $signingKey = $environment->signingKeys()
+            ->where('id', $kid)
+            ->whereIn('status', [
+                SigningKey::STATUS_ACTIVE,
+                SigningKey::STATUS_RETIRING,
+                SigningKey::STATUS_PENDING,
+            ])
+            ->first();
+        if ($signingKey === null) {
+            return false;
+        }
+
+        try {
+            $publicPem = $this->extractPublicPem($signingKey);
+            $verifyConfig = Configuration::forAsymmetricSigner(
+                new Sha256,
+                InMemory::plainText('private-not-needed-for-verification'),
+                InMemory::plainText($publicPem),
+            );
+            $verifyConfig->validator()->assert(
+                $token,
+                new SignedWith($verifyConfig->signer(), $verifyConfig->verificationKey()),
+                new StrictValidAt(SystemClock::fromSystemTimezone()),
+                new PermittedFor('magic_link'),
+            );
+
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    private function extractPublicPem(SigningKey $signingKey): string
+    {
+        $resource = openssl_pkey_get_private($signingKey->privatePem());
+        $details = openssl_pkey_get_details($resource);
+
+        return $details['key'];
+    }
+
+    private function resolveAttempt(Verification $verification): SignInAttempt|SignUpAttempt|null
+    {
+        $type = $verification->verifiable_type;
+        $id = $verification->verifiable_id;
+        if ($type === (new SignInAttempt)->getMorphClass()) {
+            return SignInAttempt::query()->withoutGlobalScopes()->where('id', $id)->first();
+        }
+        if ($type === (new SignUpAttempt)->getMorphClass()) {
+            return SignUpAttempt::query()->withoutGlobalScopes()->where('id', $id)->first();
+        }
+
+        return null;
+    }
+}

--- a/database/migrations/0014_01_01_000000_add_token_version_to_clients.php
+++ b/database/migrations/0014_01_01_000000_add_token_version_to_clients.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds `token_version` to `clients` so the cross-device magic-link flow
+ * can invalidate the originating device's polled Client snapshot the
+ * moment the click happens (PLAN §9.10 / AU-10).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('clients', function (Blueprint $table): void {
+            $table->unsignedInteger('token_version')->default(0)->after('current_sign_up_attempt_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('clients', function (Blueprint $table): void {
+            $table->dropColumn('token_version');
+        });
+    }
+};

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Http\Controllers\AccountPortal\AccountPortalController;
 use App\Http\Controllers\Fapi\ClientController;
 use App\Http\Controllers\Fapi\EnvironmentController;
+use App\Http\Controllers\Fapi\MagicLinkController;
 use App\Http\Controllers\Fapi\MeController;
 use App\Http\Controllers\Fapi\MeOrganizationController;
 use App\Http\Controllers\Fapi\OrganizationController as FapiOrganizationController;
@@ -61,6 +62,10 @@ Route::prefix('v1')->group(function (): void {
         Route::put('/client', [ClientController::class, 'store'])->name('fapi.client.store');
         Route::delete('/client', [ClientController::class, 'destroy'])->name('fapi.client.destroy');
         Route::match(['get', 'post'], '/client/handshake', [ClientController::class, 'handshake'])->name('fapi.client.handshake');
+
+        // Magic-link click handler (AU-10). Top-level browser navigation
+        // from the email — no Origin header, no Client cookie required.
+        Route::get('/client/magic_link/redeem', [MagicLinkController::class, 'redeem'])->name('fapi.magic_link.redeem');
     });
 
     // Sign-in: POST creates the attempt (and, if needed, the Client). The

--- a/tests/Feature/Http/SignIn/EmailLinkTest.php
+++ b/tests/Feature/Http/SignIn/EmailLinkTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\Mail\SendMagicLinkEmail;
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Models\VerificationCode;
+use App\Services\Client\ClientResolver;
+use App\Services\MagicLink\MagicLinkIssuer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\Sessions\SessionsTestSupport;
+
+uses(RefreshDatabase::class);
+
+function fapiReq(string $method, string $path, array $body = [], array $headers = []): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders(array_merge([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+        ], $headers))
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+function setupMagicLinkUser(Environment $env, string $email = 'alice@example.com'): array
+{
+    $user = new User(['environment_id' => $env->id, 'first_name' => 'Alice']);
+    $user->save();
+    $emailRow = EmailAddress::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'email_address' => $email,
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    return ['user' => $user, 'email' => $emailRow];
+}
+
+it('prepare_first_factor email_link issues a magic link, dispatches the email job', function (): void {
+    Bus::fake([SendMagicLinkEmail::class]);
+    $f = SessionsTestSupport::bootEnv();
+    $u = setupMagicLinkUser($f['env']);
+
+    // Create a sign-in attempt directly (mirrors what FAPI POST does).
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $cookie = app(ClientResolver::class)->mintCookieValue($client);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'identifier' => 'alice@example.com',
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+    ]);
+
+    $r = test()->withCredentials()
+        ->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => $f['origin'],
+        ])
+        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$attempt->id}/prepare_first_factor", [
+            'strategy' => 'email_link',
+            'email_address_id' => $u['email']->id,
+        ]);
+    $r->assertOk();
+
+    $verification = Verification::query()->withoutGlobalScopes()
+        ->where('verifiable_type', $attempt->getMorphClass())
+        ->where('verifiable_id', $attempt->id)
+        ->where('strategy', 'email_link')
+        ->firstOrFail();
+    expect($verification->status)->toBe('unverified');
+    expect(VerificationCode::query()
+        ->where('verification_id', $verification->id)
+        ->where('purpose', 'magic_link')
+        ->exists())->toBeTrue();
+
+    Bus::assertDispatched(SendMagicLinkEmail::class, fn ($job) => $job->emailAddress === 'alice@example.com');
+});
+
+it('attempt_first_factor email_link returns verification_failed while link is still unredeemed', function (): void {
+    Bus::fake([SendMagicLinkEmail::class]);
+    $f = SessionsTestSupport::bootEnv();
+    $u = setupMagicLinkUser($f['env']);
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $cookie = app(ClientResolver::class)->mintCookieValue($client);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'identifier' => 'alice@example.com',
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+    ]);
+
+    test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$attempt->id}/prepare_first_factor", [
+            'strategy' => 'email_link',
+            'email_address_id' => $u['email']->id,
+        ])->assertOk();
+
+    test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$attempt->id}/attempt_first_factor", [
+            'strategy' => 'email_link',
+        ])->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'verification_failed');
+});
+
+it('end-to-end same-device magic link flow: prepare → click → attempt completes', function (): void {
+    Bus::fake([SendMagicLinkEmail::class]);
+    $f = SessionsTestSupport::bootEnv();
+    $u = setupMagicLinkUser($f['env']);
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $cookie = app(ClientResolver::class)->mintCookieValue($client);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'identifier' => 'alice@example.com',
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+    ]);
+
+    test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$attempt->id}/prepare_first_factor", [
+            'strategy' => 'email_link',
+            'email_address_id' => $u['email']->id,
+        ])->assertOk();
+
+    // Mint a magic link directly (simulates the email click). The issuer
+    // returns the click URL so we extract the JWT from it.
+    $verification = Verification::query()->withoutGlobalScopes()
+        ->where('verifiable_type', $attempt->getMorphClass())
+        ->where('verifiable_id', $attempt->id)
+        ->where('strategy', 'email_link')
+        ->firstOrFail();
+    // Re-mint a fresh JWT so the test exercises the click path. The
+    // VerificationCode persisted on prepare is what the verifier matches
+    // against — we use that one.
+    $code = VerificationCode::query()->where('verification_id', $verification->id)->firstOrFail();
+    expect($code->consumed_at)->toBeNull();
+
+    // Re-issue using the issuer to get a fresh JWT we have plaintext for.
+    $issued = app(MagicLinkIssuer::class)->issue($verification);
+
+    // Click the link.
+    $click = test()->withHeaders(['Host' => 'acme.authn.local'])
+        ->getJson("https://acme.authn.local/v1/client/magic_link/redeem?__authn_magic_link={$issued['jwt']}");
+    $click->assertOk()->assertJsonPath('verified', true);
+
+    // Verification flipped + Client.token_version bumped.
+    expect($verification->fresh()->status)->toBe('verified');
+    expect((int) Client::query()->withoutGlobalScopes()->where('id', $client->id)->firstOrFail()->token_version)->toBe(1);
+
+    // Now poll attempt_first_factor — should complete and return a session.
+    $r = test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$attempt->id}/attempt_first_factor", [
+            'strategy' => 'email_link',
+        ]);
+    $r->assertOk()->assertJsonPath('response.status', 'complete');
+});
+
+it('replay protection: second click on the same link returns 410 consumed', function (): void {
+    Bus::fake([SendMagicLinkEmail::class]);
+    $f = SessionsTestSupport::bootEnv();
+    $u = setupMagicLinkUser($f['env']);
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'identifier' => 'alice@example.com',
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+    ]);
+    $verification = Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => 'email_link',
+        'status' => 'unverified',
+        'attempts' => 0,
+        'expire_at' => now()->addMinutes(5),
+    ]);
+    $issued = app(MagicLinkIssuer::class)->issue($verification);
+
+    test()->withHeaders(['Host' => 'acme.authn.local'])
+        ->getJson("https://acme.authn.local/v1/client/magic_link/redeem?__authn_magic_link={$issued['jwt']}")
+        ->assertOk();
+
+    // Second click — replay.
+    test()->withHeaders(['Host' => 'acme.authn.local'])
+        ->getJson("https://acme.authn.local/v1/client/magic_link/redeem?__authn_magic_link={$issued['jwt']}")
+        ->assertStatus(410)
+        ->assertJsonPath('errors.0.code', 'magic_link_consumed');
+});
+
+it('expired link returns 410', function (): void {
+    Bus::fake([SendMagicLinkEmail::class]);
+    $f = SessionsTestSupport::bootEnv();
+    $u = setupMagicLinkUser($f['env']);
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'identifier' => 'alice@example.com',
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+    ]);
+    $verification = Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => 'email_link',
+        'status' => 'unverified',
+        'attempts' => 0,
+        'expire_at' => now()->addMinutes(5),
+    ]);
+    $issued = app(MagicLinkIssuer::class)->issue($verification);
+    // Force-expire the persisted VerificationCode.
+    VerificationCode::query()->where('verification_id', $verification->id)->update([
+        'expires_at' => now()->subMinute(),
+    ]);
+
+    test()->withHeaders(['Host' => 'acme.authn.local'])
+        ->getJson("https://acme.authn.local/v1/client/magic_link/redeem?__authn_magic_link={$issued['jwt']}")
+        ->assertStatus(410)
+        ->assertJsonPath('errors.0.code', 'magic_link_expired');
+});
+
+it('missing/invalid token returns 400', function (): void {
+    SessionsTestSupport::bootEnv();
+
+    test()->withHeaders(['Host' => 'acme.authn.local'])
+        ->getJson('https://acme.authn.local/v1/client/magic_link/redeem')
+        ->assertStatus(400)
+        ->assertJsonPath('errors.0.code', 'magic_link_missing');
+
+    test()->withHeaders(['Host' => 'acme.authn.local'])
+        ->getJson('https://acme.authn.local/v1/client/magic_link/redeem?__authn_magic_link=garbage')
+        ->assertStatus(400)
+        ->assertJsonPath('errors.0.code', 'magic_link_invalid');
+});
+
+it('redirect_url query param triggers a 302 redirect', function (): void {
+    Bus::fake([SendMagicLinkEmail::class]);
+    $f = SessionsTestSupport::bootEnv();
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'identifier' => 'alice@example.com',
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+    ]);
+    $verification = Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => 'email_link',
+        'status' => 'unverified',
+        'attempts' => 0,
+        'expire_at' => now()->addMinutes(5),
+    ]);
+    $issued = app(MagicLinkIssuer::class)->issue($verification, 'https://app.example.com/welcome');
+
+    test()->withHeaders(['Host' => 'acme.authn.local'])
+        ->get("https://acme.authn.local/v1/client/magic_link/redeem?__authn_magic_link={$issued['jwt']}&redirect_url=https://app.example.com/welcome")
+        ->assertRedirect('https://app.example.com/welcome');
+});

--- a/tests/Feature/Http/SignUp/EmailLinkTest.php
+++ b/tests/Feature/Http/SignUp/EmailLinkTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\Mail\SendMagicLinkEmail;
+use App\Models\Client;
+use App\Models\SignUpAttempt;
+use App\Models\Verification;
+use App\Services\Client\ClientResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\Feature\Http\Sessions\SessionsTestSupport;
+
+uses(RefreshDatabase::class);
+
+it('prepare_verification email_link issues a magic link, dispatches the email job', function (): void {
+    Bus::fake([SendMagicLinkEmail::class]);
+    $f = SessionsTestSupport::bootEnv(userSettings: ['identifiers' => ['email_address' => ['enabled' => true, 'used_for_first_factor' => true, 'verifications' => ['email_code', 'email_link']]]]);
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $cookie = app(ClientResolver::class)->mintCookieValue($client);
+    $attempt = SignUpAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'email_address' => 'newbie@example.com',
+        'status' => SignUpAttempt::STATUS_MISSING_REQUIREMENTS,
+    ]);
+
+    $r = test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ups/{$attempt->id}/prepare_verification", [
+            'strategy' => 'email_link',
+        ]);
+    $r->assertOk();
+
+    $verification = Verification::query()->withoutGlobalScopes()
+        ->where('verifiable_type', $attempt->getMorphClass())
+        ->where('verifiable_id', $attempt->id)
+        ->where('strategy', 'email_link')
+        ->firstOrFail();
+    expect($verification->status)->toBe('unverified');
+
+    Bus::assertDispatched(SendMagicLinkEmail::class, fn ($job) => $job->emailAddress === 'newbie@example.com'
+        && $job->templateSlug === 'magic_link_sign_up');
+});
+
+it('attempt_verification email_link returns verification_failed while link is unredeemed', function (): void {
+    Bus::fake([SendMagicLinkEmail::class]);
+    $f = SessionsTestSupport::bootEnv();
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $cookie = app(ClientResolver::class)->mintCookieValue($client);
+    $attempt = SignUpAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'email_address' => 'newbie@example.com',
+        'status' => SignUpAttempt::STATUS_MISSING_REQUIREMENTS,
+    ]);
+
+    test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ups/{$attempt->id}/prepare_verification", [
+            'strategy' => 'email_link',
+        ])->assertOk();
+
+    test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign_ups/{$attempt->id}/attempt_verification", [
+            'strategy' => 'email_link',
+        ])->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'verification_failed');
+});


### PR DESCRIPTION
## Summary

Adds `email_link` as a first-factor strategy on sign-in + sign-up.

**Issuer + verifier:**
- `MagicLinkIssuer`: 5-minute RS256 JWT (`aud: magic_link`, `kid` header). Persists the sha256 of the JWT on a new `VerificationCode (purpose=magic_link)` so the click handler matches without holding plaintext server-side and detects replay via `consumed_at`.
- `MagicLinkVerifier`: re-derives the public key from the env signing key by `kid`, validates `aud=magic_link` + expiry, marks the `VerificationCode` consumed and flips `Verification.status=verified` inside one transaction.

**Sign-in:**
- `EmailLinkStrategy.prepare` opens the Verification on the `SignInAttempt`, mints the magic link, dispatches `SendMagicLinkEmail` with `magic_link_sign_in`.
- `attempt` returns `verification_failed` while unredeemed (poll loop), flips to `complete` + mints a session once verified.

**Sign-up:**
- `prepareVerification` now accepts `email_link` alongside `email_code`; `attemptVerification` polls for verified-status and finalizes when the link is clicked.

**Click handler:**
- New `GET /v1/client/magic_link/redeem` at the FAPI host (no Origin enforcement — top-level browser navigation). Bumps `Client.token_version` on the originating device so its next `/v1/client` poll sees the flipped state. Honors `redirect_url` with a 302.

**Schema:**
- Adds `clients.token_version` (migration 0014) for cross-device cache invalidation.

**Templates:**
- Placeholder `magic_link_sign_in` / `magic_link_sign_up` MJML in `EmailTemplate::DEFAULT_TEMPLATES`; AU-14 lands the production copy.

## Test plan

- [x] Sign-in `EmailLinkTest`: prepare issues + dispatches; attempt returns `verification_failed` while unredeemed; end-to-end same-device flow (prepare → click → attempt completes); replay protection (2nd click 410); expired (410); missing/invalid (400); `redirect_url` triggers 302. 7 tests.
- [x] Sign-up `EmailLinkTest`: prepare issues + dispatches with `magic_link_sign_up` slug; attempt returns `verification_failed` while unredeemed. 2 tests.
- [x] Full Pest suite passes (434 tests).
- [x] `vendor/bin/pint --test` clean.

Closes #44