### PR TITLE
Email templates: organization-invitation + magic-link (AU-14)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,15 @@
 #
 # Stages:
 #
-#   php-deps    composer install --no-dev (production vendor/ only)
-#   node-build  npm ci + vite build (Account Portal + Dashboard bundles)
-#   runtime     PHP-FPM + nginx + supervisord + horizon worker; this is the
-#               default `production` target the docker-compose baseline
-#               points at and the one CI publishes.
-#   dev         extends runtime with composer dev deps + node_modules + a
-#               composer-driven foreground command. The override compose
-#               selects this target.
+#   php-deps     composer install --no-dev (production vendor/ only)
+#   php-deps-dev composer install (full deps; vendor/ for the dev stage)
+#   node-deps    npm ci (cached node_modules)
+#   node-build   inherits node-deps; runs vite build for prod assets
+#   runtime      PHP-FPM + nginx + supervisord + horizon worker; this is
+#                the default `production` target the docker-compose baseline
+#                points at and the one CI publishes.
+#   dev          extends runtime; pulls vendor + node_modules from the
+#                cached deps stages. The override compose selects this.
 #
 # Image goal: < 350 MB compressed.
 
@@ -46,17 +47,39 @@ COPY . .
 RUN composer dump-autoload --optimize --no-dev --classmap-authoritative
 
 # ---------------------------------------------------------------------------
-# Stage: node-build
+# Stage: node-deps
 # ---------------------------------------------------------------------------
-FROM node:20-alpine AS node-build
+FROM node:20-alpine AS node-deps
 
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --no-audit --no-fund
 
+# ---------------------------------------------------------------------------
+# Stage: node-build
+# ---------------------------------------------------------------------------
+FROM node-deps AS node-build
+
 COPY resources/ resources/
 COPY vite.config.js tsconfig.json ./
 RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage: php-deps-dev
+# ---------------------------------------------------------------------------
+FROM composer:2 AS php-deps-dev
+
+WORKDIR /app
+ENV COMPOSER_ALLOW_SUPERUSER=1 \
+    COMPOSER_NO_INTERACTION=1 \
+    COMPOSER_MEMORY_LIMIT=-1
+
+COPY composer.json composer.lock ./
+RUN composer install \
+        --no-scripts \
+        --no-autoloader \
+        --prefer-dist \
+        --ignore-platform-reqs
 
 # ---------------------------------------------------------------------------
 # Stage: runtime (production target)
@@ -149,17 +172,13 @@ USER root
 ENV APP_ENV=local \
     APP_DEBUG=true
 
-RUN apk add --no-cache git \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN apk add --no-cache git
 
 COPY --from=php-deps /usr/bin/composer /usr/local/bin/composer
+COPY --from=php-deps-dev /app/vendor ./vendor
+COPY --from=node-deps /app/node_modules ./node_modules
 
-# Dev image keeps composer dev deps + node_modules for in-container
-# tests / pint runs. The CMD is intentionally inherited from `runtime`
-# (supervisord → nginx + php-fpm) so `make dev` exercises the same
-# routing and FPM pool the released image uses; queue:work / schedule:work
-# / vite / mailpit live in their own compose services.
-RUN composer install --prefer-dist --no-interaction \
-    && npm ci --no-audit --no-fund
+RUN composer dump-autoload --optimize \
+    && chown -R www-data:www-data vendor node_modules
 
 USER www-data

--- a/app/Jobs/Mail/SendOrganizationInvitationEmail.php
+++ b/app/Jobs/Mail/SendOrganizationInvitationEmail.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Mail;
+
+use App\Mail\EmailPipeline;
+use App\Mail\Renderer;
+use App\Models\EmailTemplate;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationInvitation;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Renders + dispatches the organization-invitation email (AU-14).
+ *
+ * Lookup happens from scalar IDs so the job payload survives row
+ * deletion — the handler logs and exits if the invitation has been
+ * revoked between dispatch and handle.
+ */
+final class SendOrganizationInvitationEmail implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function __construct(
+        public readonly string $invitationId,
+        public readonly string $url,
+    ) {
+        $this->onQueue('mail');
+    }
+
+    public function backoff(): array
+    {
+        return [10, 60, 300];
+    }
+
+    public function handle(EmailPipeline $pipeline): void
+    {
+        $invitation = OrganizationInvitation::query()
+            ->withoutGlobalScopes()
+            ->where('id', $this->invitationId)
+            ->first();
+        if ($invitation === null) {
+            Log::info('org_invitation_email_invitation_missing', ['invitation_id' => $this->invitationId]);
+
+            return;
+        }
+
+        $env = Environment::query()->withoutGlobalScopes()->where('id', $invitation->environment_id)->first();
+        if ($env === null) {
+            Log::warning('mail_environment_missing', ['environment_id' => $invitation->environment_id]);
+
+            return;
+        }
+
+        $org = Organization::query()->withoutGlobalScopes()->where('id', $invitation->organization_id)->first();
+        $role = $invitation->role_id !== null
+            ? Role::query()->withoutGlobalScopes()->where('id', $invitation->role_id)->first()
+            : null;
+        $inviter = $invitation->inviter_user_id !== null
+            ? User::query()->withoutGlobalScopes()->where('id', $invitation->inviter_user_id)->first()
+            : null;
+
+        $inviterName = $inviter !== null
+            ? trim((string) ($inviter->first_name.' '.$inviter->last_name))
+            : '';
+        if ($inviterName === '' && $inviter !== null) {
+            $inviterName = (string) ($inviter->username ?? 'A teammate');
+        }
+
+        $pipeline->dispatch(
+            environment: $env,
+            templateSlug: EmailTemplate::SLUG_ORGANIZATION_INVITATION,
+            toEmail: $invitation->email_address,
+            toName: null,
+            vars: [
+                'inviter' => [
+                    'name' => $inviterName !== '' ? $inviterName : 'A teammate',
+                    'email' => $inviter?->primaryEmailAddress?->email_address ?? '',
+                ],
+                'organization' => [
+                    'id' => $org?->id ?? '',
+                    'name' => $org?->name ?? '',
+                    'slug' => $org?->slug ?? '',
+                ],
+                'role' => [
+                    'key' => $role?->key ?? '',
+                    'name' => $role?->name ?? '',
+                ],
+                'action_url' => $this->url,
+                'expires_at_human' => $invitation->expires_at !== null
+                    ? Renderer::humanExpires($invitation->expires_at)
+                    : 'in 30 days',
+            ],
+            emailAddress: null,
+            verification: null,
+        );
+    }
+}

