### PR TITLE
ci: run pest with --parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         run: php artisan migrate --force
 
       - name: Pest (in-memory SQLite per phpunit.xml)
-        run: php artisan test
+        run: php artisan test --parallel
 
   dusk:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Switch the Pest step in CI from sequential `php artisan test` to `--parallel` so the suite uses all four cores on the GH Actions runner.

## Test plan
- [ ] CI's `test` job completes meaningfully faster than the prior run on this branch.
- [ ] All assertions still pass (paratest + per-process SQLite `:memory:` already supported in this repo — `brianium/paratest` is in vendor).