### PR TITLE
Webhook emission for v0.2 events + active-org on session events (AU-11)

### DIFF
--- a/app/Listeners/Organizations/OrganizationWebhookListener.php
+++ b/app/Listeners/Organizations/OrganizationWebhookListener.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners\Organizations;
+
+use App\Events\Organizations\OrganizationCreated;
+use App\Events\Organizations\OrganizationDeleted;
+use App\Events\Organizations\OrganizationDomainCreated;
+use App\Events\Organizations\OrganizationDomainDeleted;
+use App\Events\Organizations\OrganizationDomainUpdated;
+use App\Events\Organizations\OrganizationDomainVerified;
+use App\Events\Organizations\OrganizationInvitationAccepted;
+use App\Events\Organizations\OrganizationInvitationCreated;
+use App\Events\Organizations\OrganizationInvitationRevoked;
+use App\Events\Organizations\OrganizationMembershipCreated;
+use App\Events\Organizations\OrganizationMembershipDeleted;
+use App\Events\Organizations\OrganizationMembershipRequestApproved;
+use App\Events\Organizations\OrganizationMembershipRequestCreated;
+use App\Events\Organizations\OrganizationMembershipRequestRejected;
+use App\Events\Organizations\OrganizationMembershipUpdated;
+use App\Events\Organizations\OrganizationUpdated;
+use App\Events\Organizations\RoleCreated;
+use App\Events\Organizations\RoleDeleted;
+use App\Events\Organizations\RolePermissionsChanged;
+use App\Events\Organizations\RoleUpdated;
+use App\Http\Resources\OrganizationDomainResource;
+use App\Http\Resources\OrganizationInvitationResource;
+use App\Http\Resources\OrganizationMembershipRequestResource;
+use App\Http\Resources\OrganizationMembershipResource;
+use App\Http\Resources\OrganizationResource;
+use App\Http\Resources\RoleResource;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Webhooks\Emitter;
+
+/**
+ * Maps every Eloquent organization-domain event from AU-3 / AU-4 / AU-5 /
+ * AU-7 / AU-9 to a `WebhookEvent` row of the documented type and queues
+ * deliveries through the existing v0.1 dispatcher.
+ *
+ * One method per event class so Laravel's auto-binding of `@param`
+ * type-hinted listeners works without dispatcher glue. Listener
+ * registration happens in AppServiceProvider::boot().
+ */
+final class OrganizationWebhookListener
+{
+    public function __construct(private readonly Emitter $emitter) {}
+
+    public function organizationCreated(OrganizationCreated $event): void
+    {
+        $this->emit('organization.created', OrganizationResource::from($event->organization, includePrivate: true), $event->organization);
+    }
+
+    public function organizationUpdated(OrganizationUpdated $event): void
+    {
+        $this->emit('organization.updated', OrganizationResource::from($event->organization, includePrivate: true), $event->organization);
+    }
+
+    public function organizationDeleted(OrganizationDeleted $event): void
+    {
+        $this->emit('organization.deleted', OrganizationResource::from($event->organization, includePrivate: true), $event->organization);
+    }
+
+    public function membershipCreated(OrganizationMembershipCreated $event): void
+    {
+        $org = $this->loadOrgFor($event->membership->organization_id);
+        $this->emit('organizationMembership.created', OrganizationMembershipResource::from($event->membership->load(['user', 'role.permissions']), includePrivate: true), $org);
+    }
+
+    public function membershipUpdated(OrganizationMembershipUpdated $event): void
+    {
+        $org = $this->loadOrgFor($event->membership->organization_id);
+        $this->emit('organizationMembership.updated', OrganizationMembershipResource::from($event->membership->load(['user', 'role.permissions']), includePrivate: true), $org);
+    }
+
+    public function membershipDeleted(OrganizationMembershipDeleted $event): void
+    {
+        $org = $this->loadOrgFor($event->membership->organization_id);
+        $this->emit('organizationMembership.deleted', OrganizationMembershipResource::from($event->membership->load(['user', 'role.permissions']), includePrivate: true), $org);
+    }
+
+    public function invitationCreated(OrganizationInvitationCreated $event): void
+    {
+        $org = $this->loadOrgFor($event->invitation->organization_id);
+        $this->emit('organizationInvitation.created', OrganizationInvitationResource::from($event->invitation->load('role'), $event->url), $org);
+    }
+
+    public function invitationAccepted(OrganizationInvitationAccepted $event): void
+    {
+        $org = $this->loadOrgFor($event->invitation->organization_id);
+        $this->emit('organizationInvitation.accepted', OrganizationInvitationResource::from($event->invitation->load('role')), $org);
+    }
+
+    public function invitationRevoked(OrganizationInvitationRevoked $event): void
+    {
+        $org = $this->loadOrgFor($event->invitation->organization_id);
+        $this->emit('organizationInvitation.revoked', OrganizationInvitationResource::from($event->invitation->load('role')), $org);
+    }
+
+    public function domainCreated(OrganizationDomainCreated $event): void
+    {
+        $org = $this->loadOrgFor($event->domain->organization_id);
+        $this->emit('organizationDomain.created', OrganizationDomainResource::from($event->domain), $org);
+    }
+
+    public function domainUpdated(OrganizationDomainUpdated $event): void
+    {
+        $org = $this->loadOrgFor($event->domain->organization_id);
+        $this->emit('organizationDomain.updated', OrganizationDomainResource::from($event->domain), $org);
+    }
+
+    public function domainDeleted(OrganizationDomainDeleted $event): void
+    {
+        $org = $this->loadOrgFor($event->domain->organization_id);
+        $this->emit('organizationDomain.deleted', OrganizationDomainResource::from($event->domain), $org);
+    }
+
+    public function domainVerified(OrganizationDomainVerified $event): void
+    {
+        $org = $this->loadOrgFor($event->domain->organization_id);
+        $this->emit('organizationDomain.verified', OrganizationDomainResource::from($event->domain), $org);
+    }
+
+    public function membershipRequestCreated(OrganizationMembershipRequestCreated $event): void
+    {
+        $org = $this->loadOrgFor($event->request->organization_id);
+        $this->emit('organizationMembershipRequest.created', OrganizationMembershipRequestResource::from($event->request), $org);
+    }
+
+    public function membershipRequestApproved(OrganizationMembershipRequestApproved $event): void
+    {
+        $org = $this->loadOrgFor($event->request->organization_id);
+        $this->emit('organizationMembershipRequest.accepted', OrganizationMembershipRequestResource::from($event->request), $org);
+    }
+
+    public function membershipRequestRejected(OrganizationMembershipRequestRejected $event): void
+    {
+        $org = $this->loadOrgFor($event->request->organization_id);
+        $this->emit('organizationMembershipRequest.rejected', OrganizationMembershipRequestResource::from($event->request), $org);
+    }
+
+    public function roleCreated(RoleCreated $event): void
+    {
+        $env = $this->loadEnv($event->role->environment_id);
+        $this->emitter->emit('role.created', RoleResource::from($event->role->load('permissions')), $env);
+    }
+
+    public function roleUpdated(RoleUpdated $event): void
+    {
+        $env = $this->loadEnv($event->role->environment_id);
+        $this->emitter->emit('role.updated', RoleResource::from($event->role->load('permissions')), $env);
+    }
+
+    public function roleDeleted(RoleDeleted $event): void
+    {
+        $env = $this->loadEnv($event->role->environment_id);
+        $this->emitter->emit('role.deleted', RoleResource::from($event->role->load('permissions')), $env);
+    }
+
+    public function rolePermissionsChanged(RolePermissionsChanged $event): void
+    {
+        $env = $this->loadEnv($event->role->environment_id);
+        $this->emitter->emit('role.updated', RoleResource::from($event->role->load('permissions')), $env);
+    }
+
+    /**
+     * Send the event through Emitter scoped to the org's Environment.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    private function emit(string $type, array $data, ?Organization $org): void
+    {
+        if ($org === null) {
+            return;
+        }
+        $env = $this->loadEnv($org->environment_id);
+        $this->emitter->emit($type, $data, $env);
+    }
+
+    private function loadOrgFor(?string $organizationId): ?Organization
+    {
+        if (! is_string($organizationId) || $organizationId === '') {
+            return null;
+        }
+
+        return Organization::query()->withoutGlobalScopes()->where('id', $organizationId)->first();
+    }
+
+    private function loadEnv(?string $environmentId): ?Environment
+    {
+        if (! is_string($environmentId) || $environmentId === '') {
+            return null;
+        }
+
+        return Environment::query()->withoutGlobalScopes()->where('id', $environmentId)->first();
+    }
+}

--- a/app/Models/WebhookEndpoint.php
+++ b/app/Models/WebhookEndpoint.php
@@ -87,8 +87,25 @@ class WebhookEndpoint extends Model
             return false;
         }
         $list = is_array($this->enabled_event_types) ? $this->enabled_event_types : [];
+        if (in_array('*', $list, true) || in_array($type, $list, true)) {
+            return true;
+        }
+        foreach ($list as $pattern) {
+            if (! is_string($pattern)) {
+                continue;
+            }
+            // Prefix glob: `organization.*` matches `organization.created`,
+            // `organization.updated`, etc. Trailing `*` is the only glob
+            // form supported — anything else is treated as a literal.
+            if (str_ends_with($pattern, '.*')) {
+                $prefix = substr($pattern, 0, -1); // keep the trailing dot
+                if (str_starts_with($type, $prefix)) {
+                    return true;
+                }
+            }
+        }
 
-        return in_array('*', $list, true) || in_array($type, $list, true);
+        return false;
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,11 +2,33 @@
 
 namespace App\Providers;
 
+use App\Events\Organizations\OrganizationCreated;
+use App\Events\Organizations\OrganizationDeleted;
+use App\Events\Organizations\OrganizationDomainCreated;
+use App\Events\Organizations\OrganizationDomainDeleted;
+use App\Events\Organizations\OrganizationDomainUpdated;
+use App\Events\Organizations\OrganizationDomainVerified;
+use App\Events\Organizations\OrganizationInvitationAccepted;
+use App\Events\Organizations\OrganizationInvitationCreated;
+use App\Events\Organizations\OrganizationInvitationRevoked;
+use App\Events\Organizations\OrganizationMembershipCreated;
+use App\Events\Organizations\OrganizationMembershipDeleted;
+use App\Events\Organizations\OrganizationMembershipRequestApproved;
+use App\Events\Organizations\OrganizationMembershipRequestCreated;
+use App\Events\Organizations\OrganizationMembershipRequestRejected;
+use App\Events\Organizations\OrganizationMembershipUpdated;
+use App\Events\Organizations\OrganizationUpdated;
+use App\Events\Organizations\RoleCreated;
+use App\Events\Organizations\RoleDeleted;
+use App\Events\Organizations\RolePermissionsChanged;
+use App\Events\Organizations\RoleUpdated;
+use App\Listeners\Organizations\OrganizationWebhookListener;
 use App\Models\Environment;
 use App\Models\Organization;
 use App\Models\User;
 use App\Observers\EnvironmentObserver;
 use App\Services\Tenancy\RoleSeeder;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
@@ -31,6 +53,37 @@ class AppServiceProvider extends ServiceProvider
                 $row['key'],
                 fn (User $user, Organization $org): bool => $user->hasOrgPermission($row['key'], $org),
             );
+        }
+
+        // AU-11: route every org-domain Eloquent event through the
+        // Webhooks\Emitter via OrganizationWebhookListener. Pairs map the
+        // event class to the listener method name (Laravel resolves the
+        // listener instance from the container).
+        $listener = OrganizationWebhookListener::class;
+        $eventMap = [
+            OrganizationCreated::class => 'organizationCreated',
+            OrganizationUpdated::class => 'organizationUpdated',
+            OrganizationDeleted::class => 'organizationDeleted',
+            OrganizationMembershipCreated::class => 'membershipCreated',
+            OrganizationMembershipUpdated::class => 'membershipUpdated',
+            OrganizationMembershipDeleted::class => 'membershipDeleted',
+            OrganizationInvitationCreated::class => 'invitationCreated',
+            OrganizationInvitationAccepted::class => 'invitationAccepted',
+            OrganizationInvitationRevoked::class => 'invitationRevoked',
+            OrganizationDomainCreated::class => 'domainCreated',
+            OrganizationDomainUpdated::class => 'domainUpdated',
+            OrganizationDomainDeleted::class => 'domainDeleted',
+            OrganizationDomainVerified::class => 'domainVerified',
+            OrganizationMembershipRequestCreated::class => 'membershipRequestCreated',
+            OrganizationMembershipRequestApproved::class => 'membershipRequestApproved',
+            OrganizationMembershipRequestRejected::class => 'membershipRequestRejected',
+            RoleCreated::class => 'roleCreated',
+            RoleUpdated::class => 'roleUpdated',
+            RoleDeleted::class => 'roleDeleted',
+            RolePermissionsChanged::class => 'rolePermissionsChanged',
+        ];
+        foreach ($eventMap as $event => $method) {
+            Event::listen($event, "{$listener}@{$method}");
         }
     }
 }

--- a/app/Services/Sessions/SessionLifecycle.php
+++ b/app/Services/Sessions/SessionLifecycle.php
@@ -6,6 +6,7 @@ namespace App\Services\Sessions;
 
 use App\Models\Client;
 use App\Models\Environment;
+use App\Models\OrganizationMembership;
 use App\Models\Session;
 use App\Models\SessionActivity;
 use App\Webhooks\Emitter;
@@ -248,9 +249,42 @@ final class SessionLifecycle
             'expire_at' => $session->expire_at->getTimestampMs(),
             'abandon_at' => $session->abandon_at?->getTimestampMs(),
             'last_active_organization_id' => $session->last_active_organization_id,
+            'organization' => $this->activeOrganizationShape($session),
             'actor' => $session->actor,
             'created_at' => $session->created_at?->getTimestampMs(),
             'updated_at' => $session->updated_at?->getTimestampMs(),
+        ];
+    }
+
+    /**
+     * Compact `{ id, slug, role, permissions[] }` block for the
+     * session's active organization (PLAN §4.4 / OA-5 / AU-11). Returns
+     * null when the session has no active org or when the membership row
+     * has been deleted between the touch and the emit.
+     *
+     * @return array{id: string, slug: string, role: string, permissions: list<string>}|null
+     */
+    private function activeOrganizationShape(Session $session): ?array
+    {
+        $orgId = $session->last_active_organization_id;
+        if (! is_string($orgId) || $orgId === '') {
+            return null;
+        }
+
+        $membership = OrganizationMembership::query()
+            ->where('organization_id', $orgId)
+            ->where('user_id', $session->user_id)
+            ->with(['organization', 'role.permissions'])
+            ->first();
+        if ($membership === null || $membership->organization === null || $membership->role === null) {
+            return null;
+        }
+
+        return [
+            'id' => $membership->organization->id,
+            'slug' => $membership->organization->slug,
+            'role' => $membership->role->key,
+            'permissions' => $membership->role->permissions->pluck('key')->unique()->values()->all(),
         ];
     }
 

--- a/tests/Feature/Webhooks/SessionActiveOrgTest.php
+++ b/tests/Feature/Webhooks/SessionActiveOrgTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\Webhooks\DispatchWebhookDelivery;
+use App\Models\Client;
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\Session;
+use App\Models\User;
+use App\Models\WebhookEndpoint;
+use App\Models\WebhookEvent;
+use App\Services\Sessions\SessionLifecycle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\Feature\Http\Sessions\SessionsTestSupport;
+
+uses(RefreshDatabase::class);
+
+it('session.created carries the active organization block when the session has one', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = SessionsTestSupport::bootEnv();
+    WebhookEndpoint::create([
+        'environment_id' => $f['env']->id,
+        'url' => 'https://example.test/hook',
+        'signing_secret' => WebhookEndpoint::mintSecret(),
+        'enabled_event_types' => ['session.*'],
+        'enabled' => true,
+    ]);
+
+    $user = new User(['environment_id' => $f['env']->id, 'username' => 'op']);
+    $user->save();
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme-active']);
+    $admin = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:admin')->firstOrFail();
+    OrganizationMembership::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'user_id' => $user->id,
+        'role_id' => $admin->id,
+    ]);
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $session = Session::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'user_id' => $user->id,
+        'status' => Session::STATUS_ACTIVE,
+        'last_active_organization_id' => $org->id,
+    ]);
+
+    app(SessionLifecycle::class)->notifyCreated($session->fresh());
+
+    $event = WebhookEvent::query()->where('type', 'session.created')->latest('id')->first();
+    expect($event)->not->toBeNull();
+    expect($event->data['organization'])->not->toBeNull();
+    expect($event->data['organization']['id'])->toBe($org->id);
+    expect($event->data['organization']['slug'])->toBe('acme-active');
+    expect($event->data['organization']['role'])->toBe('org:admin');
+    expect($event->data['organization']['permissions'])->toContain('org:sys_profile:manage');
+});
+
+it('session.created omits the organization block when no active org', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = SessionsTestSupport::bootEnv();
+    WebhookEndpoint::create([
+        'environment_id' => $f['env']->id,
+        'url' => 'https://example.test/hook',
+        'signing_secret' => WebhookEndpoint::mintSecret(),
+        'enabled_event_types' => ['*'],
+        'enabled' => true,
+    ]);
+
+    $user = new User(['environment_id' => $f['env']->id, 'username' => 'plain']);
+    $user->save();
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $session = Session::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'user_id' => $user->id,
+        'status' => Session::STATUS_ACTIVE,
+    ]);
+
+    app(SessionLifecycle::class)->notifyCreated($session->fresh());
+
+    $event = WebhookEvent::query()->where('type', 'session.created')->latest('id')->first();
+    expect($event)->not->toBeNull();
+    expect($event->data['organization'])->toBeNull();
+});