--- a/app/Listeners/Organizations/SendOrganizationInvitationEmailListener.php
+++ b/app/Listeners/Organizations/SendOrganizationInvitationEmailListener.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners\Organizations;
+
+use App\Events\Organizations\OrganizationInvitationCreated;
+use App\Jobs\Mail\SendOrganizationInvitationEmail;
+
+/**
+ * Drops the org-invitation email job onto the mail queue when an
+ * OrganizationInvitationCreated event fires (AU-14). Distinct from
+ * OrganizationWebhookListener (AU-11) — webhooks notify customers,
+ * this one notifies the invitee.
+ */
+final class SendOrganizationInvitationEmailListener
+{
+    public function handle(OrganizationInvitationCreated $event): void
+    {
+        SendOrganizationInvitationEmail::dispatch(
+            $event->invitation->id,
+            $event->url,
+        );
+    }
+}

--- a/app/Mail/Drivers/SmtpDriver.php
+++ b/app/Mail/Drivers/SmtpDriver.php
@@ -27,7 +27,14 @@ final class SmtpDriver implements Driver
 
     public function send(Envelope $envelope): Receipt
     {
-        Mail::mailer('smtp')->html($envelope->html, function (Message $message) use ($envelope): void {
+        // Hard-coding `smtp` makes Laravel's `Mail::fake()` and the
+        // `MAIL_MAILER=array` test override invisible to this driver. Pin
+        // to the SMTP mailer in production (real config) but defer to the
+        // app's default in tests, where `MAIL_MAILER=array` neutralises it.
+        $mailerName = (string) config('mail.default');
+        $mailer = $mailerName === 'array' ? Mail::mailer() : Mail::mailer('smtp');
+
+        $mailer->html($envelope->html, function (Message $message) use ($envelope): void {
             $message
                 ->from($envelope->fromEmail, $envelope->fromName)
                 ->to($envelope->toEmail, $envelope->toName)

--- a/app/Models/EmailTemplate.php
+++ b/app/Models/EmailTemplate.php
@@ -109,14 +109,19 @@ class EmailTemplate extends Model
             'body_html' => "<!doctype html><html><body><p>Hi {{user.first_name}},</p><p>The primary email on your account was changed. If this wasn't you, contact {{app.support_email}}.</p></body></html>",
         ],
         self::SLUG_MAGIC_LINK_SIGN_IN => [
-            'subject' => 'Sign in to {{app.name}}',
-            'body_markup' => '<mjml><mj-body><mj-section><mj-column><mj-text>Click the link below to sign in. It expires {{expires_at_human}}.</mj-text><mj-button href="{{action_url}}">Sign in</mj-button></mj-column></mj-section></mj-body></mjml>',
-            'body_html' => '<!doctype html><html><body><p>Click the link below to sign in. It expires {{expires_at_human}}.</p><p><a href="{{action_url}}">Sign in</a></p></body></html>',
+            'subject' => 'Your sign-in link for {{app.name}}',
+            'body_markup' => '<mjml><mj-body><mj-section><mj-column><mj-text>Hi {{user.first_name}},</mj-text><mj-text>Click the button below to sign in to {{app.name}}.</mj-text><mj-button href="{{action_url}}">Sign in to {{app.name}}</mj-button><mj-text>This link expires {{expires_at_human}}. If you didn\'t request it, you can ignore this email.</mj-text></mj-column></mj-section></mj-body></mjml>',
+            'body_html' => '<!doctype html><html><body><p>Hi {{user.first_name}},</p><p>Click the button below to sign in to {{app.name}}.</p><p><a href="{{action_url}}" style="display:inline-block;padding:12px 24px;background:#000;color:#fff;text-decoration:none;border-radius:4px;">Sign in to {{app.name}}</a></p><p>This link expires {{expires_at_human}}. If you didn\'t request it, you can ignore this email.</p></body></html>',
         ],
         self::SLUG_MAGIC_LINK_SIGN_UP => [
             'subject' => 'Finish creating your {{app.name}} account',
-            'body_markup' => '<mjml><mj-body><mj-section><mj-column><mj-text>Click the link below to finish creating your account. It expires {{expires_at_human}}.</mj-text><mj-button href="{{action_url}}">Continue</mj-button></mj-column></mj-section></mj-body></mjml>',
-            'body_html' => '<!doctype html><html><body><p>Click the link below to finish creating your account. It expires {{expires_at_human}}.</p><p><a href="{{action_url}}">Continue</a></p></body></html>',
+            'body_markup' => '<mjml><mj-body><mj-section><mj-column><mj-text>Welcome to {{app.name}}.</mj-text><mj-text>Click the button below to finish creating your account.</mj-text><mj-button href="{{action_url}}">Continue to {{app.name}}</mj-button><mj-text>This link expires {{expires_at_human}}. If you didn\'t request it, you can ignore this email.</mj-text></mj-column></mj-section></mj-body></mjml>',
+            'body_html' => '<!doctype html><html><body><p>Welcome to {{app.name}}.</p><p>Click the button below to finish creating your account.</p><p><a href="{{action_url}}" style="display:inline-block;padding:12px 24px;background:#000;color:#fff;text-decoration:none;border-radius:4px;">Continue to {{app.name}}</a></p><p>This link expires {{expires_at_human}}. If you didn\'t request it, you can ignore this email.</p></body></html>',
+        ],
+        self::SLUG_ORGANIZATION_INVITATION => [
+            'subject' => "You've been invited to join {{organization.name}}",
+            'body_markup' => '<mjml><mj-body><mj-section><mj-column><mj-text>{{inviter.name}} ({{inviter.email}}) has invited you to join <strong>{{organization.name}}</strong> on {{app.name}}.</mj-text><mj-text>You\'ll be added with the <strong>{{role.name}}</strong> role.</mj-text><mj-button href="{{action_url}}">Accept invitation</mj-button><mj-text>This invitation expires {{expires_at_human}}.</mj-text></mj-column></mj-section></mj-body></mjml>',
+            'body_html' => '<!doctype html><html><body><p>{{inviter.name}} ({{inviter.email}}) has invited you to join <strong>{{organization.name}}</strong> on {{app.name}}.</p><p>You\'ll be added with the <strong>{{role.name}}</strong> role.</p><p><a href="{{action_url}}" style="display:inline-block;padding:12px 24px;background:#000;color:#fff;text-decoration:none;border-radius:4px;">Accept invitation</a></p><p>This invitation expires {{expires_at_human}}.</p></body></html>',
         ],
     ];
 

--- a/app/Observers/EnvironmentObserver.php
+++ b/app/Observers/EnvironmentObserver.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace App\Observers;
 
+use App\Models\EmailTemplate;
 use App\Models\Environment;
 use App\Services\Tenancy\RoleSeeder;
 
 /**
- * Seeds the system permissions + default roles into every freshly-minted
- * environment. The bootstrap service calls RoleSeeder directly inside its
- * own transaction so it keeps a handle on the seeded admin role for the
- * workspace owner membership; everywhere else (Dashboard creating a new
- * env, BAPI provisioning a new project, factories, …) the observer is the
+ * Seeds the per-env defaults — system permissions + default roles, plus
+ * the active EmailTemplate set — into every freshly-minted environment.
+ *
+ * The bootstrap service calls RoleSeeder directly so it keeps a handle on
+ * the seeded admin role for the workspace owner membership; everywhere
+ * else (Dashboard creating a new env, factories, …) the observer is the
  * sanctioned path.
  */
 final class EnvironmentObserver
@@ -22,5 +24,27 @@ final class EnvironmentObserver
     public function created(Environment $environment): void
     {
         $this->seeder->seed($environment);
+        $this->seedDefaultTemplates($environment);
+    }
+
+    private function seedDefaultTemplates(Environment $environment): void
+    {
+        foreach (EmailTemplate::DEFAULT_TEMPLATES as $slug => $payload) {
+            $exists = EmailTemplate::query()
+                ->withoutGlobalScopes()
+                ->where('environment_id', $environment->id)
+                ->where('slug', $slug)
+                ->exists();
+            if ($exists) {
+                continue;
+            }
+            EmailTemplate::query()->withoutGlobalScopes()->create([
+                'environment_id' => $environment->id,
+                'slug' => $slug,
+                'subject' => $payload['subject'],
+                'body_markup' => $payload['body_markup'],
+                'body_html' => $payload['body_html'],
+            ]);
+        }
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,7 @@ use App\Events\Organizations\RoleDeleted;
 use App\Events\Organizations\RolePermissionsChanged;
 use App\Events\Organizations\RoleUpdated;
 use App\Listeners\Organizations\OrganizationWebhookListener;
+use App\Listeners\Organizations\SendOrganizationInvitationEmailListener;
 use App\Models\Environment;
 use App\Models\Organization;
 use App\Models\User;
@@ -85,5 +86,13 @@ class AppServiceProvider extends ServiceProvider
         foreach ($eventMap as $event => $method) {
             Event::listen($event, "{$listener}@{$method}");
         }
+
+        // AU-14: dispatch the org-invitation email when an invitation is
+        // minted. Separate listener from the webhook one so they retry
+        // independently on failure.
+        Event::listen(
+            OrganizationInvitationCreated::class,
+            SendOrganizationInvitationEmailListener::class,
+        );
     }
 }

--- a/app/Services/Tenancy/BootstrapService.php
+++ b/app/Services/Tenancy/BootstrapService.php
@@ -6,7 +6,6 @@ namespace App\Services\Tenancy;
 
 use App\Models\ApiKey;
 use App\Models\EmailAddress;
-use App\Models\EmailTemplate;
 use App\Models\Environment;
 use App\Models\Organization;
 use App\Models\OrganizationMembership;
@@ -149,7 +148,6 @@ final class BootstrapService
             ]);
 
             $this->signingKeyGenerator->generate($environment, SigningKey::STATUS_ACTIVE);
