### PR TITLE
Dashboard organizations / roles & permissions panels (AU-13)

### DIFF
--- a/app/Http/Controllers/Dashboard/DashboardController.php
+++ b/app/Http/Controllers/Dashboard/DashboardController.php
@@ -10,8 +10,14 @@ use App\Models\BlocklistIdentifier;
 use App\Models\EmailTemplate;
 use App\Models\Environment;
 use App\Models\Invitation;
+use App\Models\Organization;
+use App\Models\OrganizationDomain;
+use App\Models\OrganizationInvitation;
 use App\Models\OrganizationMembership;
+use App\Models\OrganizationMembershipRequest;
+use App\Models\Permission;
 use App\Models\Project;
+use App\Models\Role;
 use App\Models\Session;
 use App\Models\User;
 use App\Models\WebhookDelivery;
@@ -402,6 +408,171 @@ final class DashboardController
                 'organization_id' => $workspace->organization_id,
                 'role' => $workspace->role?->key,
             ],
+        ]);
+    }
+
+    public function organizations(Request $request, string $project_slug, string $env_slug): InertiaResponse|RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+        $query = Organization::query()->withoutGlobalScopes()->where('environment_id', $env->id);
+        if ($request->filled('q')) {
+            $needle = '%'.strtolower((string) $request->input('q')).'%';
+            $query->where(function ($q) use ($needle): void {
+                $q->whereRaw('LOWER(name) LIKE ?', [$needle])
+                    ->orWhereRaw('LOWER(slug) LIKE ?', [$needle]);
+            });
+        }
+        $rows = $query->latest('created_at')->limit(50)->get();
+
+        return Inertia::render('Dashboard/Organizations', [
+            'organizations' => $rows->map(fn (Organization $o) => [
+                'id' => $o->id,
+                'name' => $o->name,
+                'slug' => $o->slug,
+                'members_count' => (int) $o->members_count,
+                'pending_invitations_count' => (int) $o->pending_invitations_count,
+                'admin_delete_enabled' => (bool) $o->admin_delete_enabled,
+                'created_at' => $o->created_at?->getTimestampMs(),
+            ])->all(),
+            'query' => (string) $request->input('q', ''),
+        ]);
+    }
+
+    public function organization(Request $request, string $project_slug, string $env_slug, string $organization_id): InertiaResponse|RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+        $org = Organization::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $organization_id)
+            ->first();
+        if ($org === null) {
+            return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/organizations");
+        }
+
+        $tab = (string) $request->input('tab', 'members');
+
+        $members = OrganizationMembership::query()
+            ->where('organization_id', $org->id)
+            ->with(['user', 'role'])
+            ->latest('created_at')
+            ->limit(100)
+            ->get()
+            ->map(fn (OrganizationMembership $m) => [
+                'id' => $m->id,
+                'user_id' => $m->user_id,
+                'role' => $m->role?->key,
+                'username' => $m->user?->username,
+                'first_name' => $m->user?->first_name,
+                'last_name' => $m->user?->last_name,
+                'created_at' => $m->created_at?->getTimestampMs(),
+            ])->all();
+
+        $invitations = OrganizationInvitation::query()
+            ->where('organization_id', $org->id)
+            ->with('role')
+            ->latest('created_at')
+            ->limit(100)
+            ->get()
+            ->map(fn (OrganizationInvitation $i) => [
+                'id' => $i->id,
+                'email_address' => $i->email_address,
+                'role' => $i->role?->key,
+                'status' => $i->status,
+                'expires_at' => $i->expires_at?->getTimestampMs(),
+                'created_at' => $i->created_at?->getTimestampMs(),
+            ])->all();
+
+        $requests = OrganizationMembershipRequest::query()
+            ->where('organization_id', $org->id)
+            ->latest('created_at')
+            ->limit(100)
+            ->get()
+            ->map(fn (OrganizationMembershipRequest $r) => [
+                'id' => $r->id,
+                'user_id' => $r->user_id,
+                'status' => $r->status,
+                'created_at' => $r->created_at?->getTimestampMs(),
+            ])->all();
+
+        $domains = OrganizationDomain::query()
+            ->where('organization_id', $org->id)
+            ->latest('created_at')
+            ->limit(100)
+            ->get()
+            ->map(fn (OrganizationDomain $d) => [
+                'id' => $d->id,
+                'name' => $d->name,
+                'verified' => (bool) $d->verified,
+                'enrollment_mode' => $d->enrollment_mode,
+                'total_pending_invitations' => (int) $d->total_pending_invitations,
+                'created_at' => $d->created_at?->getTimestampMs(),
+            ])->all();
+
+        return Inertia::render('Dashboard/Organization', [
+            'organization' => [
+                'id' => $org->id,
+                'name' => $org->name,
+                'slug' => $org->slug,
+                'members_count' => (int) $org->members_count,
+                'pending_invitations_count' => (int) $org->pending_invitations_count,
+                'max_allowed_memberships' => $org->max_allowed_memberships,
+                'admin_delete_enabled' => (bool) $org->admin_delete_enabled,
+                'public_metadata' => is_array($org->public_metadata) ? $org->public_metadata : [],
+                'created_at' => $org->created_at?->getTimestampMs(),
+            ],
+            'tab' => $tab,
+            'members' => $members,
+            'invitations' => $invitations,
+            'membership_requests' => $requests,
+            'domains' => $domains,
+        ]);
+    }
+
+    public function rolesAndPermissions(string $project_slug, string $env_slug): InertiaResponse|RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+
+        $roles = Role::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->with('permissions')
+            ->orderBy('is_system', 'desc')
+            ->orderBy('key')
+            ->get()
+            ->map(fn (Role $r) => [
+                'id' => $r->id,
+                'key' => $r->key,
+                'name' => $r->name,
+                'description' => $r->description,
+                'is_system' => (bool) $r->is_system,
+                'is_default' => (bool) $r->is_default,
+                'is_creator_eligible' => (bool) $r->is_creator_eligible,
+                'permissions' => $r->permissions->pluck('key')->all(),
+            ])->all();
+
+        $permissions = Permission::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->orderBy('key')
+            ->get()
+            ->map(fn (Permission $p) => [
+                'id' => $p->id,
+                'key' => $p->key,
+                'name' => $p->name,
+                'description' => $p->description,
+                'is_system' => (bool) $p->is_system,
+            ])->all();
+
+        return Inertia::render('Dashboard/RolesAndPermissions', [
+            'roles' => $roles,
+            'permissions' => $permissions,
         ]);
     }
 

