### PR TITLE
fix(test): skip bootstrap migrate under paratest

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,10 +9,16 @@ require __DIR__.'/../vendor/autoload.php';
 $app = require __DIR__.'/../bootstrap/app.php';
 $app->make(Kernel::class)->bootstrap();
 
-Artisan::call('migrate:fresh', [
-    '--force' => true,
-    '--seed' => false,
-]);
+// Under paratest each worker gets its own DB file via Laravel's
+// ParallelTestingServiceProvider; running migrate:fresh here would race
+// on the unsuffixed DB before that switch happens. Sequential runs still
+// migrate here so the shared file is ready before the first test.
+if (! ($_SERVER['TEST_TOKEN'] ?? $_ENV['TEST_TOKEN'] ?? null)) {
+    Artisan::call('migrate:fresh', [
+        '--force' => true,
+        '--seed' => false,
+    ]);
+}
 
 while (get_exception_handler() !== null) {
     restore_exception_handler();


### PR DESCRIPTION
## Summary
- After PR #79 (parallel) and PR #80 (DatabaseTransactions) both merged, CI's `test` job hit `SQLSTATE[HY000]: General error: 1 table "migrations" already exists` — every paratest worker was running `migrate:fresh` on the shared `database/testing.sqlite` before Laravel's `ParallelTestingServiceProvider` switched each worker to its own `testing.sqlite_test_<TOKEN>` file.
- Skip the bootstrap-level `migrate:fresh` when `TEST_TOKEN` is set. Laravel's `TestDatabases` trait will create + migrate per-worker DBs via `ensureSchemaIsUpToDate`; sequential runs still migrate at bootstrap as before.

## Test plan
- [x] Local `php artisan test` (sequential) — 454 passed, 32.71s.
- [x] Local `php artisan test --parallel --processes=4` — 454 passed, 9.84s.
- [ ] CI `test` job green.