--- a/tests/Feature/Webhooks/V02EventEmissionTest.php
+++ b/tests/Feature/Webhooks/V02EventEmissionTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\Organizations\OrganizationCreated;
+use App\Events\Organizations\OrganizationDeleted;
+use App\Events\Organizations\OrganizationDomainCreated;
+use App\Events\Organizations\OrganizationDomainDeleted;
+use App\Events\Organizations\OrganizationDomainUpdated;
+use App\Events\Organizations\OrganizationDomainVerified;
+use App\Events\Organizations\OrganizationInvitationAccepted;
+use App\Events\Organizations\OrganizationInvitationCreated;
+use App\Events\Organizations\OrganizationInvitationRevoked;
+use App\Events\Organizations\OrganizationMembershipCreated;
+use App\Events\Organizations\OrganizationMembershipDeleted;
+use App\Events\Organizations\OrganizationMembershipRequestApproved;
+use App\Events\Organizations\OrganizationMembershipRequestCreated;
+use App\Events\Organizations\OrganizationMembershipRequestRejected;
+use App\Events\Organizations\OrganizationMembershipUpdated;
+use App\Events\Organizations\OrganizationUpdated;
+use App\Events\Organizations\RoleCreated;
+use App\Events\Organizations\RoleDeleted;
+use App\Events\Organizations\RolePermissionsChanged;
+use App\Events\Organizations\RoleUpdated;
+use App\Jobs\Webhooks\DispatchWebhookDelivery;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationDomain;
+use App\Models\OrganizationInvitation;
+use App\Models\OrganizationMembership;
+use App\Models\OrganizationMembershipRequest;
+use App\Models\Permission;
+use App\Models\Project;
+use App\Models\Role;
+use App\Models\User;
+use App\Models\WebhookDelivery;
+use App\Models\WebhookEndpoint;
+use App\Models\WebhookEvent;
+use App\Services\Keys\SigningKeyGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+
+uses(RefreshDatabase::class);
+
+function v02BootEnv(): array
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-events']);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'events',
+        'routing_label' => 'events',
+        'allowed_origins' => [],
+    ]);
+    (new SigningKeyGenerator)->generate($env);
+
+    return ['env' => $env];
+}
+
+function v02MakeEndpoint(Environment $env, array $types = ['*']): WebhookEndpoint
+{
+    return WebhookEndpoint::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'url' => 'https://example.test/hook',
+        'signing_secret' => WebhookEndpoint::mintSecret(),
+        'enabled_event_types' => $types,
+        'enabled' => true,
+    ]);
+}
+
+function v02MakeOrg(Environment $env, string $slug = 'acme'): Organization
+{
+    return Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => $slug]);
+}
+
+function v02LastEvent(string $type): ?WebhookEvent
+{
+    return WebhookEvent::query()->where('type', $type)->latest('id')->first();
+}
+
+it('emits organization.created/.updated/.deleted', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = v02BootEnv();
+    v02MakeEndpoint($f['env']);
+    $org = v02MakeOrg($f['env']);
+
+    OrganizationCreated::dispatch($org);
+    expect(v02LastEvent('organization.created')?->data['id'])->toBe($org->id);
+
+    OrganizationUpdated::dispatch($org);
+    expect(v02LastEvent('organization.updated'))->not->toBeNull();
+
+    OrganizationDeleted::dispatch($org);
+    expect(v02LastEvent('organization.deleted'))->not->toBeNull();
+});
+
+it('emits organizationMembership.created/.updated/.deleted with public_user_data', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = v02BootEnv();
+    v02MakeEndpoint($f['env']);
+    $org = v02MakeOrg($f['env']);
+    $user = new User(['environment_id' => $f['env']->id, 'username' => 'm']);
+    $user->save();
+    $admin = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:admin')->firstOrFail();
+    $m = OrganizationMembership::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'user_id' => $user->id,
+        'role_id' => $admin->id,
+    ]);
+
+    OrganizationMembershipCreated::dispatch($m);
+    $event = v02LastEvent('organizationMembership.created');
+    expect($event)->not->toBeNull();
+    expect($event->data['public_user_data']['user_id'])->toBe($user->id);
+
+    OrganizationMembershipUpdated::dispatch($m);
+    expect(v02LastEvent('organizationMembership.updated'))->not->toBeNull();
+
+    OrganizationMembershipDeleted::dispatch($m);
+    expect(v02LastEvent('organizationMembership.deleted'))->not->toBeNull();
+});
+
+it('emits organizationInvitation.created with url, plus accepted/revoked', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = v02BootEnv();
+    v02MakeEndpoint($f['env']);
+    $org = v02MakeOrg($f['env']);
+    $role = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:member')->firstOrFail();
+    $inv = OrganizationInvitation::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'email_address' => 'a@example.com',
+        'role_id' => $role->id,
+        'status' => 'pending',
+    ]);
+
+    OrganizationInvitationCreated::dispatch($inv, 'https://app.example.com/sign-up?__authn_ticket=fixture');
+    $event = v02LastEvent('organizationInvitation.created');
+    expect($event)->not->toBeNull();
+    expect($event->data['url'])->toBe('https://app.example.com/sign-up?__authn_ticket=fixture');
+
+    OrganizationInvitationAccepted::dispatch($inv);
+    expect(v02LastEvent('organizationInvitation.accepted'))->not->toBeNull();
+
+    OrganizationInvitationRevoked::dispatch($inv);
+    expect(v02LastEvent('organizationInvitation.revoked'))->not->toBeNull();
+});
+
+it('emits organizationDomain.created/updated/deleted/verified', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = v02BootEnv();
+    v02MakeEndpoint($f['env']);
+    $org = v02MakeOrg($f['env']);
+    $domain = OrganizationDomain::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'name' => 'acme.test',
+    ]);
+
+    OrganizationDomainCreated::dispatch($domain);
+    expect(v02LastEvent('organizationDomain.created'))->not->toBeNull();
+    OrganizationDomainUpdated::dispatch($domain);
+    expect(v02LastEvent('organizationDomain.updated'))->not->toBeNull();
+    OrganizationDomainVerified::dispatch($domain);
+    expect(v02LastEvent('organizationDomain.verified'))->not->toBeNull();
+    OrganizationDomainDeleted::dispatch($domain);
+    expect(v02LastEvent('organizationDomain.deleted'))->not->toBeNull();
+});
+
+it('emits organizationMembershipRequest.created/accepted/rejected', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = v02BootEnv();
+    v02MakeEndpoint($f['env']);
+    $org = v02MakeOrg($f['env']);
+    $user = new User(['environment_id' => $f['env']->id, 'username' => 'r']);
+    $user->save();
+    $req = OrganizationMembershipRequest::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'user_id' => $user->id,
+        'status' => 'pending',
+    ]);
+
+    OrganizationMembershipRequestCreated::dispatch($req);
+    expect(v02LastEvent('organizationMembershipRequest.created'))->not->toBeNull();
+    OrganizationMembershipRequestApproved::dispatch($req);
+    expect(v02LastEvent('organizationMembershipRequest.accepted'))->not->toBeNull();
+    OrganizationMembershipRequestRejected::dispatch($req);
+    expect(v02LastEvent('organizationMembershipRequest.rejected'))->not->toBeNull();
+});
+
+it('emits role.created/updated/deleted; RolePermissionsChanged maps to role.updated', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = v02BootEnv();
+    v02MakeEndpoint($f['env']);
+
+    $role = Role::create(['environment_id' => $f['env']->id, 'key' => 'org:custom', 'name' => 'C']);
+
+    RoleCreated::dispatch($role);
+    expect(v02LastEvent('role.created'))->not->toBeNull();
+
+    RoleUpdated::dispatch($role);
+    expect(v02LastEvent('role.updated'))->not->toBeNull();
+
+    $perm = Permission::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:sys_profile:read')->firstOrFail();
+    $role->permissions()->attach($perm->id);
+    RolePermissionsChanged::dispatch($role->fresh(), [$perm->key]);
+    // RolePermissionsChanged maps to role.updated per AU-11 spec.
+    expect(WebhookEvent::query()->where('type', 'role.updated')->count())->toBeGreaterThanOrEqual(2);
+
+    RoleDeleted::dispatch($role);
+    expect(v02LastEvent('role.deleted'))->not->toBeNull();
+});
+
+it('matches `organization.*` glob pattern on enabled_event_types', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = v02BootEnv();
+    $endpoint = v02MakeEndpoint($f['env'], types: ['organization.*']);
+    $org = v02MakeOrg($f['env']);
+
+    OrganizationCreated::dispatch($org);
+    OrganizationUpdated::dispatch($org);
+
+    expect(WebhookDelivery::query()->where('webhook_endpoint_id', $endpoint->id)->count())->toBe(2);
+});
+
+it('filters by literal exact match', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = v02BootEnv();
+    $endpoint = v02MakeEndpoint($f['env'], types: ['organization.created']);
+    $org = v02MakeOrg($f['env']);
+
+    OrganizationCreated::dispatch($org);
+    OrganizationUpdated::dispatch($org);
+    OrganizationDeleted::dispatch($org);
+
+    // Only organization.created subscribed.
+    expect(WebhookDelivery::query()->where('webhook_endpoint_id', $endpoint->id)->count())->toBe(1);
+});
+
+it('does NOT match unrelated prefix when listed event has different namespace', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = v02BootEnv();
+    $endpoint = v02MakeEndpoint($f['env'], types: ['role.*']);
+    $org = v02MakeOrg($f['env']);
+
+    OrganizationCreated::dispatch($org);
+    expect(WebhookDelivery::query()->where('webhook_endpoint_id', $endpoint->id)->count())->toBe(0);
+
+    $role = Role::create(['environment_id' => $f['env']->id, 'key' => 'org:custom2', 'name' => 'X']);
+    RoleCreated::dispatch($role);
+    expect(WebhookDelivery::query()->where('webhook_endpoint_id', $endpoint->id)->count())->toBe(1);
+});