--- a/resources/js/dashboard/pages/Organization.tsx
+++ b/resources/js/dashboard/pages/Organization.tsx
@@ -1,0 +1,97 @@
+type Props = {
+    organization: {
+        id: string
+        name: string
+        slug: string
+        members_count: number
+        pending_invitations_count: number
+        max_allowed_memberships: number | null
+        admin_delete_enabled: boolean
+    }
+    tab: string
+    members: Array<{ id: string; user_id: string; role: string | null; username: string | null; first_name: string | null; last_name: string | null }>
+    invitations: Array<{ id: string; email_address: string; role: string | null; status: string; expires_at: number | null }>
+    membership_requests: Array<{ id: string; user_id: string; status: string; created_at: number | null }>
+    domains: Array<{ id: string; name: string; verified: boolean; enrollment_mode: string; total_pending_invitations: number }>
+}
+
+export default function Organization({ organization, tab, members, invitations, membership_requests, domains }: Props) {
+    return (
+        <div>
+            <header>
+                <h1>{organization.name}</h1>
+                <p><code>{organization.slug}</code> · {organization.members_count} members · {organization.pending_invitations_count} pending invites</p>
+            </header>
+
+            {tab === 'members' && (
+                <section>
+                    <h2>Members</h2>
+                    <table>
+                        <thead><tr><th>User</th><th>Role</th></tr></thead>
+                        <tbody>
+                            {members.map((m) => (
+                                <tr key={m.id}>
+                                    <td>{m.username || [m.first_name, m.last_name].filter(Boolean).join(' ') || m.user_id}</td>
+                                    <td>{m.role ?? '—'}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </section>
+            )}
+
+            {tab === 'invitations' && (
+                <section>
+                    <h2>Pending invitations</h2>
+                    <table>
+                        <thead><tr><th>Email</th><th>Role</th><th>Status</th></tr></thead>
+                        <tbody>
+                            {invitations.map((i) => (
+                                <tr key={i.id}>
+                                    <td>{i.email_address}</td>
+                                    <td>{i.role ?? '—'}</td>
+                                    <td>{i.status}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </section>
+            )}
+
+            {tab === 'requests' && (
+                <section>
+                    <h2>Membership requests</h2>
+                    <table>
+                        <thead><tr><th>User id</th><th>Status</th></tr></thead>
+                        <tbody>
+                            {membership_requests.map((r) => (
+                                <tr key={r.id}>
+                                    <td>{r.user_id}</td>
+                                    <td>{r.status}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </section>
+            )}
+
+            {tab === 'domains' && (
+                <section>
+                    <h2>Domains</h2>
+                    <table>
+                        <thead><tr><th>Domain</th><th>Verified</th><th>Mode</th></tr></thead>
+                        <tbody>
+                            {domains.map((d) => (
+                                <tr key={d.id}>
+                                    <td>{d.name}</td>
+                                    <td>{d.verified ? 'yes' : 'no'}</td>
+                                    <td>{d.enrollment_mode}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </section>
+            )}
+        </div>
+    )
+}

--- a/resources/js/dashboard/pages/Organizations.tsx
+++ b/resources/js/dashboard/pages/Organizations.tsx
@@ -1,0 +1,44 @@
+import { Link } from '@inertiajs/react'
+
+type Org = {
+    id: string
+    name: string
+    slug: string
+    members_count: number
+    pending_invitations_count: number
+    admin_delete_enabled: boolean
+}
+
+type Props = {
+    organizations: Org[]
+    query: string
+    dashboard_prefix?: string
+    active_project?: { slug: string }
+    active_environment?: { slug: string }
+}
+
+export default function Organizations({ organizations, query, dashboard_prefix, active_project, active_environment }: Props) {
+    const base = `${dashboard_prefix ?? ''}/${active_project?.slug ?? ''}/${active_environment?.slug ?? ''}/organizations`
+
+    return (
+        <div>
+            <h1>Organizations</h1>
+            <p>Filter: <code>{query || '—'}</code></p>
+            <table>
+                <thead>
+                    <tr><th>Name</th><th>Slug</th><th>Members</th><th>Pending invites</th></tr>
+                </thead>
+                <tbody>
+                    {organizations.map((o) => (
+                        <tr key={o.id}>
+                            <td><Link href={`${base}/${o.id}`}>{o.name}</Link></td>
+                            <td><code>{o.slug}</code></td>
+                            <td>{o.members_count}</td>
+                            <td>{o.pending_invitations_count}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    )
+}

--- a/resources/js/dashboard/pages/RolesAndPermissions.tsx
+++ b/resources/js/dashboard/pages/RolesAndPermissions.tsx
@@ -1,0 +1,67 @@
+type Role = {
+    id: string
+    key: string
+    name: string
+    description: string | null
+    is_system: boolean
+    is_default: boolean
+    is_creator_eligible: boolean
+    permissions: string[]
+}
+
+type Permission = {
+    id: string
+    key: string
+    name: string
+    description: string | null
+    is_system: boolean
+}
+
+type Props = {
+    roles: Role[]
+    permissions: Permission[]
+}
+
+export default function RolesAndPermissions({ roles, permissions }: Props) {
+    return (
+        <div>
+            <h1>Roles &amp; permissions</h1>
+
+            <section>
+                <h2>Roles</h2>
+                <table>
+                    <thead><tr><th>Key</th><th>Name</th><th>Permissions</th><th>Flags</th></tr></thead>
+                    <tbody>
+                        {roles.map((r) => (
+                            <tr key={r.id}>
+                                <td><code>{r.key}</code></td>
+                                <td>{r.name}</td>
+                                <td>{r.permissions.length}</td>
+                                <td>
+                                    {r.is_system && <span>system </span>}
+                                    {r.is_default && <span>default </span>}
+                                    {r.is_creator_eligible && <span>creator</span>}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </section>
+
+            <section>
+                <h2>System permissions</h2>
+                <table>
+                    <thead><tr><th>Key</th><th>Name</th></tr></thead>
+                    <tbody>
+                        {permissions.map((p) => (
+                            <tr key={p.id}>
+                                <td><code>{p.key}</code></td>
+                                <td>{p.name}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </section>
+        </div>
+    )
+}

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -48,4 +48,9 @@ Route::prefix('{project_slug}/{env_slug}')->group(function (): void {
     Route::post('/webhooks', [DashboardController::class, 'storeWebhook'])->name('dashboard.webhooks.store');
 
     Route::get('/audit-log', [DashboardController::class, 'auditLog'])->name('dashboard.audit_log');
+
+    // v0.2 panels (AU-13).
+    Route::get('/organizations', [DashboardController::class, 'organizations'])->name('dashboard.organizations');
+    Route::get('/organizations/{organization_id}', [DashboardController::class, 'organization'])->name('dashboard.organization');
+    Route::get('/roles', [DashboardController::class, 'rolesAndPermissions'])->name('dashboard.roles_and_permissions');
 });

--- a/tests/Feature/Http/Dashboard/DashboardTest.php
+++ b/tests/Feature/Http/Dashboard/DashboardTest.php
@@ -195,10 +195,13 @@ it('overview / users / sessions / api keys / webhooks pages render for authed op
         'allowlist' => 'Dashboard/Allowlist',
         'blocklist' => 'Dashboard/Blocklist',
         'configure/attributes' => 'Dashboard/Configure',
+        'configure/organizations' => 'Dashboard/Configure',
         'email-templates' => 'Dashboard/EmailTemplates',
         'api-keys' => 'Dashboard/ApiKeys',
         'webhooks' => 'Dashboard/Webhooks',
         'audit-log' => 'Dashboard/AuditLog',
+        'organizations' => 'Dashboard/Organizations',
+        'roles' => 'Dashboard/RolesAndPermissions',
     ] as $segment => $component) {
         $r = $this->withHeaders(dashHeaders($bs['jwt']))
             ->get("http://dashboard.authn.local/acme/production/{$segment}");
@@ -258,4 +261,67 @@ it('creates a webhook endpoint with the secret returned in the flash bag', funct
     $r->assertRedirect();
     expect(session('signing_secret'))->toStartWith('whsec_');
     expect(WebhookEndpoint::query()->withoutGlobalScopes()->where('environment_id', $env->id)->count())->toBe(1);
+});
+
+it('renders the single-org dashboard view with members / invitations / requests / domains tabs', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme Org', 'slug' => 'acme-org']);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->get("http://dashboard.authn.local/acme/production/organizations/{$org->id}");
+    $r->assertOk()
+        ->assertJsonPath('component', 'Dashboard/Organization')
+        ->assertJsonPath('props.organization.id', $org->id)
+        ->assertJsonPath('props.tab', 'members');
+
+    $r2 = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->get("http://dashboard.authn.local/acme/production/organizations/{$org->id}?tab=invitations");
+    $r2->assertOk()->assertJsonPath('props.tab', 'invitations');
+});
+
+it('roles panel returns the seeded system roles + permissions', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->get('http://dashboard.authn.local/acme/production/roles');
+    $r->assertOk()->assertJsonPath('component', 'Dashboard/RolesAndPermissions');
+    $keys = array_column($r->json('props.roles'), 'key');
+    expect($keys)->toContain('org:admin', 'org:member');
+    expect(count($r->json('props.permissions')))->toBe(13);
+});
+
+it('redirects on unknown organization id back to organizations list', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->get('http://dashboard.authn.local/acme/production/organizations/org_nope');
+    $r->assertRedirect();
+    expect($r->headers->get('Location'))->toContain('/acme/production/organizations');
 });


### PR DESCRIPTION
## Summary

Three new operator-facing dashboard panels, all server-side rendered with Inertia + React on top of v0.1 dashboard plumbing.

- `/{project_slug}/{env_slug}/organizations` — list of orgs with `?q=` search by name/slug, members + pending counter caches, click-through to the per-org view.
- `/{project_slug}/{env_slug}/organizations/{organization_id}` — single-org view with `members / invitations / requests / domains` tabs (`?tab=…`). Each tab pre-renders its data set; unknown id redirects back to the list.
- `/{project_slug}/{env_slug}/roles` — roles list (system rows pinned) + system permissions catalogue with full metadata for the operator-side role editor.

**Organization settings tab** (Environment → Settings → Organizations) reaches `/{project_slug}/{env_slug}/configure/organizations` and reuses the existing `Configure.tsx` page — the env's `user_settings` blob already round-trips through that controller path; the React form for the org-settings shape is JS-3's domain.

## Test plan

- [x] Existing dashboard test loop now also exercises `Dashboard/Organizations`, `Dashboard/RolesAndPermissions`, and `Dashboard/Configure` for the `organizations` section.
- [x] Single-org view renders with the right component + tab; deep-link `?tab=invitations` works.
- [x] Roles panel returns the seeded `org:admin` / `org:member` system roles + 13 system permissions.
- [x] Unknown-id redirects to the organizations list.
- [x] Full Pest suite passes (456 tests).
- [x] `vendor/bin/pint --test` clean.
- [x] `npm run build` clean; size budget under 200 KB gzipped.

Closes #47