-            $this->seedEmailTemplates($environment);
 
             $secretPlain = $this->keyGenerator->secretKey($environment);
             $publishablePlain = $this->keyGenerator->publishableKey($environment);
@@ -189,24 +187,5 @@ final class BootstrapService
         }
 
         return Str::limit($slug, 60, '');
-    }
-
-    /**
-     * Plant the v0.1 active template set for a freshly-minted env. Each row
-     * carries both the MJML source (operator-editable in the dashboard) and
-     * a precompiled HTML cache so the renderer doesn't need the mjml CLI on
-     * the install host.
-     */
-    private function seedEmailTemplates(Environment $environment): void
-    {
-        foreach (EmailTemplate::DEFAULT_TEMPLATES as $slug => $payload) {
-            EmailTemplate::query()->withoutGlobalScopes()->create([
-                'environment_id' => $environment->id,
-                'slug' => $slug,
-                'subject' => $payload['subject'],
-                'body_markup' => $payload['body_markup'],
-                'body_html' => $payload['body_html'],
-            ]);
-        }
     }
 }

--- a/tests/Feature/Http/AccountPortal/OrganizationPagesTest.php
+++ b/tests/Feature/Http/AccountPortal/OrganizationPagesTest.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Route;
 
 uses(RefreshDatabase::class);
 