### PR DESCRIPTION
## Summary

Plugs every Eloquent event from AU-3 / AU-4 / AU-5 / AU-7 / AU-9 into the existing v0.1 webhook dispatcher.

**OrganizationWebhookListener** routes 20 event classes through `Webhooks\Emitter` with the documented `WebhookEvent.type`:

| Eloquent event class | WebhookEvent.type |
|---|---|
| `Organization{Created,Updated,Deleted}` | `organization.{created,updated,deleted}` |
| `OrganizationMembership{Created,Updated,Deleted}` | `organizationMembership.{created,updated,deleted}` |
| `OrganizationInvitation{Created,Accepted,Revoked}` | `organizationInvitation.{created,accepted,revoked}` |
| `OrganizationDomain{Created,Updated,Deleted,Verified}` | `organizationDomain.{created,updated,deleted,verified}` |
| `OrganizationMembershipRequest{Created,Approved,Rejected}` | `organizationMembershipRequest.{created,accepted,rejected}` |
| `Role{Created,Updated,Deleted}` + `RolePermissionsChanged` | `role.{created,updated,deleted}` (Changed → updated) |

Resource shapes match OpenAPI: membership events include `public_user_data`; invitation `created` carries the ticket `url`.

**Active-organization on session events (OA-5):** `SessionLifecycle::shape` now includes an `organization` block (`{id, slug, role, permissions[]}`) when the session has an active org. Affects every `session.*` event the lifecycle service emits.

**Glob matching:** `WebhookEndpoint::matches()` accepts trailing-`*` prefix globs (`organization.*`). `*` and exact-string matches stay as before. No middle-glob.

## Test plan

- [x] `V02EventEmissionTest`: every event class fires the right `WebhookEvent.type` with the right resource shape (org / membership / invitation / domain / membership-request / role); glob matching for `organization.*`; literal exact match; non-match on unrelated prefix. 9 tests.
- [x] `SessionActiveOrgTest`: session.created carries the active-org block when set; omits when no active org. 2 tests.
- [x] Full Pest suite passes (445 tests).
- [x] `vendor/bin/pint --test` clean.

Closes #45