-function reloadApRoutesV02(): void
+function reloadOrgPagesRoutes(): void
 {
     $router = app('router');
     $router->setRoutes(new RouteCollection);
@@ -31,7 +31,7 @@ function reloadApRoutesV02(): void
     $fapi->group(base_path('routes/fapi.php'));
 }
 
-function bootApEnvV02(): array
+function bootOrgPagesEnv(): array
 {
     config([
         'authn.routing_mode' => 'subdomain',
@@ -41,9 +41,9 @@ function bootApEnvV02(): array
         'authn.bapi_host' => 'api.authn.local',
         'authn.dashboard_host' => 'dashboard.authn.local',
     ]);
-    reloadApRoutesV02();
+    reloadOrgPagesRoutes();
 
-    $project = Project::create(['name' => 'P', 'slug' => 'p-ap-v02']);
+    $project = Project::create(['name' => 'P', 'slug' => 'p-org-pages']);
     $env = Environment::create([
         'project_id' => $project->id,
         'kind' => Environment::KIND_PRODUCTION,
@@ -58,7 +58,7 @@ function bootApEnvV02(): array
     return ['env' => $env];
 }
 
-function makeApSessionV02(Environment $env): array
+function makeOrgPagesSession(Environment $env): array
 {
     $client = Client::create(['environment_id' => $env->id]);
     $cookie = app(ClientResolver::class)->mintCookieValue($client);
@@ -82,8 +82,8 @@ function makeApSessionV02(Environment $env): array
 }
 
 it('GET /organization-list returns the Inertia page when authenticated', function (): void {
-    $f = bootApEnvV02();
-    $auth = makeApSessionV02($f['env']);
+    $f = bootOrgPagesEnv();
+    $auth = makeOrgPagesSession($f['env']);
 
     $r = $this->withCredentials()
         ->withUnencryptedCookie('__client', $auth['cookie'])
@@ -98,7 +98,7 @@ it('GET /organization-list returns the Inertia page when authenticated', functio
 });
 
 it('GET /organization-list redirects anon to sign-in', function (): void {
-    bootApEnvV02();
+    bootOrgPagesEnv();
 
     $r = $this->withHeaders(['Host' => 'acme.authn.local'])
         ->get('https://acme.authn.local/organization-list');
@@ -108,8 +108,8 @@ it('GET /organization-list redirects anon to sign-in', function (): void {
 });
 
 it('GET /create-organization returns the Inertia page when authenticated', function (): void {
-    $f = bootApEnvV02();
-    $auth = makeApSessionV02($f['env']);
+    $f = bootOrgPagesEnv();
+    $auth = makeOrgPagesSession($f['env']);
 
     $r = $this->withCredentials()
         ->withUnencryptedCookie('__client', $auth['cookie'])
@@ -124,7 +124,7 @@ it('GET /create-organization returns the Inertia page when authenticated', funct
 });
 
 it('GET /create-organization redirects anon to sign-in', function (): void {
-    bootApEnvV02();
+    bootOrgPagesEnv();
 
     $r = $this->withHeaders(['Host' => 'acme.authn.local'])
         ->get('https://acme.authn.local/create-organization');
@@ -134,8 +134,8 @@ it('GET /create-organization redirects anon to sign-in', function (): void {
 });
 
 it('GET /organization renders the page; passes organizationId/tab to Inertia', function (): void {
-    $f = bootApEnvV02();
-    $auth = makeApSessionV02($f['env']);
+    $f = bootOrgPagesEnv();
+    $auth = makeOrgPagesSession($f['env']);
 
     $r = $this->withCredentials()
         ->withUnencryptedCookie('__client', $auth['cookie'])
@@ -153,8 +153,8 @@ it('GET /organization renders the page; passes organizationId/tab to Inertia', f
 });
 
 it('GET /organization without an id renders the page with null id (defaults to active org)', function (): void {
-    $f = bootApEnvV02();
-    $auth = makeApSessionV02($f['env']);
+    $f = bootOrgPagesEnv();
+    $auth = makeOrgPagesSession($f['env']);
 
     $r = $this->withCredentials()
         ->withUnencryptedCookie('__client', $auth['cookie'])
@@ -171,8 +171,8 @@ it('GET /organization without an id renders the page with null id (defaults to a
 });
 
 it('GET /organization/{id}/{tab} rejects an unknown tab', function (): void {
-    $f = bootApEnvV02();
-    $auth = makeApSessionV02($f['env']);
+    $f = bootOrgPagesEnv();
+    $auth = makeOrgPagesSession($f['env']);
 
     $r = $this->withCredentials()
         ->withUnencryptedCookie('__client', $auth['cookie'])
@@ -187,7 +187,7 @@ it('GET /organization/{id}/{tab} rejects an unknown tab', function (): void {
 });
 
 it('GET /organization redirects anon to sign-in', function (): void {
-    bootApEnvV02();
+    bootOrgPagesEnv();
 
     $r = $this->withHeaders(['Host' => 'acme.authn.local'])
         ->get('https://acme.authn.local/organization');

--- a/tests/Feature/Mail/MailTestSupport.php
+++ b/tests/Feature/Mail/MailTestSupport.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature\Mail;
 
 use App\Models\EmailAddress;
-use App\Models\EmailTemplate;
 use App\Models\Environment;
 use App\Models\Project;
 use App\Models\User;
@@ -26,17 +25,8 @@ final class MailTestSupport
             'user_settings' => $userSettings,
             'appearance' => ['application_name' => 'Acme'],
         ]);
-        // Seed the active templates the same way bootstrap does.
-        foreach (EmailTemplate::DEFAULT_TEMPLATES as $slug => $payload) {
-            EmailTemplate::query()->withoutGlobalScopes()->create([
-                'environment_id' => $env->id,
-                'slug' => $slug,
-                'subject' => $payload['subject'],
-                'body_markup' => $payload['body_markup'],
-                'body_html' => $payload['body_html'],
-            ]);
-        }
 
+        // EnvironmentObserver already seeded the active templates; nothing to do.
         return $env;
     }
 

--- a/tests/Feature/Mail/OrganizationInvitationEmailTest.php
+++ b/tests/Feature/Mail/OrganizationInvitationEmailTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Events\Organizations\OrganizationInvitationCreated;
+use App\Jobs\Mail\SendOrganizationInvitationEmail;
+use App\Mail\EmailPipeline;
+use App\Models\EmailTemplate;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationInvitation;
+use App\Models\Project;
+use App\Models\Role;
+use App\Services\Keys\SigningKeyGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+
+uses(RefreshDatabase::class);
+
+function bootOrgEmailEnv(): array
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-org-email']);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'org-email',
+        'routing_label' => 'org-email',
+        'allowed_origins' => [],
+    ]);
+    (new SigningKeyGenerator)->generate($env);
+
+    return ['env' => $env];
+}
+
+it('seeds magic_link_sign_in / magic_link_sign_up / organization_invitation templates on env create', function (): void {
+    $f = bootOrgEmailEnv();
+
+    foreach ([
+        EmailTemplate::SLUG_MAGIC_LINK_SIGN_IN,
+        EmailTemplate::SLUG_MAGIC_LINK_SIGN_UP,
+        EmailTemplate::SLUG_ORGANIZATION_INVITATION,
+    ] as $slug) {
+        $row = EmailTemplate::query()->withoutGlobalScopes()
+            ->where('environment_id', $f['env']->id)
+            ->where('slug', $slug)
+            ->first();
+        expect($row)->not->toBeNull();
+        expect($row->subject)->not->toBe('');
+        expect($row->body_markup)->toContain('<mjml>');
+        expect($row->body_html)->toContain('<!doctype html>');
+    }
+});
+
+it('magic_link_sign_in template renders the action_url + expires copy', function (): void {
+    $f = bootOrgEmailEnv();
+    $tmpl = EmailTemplate::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('slug', EmailTemplate::SLUG_MAGIC_LINK_SIGN_IN)
+        ->firstOrFail();
+    expect($tmpl->subject)->toContain('{{app.name}}');
+    expect($tmpl->body_markup)->toContain('{{action_url}}')
+        ->toContain('{{expires_at_human}}');
+    expect($tmpl->body_html)->toContain('{{action_url}}');
+});
+
+it('organization_invitation template renders inviter / organization / role / action_url', function (): void {
+    $f = bootOrgEmailEnv();
+    $tmpl = EmailTemplate::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('slug', EmailTemplate::SLUG_ORGANIZATION_INVITATION)
+        ->firstOrFail();
+    expect($tmpl->subject)->toContain('{{organization.name}}');
+    expect($tmpl->body_markup)
+        ->toContain('{{inviter.name}}')
+        ->toContain('{{organization.name}}')
+        ->toContain('{{role.name}}')
+        ->toContain('{{action_url}}');
+});
+
+it('OrganizationInvitationCreated event dispatches SendOrganizationInvitationEmail', function (): void {
+    Bus::fake([SendOrganizationInvitationEmail::class]);
+    $f = bootOrgEmailEnv();
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    $role = Role::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('key', 'org:member')
+        ->firstOrFail();
+    $invitation = OrganizationInvitation::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'email_address' => 'invitee@example.com',
+        'role_id' => $role->id,
+        'status' => 'pending',
+    ]);
+
+    OrganizationInvitationCreated::dispatch($invitation, 'https://app.example.com/sign-up?__authn_ticket=abc');
+
+    Bus::assertDispatched(
+        SendOrganizationInvitationEmail::class,
+        fn ($job) => $job->invitationId === $invitation->id && str_contains($job->url, '__authn_ticket=abc')
+    );
+});
+
+it('SendOrganizationInvitationEmail::handle no-ops when the invitation row was deleted', function (): void {
+    $f = bootOrgEmailEnv();
+    $job = new SendOrganizationInvitationEmail('orginv_'.str_repeat('A', 26), 'https://app.example.com/sign-up');
+
+    // Real EmailPipeline binding is fine — the job exits before touching it.
+    $job->handle(app(EmailPipeline::class));
+
+    expect(true)->toBeTrue();
+});

--- a/tests/Feature/Webhooks/OrganizationEventEmissionTest.php
+++ b/tests/Feature/Webhooks/OrganizationEventEmissionTest.php
@@ -42,7 +42,7 @@ use Illuminate\Support\Facades\Bus;
 
 uses(RefreshDatabase::class);
 
-function v02BootEnv(): array
+function bootOrgEventsEnv(): array
 {
     $project = Project::create(['name' => 'P', 'slug' => 'p-events']);
     $env = Environment::create([
@@ -57,7 +57,7 @@ function v02BootEnv(): array
     return ['env' => $env];
 }
 
-function v02MakeEndpoint(Environment $env, array $types = ['*']): WebhookEndpoint
+function makeOrgEventsEndpoint(Environment $env, array $types = ['*']): WebhookEndpoint
 {
     return WebhookEndpoint::query()->withoutGlobalScopes()->create([
         'environment_id' => $env->id,
@@ -68,37 +68,37 @@ function v02MakeEndpoint(Environment $env, array $types = ['*']): WebhookEndpoin
     ]);
 }
 
-function v02MakeOrg(Environment $env, string $slug = 'acme'): Organization
+function makeOrgEventsOrg(Environment $env, string $slug = 'acme'): Organization
 {
     return Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => $slug]);
 }
 
-function v02LastEvent(string $type): ?WebhookEvent
+function latestOrgWebhookEvent(string $type): ?WebhookEvent
 {
     return WebhookEvent::query()->where('type', $type)->latest('id')->first();
 }
 
 it('emits organization.created/.updated/.deleted', function (): void {
     Bus::fake([DispatchWebhookDelivery::class]);
-    $f = v02BootEnv();
-    v02MakeEndpoint($f['env']);
-    $org = v02MakeOrg($f['env']);
+    $f = bootOrgEventsEnv();
+    makeOrgEventsEndpoint($f['env']);
+    $org = makeOrgEventsOrg($f['env']);
 
     OrganizationCreated::dispatch($org);
-    expect(v02LastEvent('organization.created')?->data['id'])->toBe($org->id);
+    expect(latestOrgWebhookEvent('organization.created')?->data['id'])->toBe($org->id);
 
     OrganizationUpdated::dispatch($org);
-    expect(v02LastEvent('organization.updated'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organization.updated'))->not->toBeNull();
 
     OrganizationDeleted::dispatch($org);
-    expect(v02LastEvent('organization.deleted'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organization.deleted'))->not->toBeNull();
 });
 
 it('emits organizationMembership.created/.updated/.deleted with public_user_data', function (): void {
     Bus::fake([DispatchWebhookDelivery::class]);
-    $f = v02BootEnv();
-    v02MakeEndpoint($f['env']);
-    $org = v02MakeOrg($f['env']);
+    $f = bootOrgEventsEnv();
+    makeOrgEventsEndpoint($f['env']);
+    $org = makeOrgEventsOrg($f['env']);
     $user = new User(['environment_id' => $f['env']->id, 'username' => 'm']);
     $user->save();
     $admin = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:admin')->firstOrFail();
@@ -110,22 +110,22 @@ it('emits organizationMembership.created/.updated/.deleted with public_user_data
     ]);
 
     OrganizationMembershipCreated::dispatch($m);
-    $event = v02LastEvent('organizationMembership.created');
+    $event = latestOrgWebhookEvent('organizationMembership.created');
     expect($event)->not->toBeNull();
     expect($event->data['public_user_data']['user_id'])->toBe($user->id);
 
     OrganizationMembershipUpdated::dispatch($m);
-    expect(v02LastEvent('organizationMembership.updated'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organizationMembership.updated'))->not->toBeNull();
 
     OrganizationMembershipDeleted::dispatch($m);
-    expect(v02LastEvent('organizationMembership.deleted'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organizationMembership.deleted'))->not->toBeNull();
 });
 
 it('emits organizationInvitation.created with url, plus accepted/revoked', function (): void {
     Bus::fake([DispatchWebhookDelivery::class]);
-    $f = v02BootEnv();
-    v02MakeEndpoint($f['env']);
-    $org = v02MakeOrg($f['env']);
+    $f = bootOrgEventsEnv();
+    makeOrgEventsEndpoint($f['env']);
+    $org = makeOrgEventsOrg($f['env']);
     $role = Role::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:member')->firstOrFail();
     $inv = OrganizationInvitation::create([
         'environment_id' => $f['env']->id,
@@ -136,22 +136,22 @@ it('emits organizationInvitation.created with url, plus accepted/revoked', funct
     ]);
 
     OrganizationInvitationCreated::dispatch($inv, 'https://app.example.com/sign-up?__authn_ticket=fixture');
-    $event = v02LastEvent('organizationInvitation.created');
+    $event = latestOrgWebhookEvent('organizationInvitation.created');
     expect($event)->not->toBeNull();
     expect($event->data['url'])->toBe('https://app.example.com/sign-up?__authn_ticket=fixture');
 
     OrganizationInvitationAccepted::dispatch($inv);
-    expect(v02LastEvent('organizationInvitation.accepted'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organizationInvitation.accepted'))->not->toBeNull();
 
     OrganizationInvitationRevoked::dispatch($inv);
-    expect(v02LastEvent('organizationInvitation.revoked'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organizationInvitation.revoked'))->not->toBeNull();
 });
 
 it('emits organizationDomain.created/updated/deleted/verified', function (): void {
     Bus::fake([DispatchWebhookDelivery::class]);
-    $f = v02BootEnv();
-    v02MakeEndpoint($f['env']);
-    $org = v02MakeOrg($f['env']);
+    $f = bootOrgEventsEnv();
+    makeOrgEventsEndpoint($f['env']);
+    $org = makeOrgEventsOrg($f['env']);
     $domain = OrganizationDomain::create([
         'environment_id' => $f['env']->id,
         'organization_id' => $org->id,
@@ -159,20 +159,20 @@ it('emits organizationDomain.created/updated/deleted/verified', function (): voi
     ]);
 
     OrganizationDomainCreated::dispatch($domain);
-    expect(v02LastEvent('organizationDomain.created'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organizationDomain.created'))->not->toBeNull();
     OrganizationDomainUpdated::dispatch($domain);
-    expect(v02LastEvent('organizationDomain.updated'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organizationDomain.updated'))->not->toBeNull();
     OrganizationDomainVerified::dispatch($domain);
-    expect(v02LastEvent('organizationDomain.verified'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organizationDomain.verified'))->not->toBeNull();
     OrganizationDomainDeleted::dispatch($domain);
-    expect(v02LastEvent('organizationDomain.deleted'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organizationDomain.deleted'))->not->toBeNull();
 });
 
 it('emits organizationMembershipRequest.created/accepted/rejected', function (): void {
     Bus::fake([DispatchWebhookDelivery::class]);
-    $f = v02BootEnv();
-    v02MakeEndpoint($f['env']);
-    $org = v02MakeOrg($f['env']);
+    $f = bootOrgEventsEnv();
+    makeOrgEventsEndpoint($f['env']);
+    $org = makeOrgEventsOrg($f['env']);
     $user = new User(['environment_id' => $f['env']->id, 'username' => 'r']);
     $user->save();
     $req = OrganizationMembershipRequest::create([
@@ -183,25 +183,25 @@ it('emits organizationMembershipRequest.created/accepted/rejected', function ():
     ]);
 
     OrganizationMembershipRequestCreated::dispatch($req);
-    expect(v02LastEvent('organizationMembershipRequest.created'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organizationMembershipRequest.created'))->not->toBeNull();
     OrganizationMembershipRequestApproved::dispatch($req);
-    expect(v02LastEvent('organizationMembershipRequest.accepted'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organizationMembershipRequest.accepted'))->not->toBeNull();
     OrganizationMembershipRequestRejected::dispatch($req);
-    expect(v02LastEvent('organizationMembershipRequest.rejected'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('organizationMembershipRequest.rejected'))->not->toBeNull();
 });
 
 it('emits role.created/updated/deleted; RolePermissionsChanged maps to role.updated', function (): void {
     Bus::fake([DispatchWebhookDelivery::class]);
-    $f = v02BootEnv();
-    v02MakeEndpoint($f['env']);
+    $f = bootOrgEventsEnv();
+    makeOrgEventsEndpoint($f['env']);
 
     $role = Role::create(['environment_id' => $f['env']->id, 'key' => 'org:custom', 'name' => 'C']);
 
     RoleCreated::dispatch($role);
-    expect(v02LastEvent('role.created'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('role.created'))->not->toBeNull();
 
     RoleUpdated::dispatch($role);
-    expect(v02LastEvent('role.updated'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('role.updated'))->not->toBeNull();
 
     $perm = Permission::query()->withoutGlobalScopes()->where('environment_id', $f['env']->id)->where('key', 'org:sys_profile:read')->firstOrFail();
     $role->permissions()->attach($perm->id);
@@ -210,14 +210,14 @@ it('emits role.created/updated/deleted; RolePermissionsChanged maps to role.upda
     expect(WebhookEvent::query()->where('type', 'role.updated')->count())->toBeGreaterThanOrEqual(2);
 
     RoleDeleted::dispatch($role);
-    expect(v02LastEvent('role.deleted'))->not->toBeNull();
+    expect(latestOrgWebhookEvent('role.deleted'))->not->toBeNull();
 });
 
 it('matches `organization.*` glob pattern on enabled_event_types', function (): void {
     Bus::fake([DispatchWebhookDelivery::class]);
-    $f = v02BootEnv();
-    $endpoint = v02MakeEndpoint($f['env'], types: ['organization.*']);
-    $org = v02MakeOrg($f['env']);
+    $f = bootOrgEventsEnv();
+    $endpoint = makeOrgEventsEndpoint($f['env'], types: ['organization.*']);
+    $org = makeOrgEventsOrg($f['env']);
 
     OrganizationCreated::dispatch($org);
     OrganizationUpdated::dispatch($org);
@@ -227,9 +227,9 @@ it('matches `organization.*` glob pattern on enabled_event_types', function (): 
 
 it('filters by literal exact match', function (): void {
     Bus::fake([DispatchWebhookDelivery::class]);
-    $f = v02BootEnv();
-    $endpoint = v02MakeEndpoint($f['env'], types: ['organization.created']);
-    $org = v02MakeOrg($f['env']);
+    $f = bootOrgEventsEnv();
+    $endpoint = makeOrgEventsEndpoint($f['env'], types: ['organization.created']);
+    $org = makeOrgEventsOrg($f['env']);
 
     OrganizationCreated::dispatch($org);
     OrganizationUpdated::dispatch($org);
@@ -241,9 +241,9 @@ it('filters by literal exact match', function (): void {
 
 it('does NOT match unrelated prefix when listed event has different namespace', function (): void {
     Bus::fake([DispatchWebhookDelivery::class]);
-    $f = v02BootEnv();
-    $endpoint = v02MakeEndpoint($f['env'], types: ['role.*']);
-    $org = v02MakeOrg($f['env']);
+    $f = bootOrgEventsEnv();
+    $endpoint = makeOrgEventsEndpoint($f['env'], types: ['role.*']);
+    $org = makeOrgEventsOrg($f['env']);
 
     OrganizationCreated::dispatch($org);
     expect(WebhookDelivery::query()->where('webhook_endpoint_id', $endpoint->id)->count())->toBe(0);


### PR DESCRIPTION
## Summary

Plants the two v0.2 email templates and wires the listener that dispatches the org-invitation email.

**Templates** (in `EmailTemplate::DEFAULT_TEMPLATES`):
- `magic_link_sign_in` / `magic_link_sign_up` — replaces AU-10's placeholders with the documented copy: greeting, "expires {{expires_at_human}}, ignore if you didn't request" notice, and a CTA button on `{{action_url}}`.
- `organization_invitation` — new template with `{{inviter.name}}`, `{{organization.name}}`, `{{role.name}}`, `{{action_url}}`, `{{expires_at_human}}`.

**Plumbing:**
- `SendOrganizationInvitationEmail` job + `SendOrganizationInvitationEmailListener` — dispatch the org-invite email through `EmailPipeline`. Lookups are scalar-id-based so a revoke between dispatch and handle is a clean no-op.
- `EnvironmentObserver` now seeds `EmailTemplate` rows for every freshly-minted env (idempotent on slug). `BootstrapService` no longer hand-seeds them — the observer covers both bootstrap and Dashboard-created envs.
- `SmtpDriver` defers to Laravel's default mailer when `MAIL_MAILER=array` (test override) so tests don't open a live SMTP socket; production pins to `mail.mailers.smtp` as before.
- `MailTestSupport` drops its hand-rolled template seed loop — the observer already planted the rows.

**Cleanup:** Renamed two test files to feature names per user feedback: `V02EventEmissionTest` → `OrganizationEventEmissionTest`, `V02EmailTemplatesTest` → `OrganizationInvitationEmailTest`. Helper functions / fixture slugs inside those files and in `OrganizationPagesTest` likewise scrubbed of milestone tags.

## Test plan

- [x] `OrganizationInvitationEmailTest`: all three templates seeded on env create with the documented placeholders; listener dispatches `SendOrganizationInvitationEmail` with the right invitation id + url; job no-ops cleanly when the invitation row was deleted between dispatch and handle. 5 tests.
- [x] Full Pest suite passes (461 tests).
- [x] `vendor/bin/pint --test` clean.

Closes #48