### PR TITLE
refactor: kebab-case URL paths across routes + tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,7 +125,7 @@ MAIL_FROM_NAME="${APP_NAME}"
 
 # ----------------------------------------------------------------------
 # Object storage — S3-compatible. Avatars, org logos, email attachments.
-# Used by BAPI POST /v1/users/{id}/profile_image (AU-13).
+# Used by BAPI POST /v1/users/{id}/profile-image (AU-13).
 # ----------------------------------------------------------------------
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/app/Auth/SignUp/IdentifierNormalizer.php
+++ b/app/Auth/SignUp/IdentifierNormalizer.php
@@ -12,7 +12,7 @@ namespace App\Auth\SignUp;
  *                                                            == `foo@gmail.com`
  *
  * Used both at sign-up time (collision detection) and at sign-in /
- * /v1/me/email_addresses CRUD time so the same canonical form is what we
+ * /v1/me/email-addresses CRUD time so the same canonical form is what we
  * uniqueness-check against.
  */
 final class IdentifierNormalizer

--- a/app/Auth/Strategies/ResetPasswordEmailCodeStrategy.php
+++ b/app/Auth/Strategies/ResetPasswordEmailCodeStrategy.php
@@ -18,7 +18,7 @@ use App\Services\Verification\VerificationManager;
  * but routed through the `reset_password_code` template (AU-14 wires
  * the template). On successful attempt the SignInController flips
  * `attempt->status` to `needs_new_password`; the SDK then calls
- * `POST /v1/client/sign_ins/{id}/reset_password`.
+ * `POST /v1/client/sign-ins/{id}/reset-password`.
  */
 final class ResetPasswordEmailCodeStrategy implements Strategy
 {

--- a/app/Auth/Strategies/Strategy.php
+++ b/app/Auth/Strategies/Strategy.php
@@ -24,7 +24,7 @@ interface Strategy
 
     /**
      * Issue any out-of-band material (email code, magic link). Called
-     * by `POST /v1/client/sign_ins/{id}/prepare_first_factor`.
+     * by `POST /v1/client/sign-ins/{id}/prepare-first-factor`.
      *
      * @param  array<string, mixed>  $params
      */

--- a/app/Http/Controllers/Bapi/AllowlistIdentifiersController.php
+++ b/app/Http/Controllers/Bapi/AllowlistIdentifiersController.php
@@ -10,9 +10,9 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 /**
- *   GET    /v1/allowlist_identifiers
- *   POST   /v1/allowlist_identifiers
- *   DELETE /v1/allowlist_identifiers/{id}
+ *   GET    /v1/allowlist-identifiers
+ *   POST   /v1/allowlist-identifiers
+ *   DELETE /v1/allowlist-identifiers/{id}
  */
 final class AllowlistIdentifiersController
 {

--- a/app/Http/Controllers/Bapi/BlocklistIdentifiersController.php
+++ b/app/Http/Controllers/Bapi/BlocklistIdentifiersController.php
@@ -10,9 +10,9 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 /**
- *   GET    /v1/blocklist_identifiers
- *   POST   /v1/blocklist_identifiers
- *   DELETE /v1/blocklist_identifiers/{id}
+ *   GET    /v1/blocklist-identifiers
+ *   POST   /v1/blocklist-identifiers
+ *   DELETE /v1/blocklist-identifiers/{id}
  */
 final class BlocklistIdentifiersController
 {

--- a/app/Http/Controllers/Bapi/InstanceController.php
+++ b/app/Http/Controllers/Bapi/InstanceController.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Log;
  *   GET    /v1/instance                     full env settings blob
  *   PATCH  /v1/instance                     top-level toggles
  *   PATCH  /v1/instance/restrictions        restrictions sub-object
- *   PATCH  /v1/instance/organization_settings  v0.1 placeholder
+ *   PATCH  /v1/instance/organization-settings  v0.1 placeholder
  *
  * The full attribute matrix shape (PLAN §13.2) is exposed read-only via
  * the FAPI `/v1/environment` endpoint; PATCH here writes through to the

--- a/app/Http/Controllers/Bapi/RedirectUrlsController.php
+++ b/app/Http/Controllers/Bapi/RedirectUrlsController.php
@@ -10,10 +10,10 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 /**
- *   GET    /v1/redirect_urls
- *   POST   /v1/redirect_urls
- *   GET    /v1/redirect_urls/{id}
- *   DELETE /v1/redirect_urls/{id}
+ *   GET    /v1/redirect-urls
+ *   POST   /v1/redirect-urls
+ *   GET    /v1/redirect-urls/{id}
+ *   DELETE /v1/redirect-urls/{id}
  */
 final class RedirectUrlsController
 {

--- a/app/Http/Controllers/Bapi/UsersController.php
+++ b/app/Http/Controllers/Bapi/UsersController.php
@@ -33,10 +33,10 @@ use Illuminate\Support\Facades\Storage;
  *   PATCH  /v1/users/{id}
  *   DELETE /v1/users/{id}             soft-delete + revoke every session
  *   POST   /v1/users/{id}/ban|unban|lock|unlock
- *   POST   /v1/users/{id}/profile_image
- *   DELETE /v1/users/{id}/profile_image
+ *   POST   /v1/users/{id}/profile-image
+ *   DELETE /v1/users/{id}/profile-image
  *   PATCH  /v1/users/{id}/metadata
- *   POST   /v1/users/{id}/verify_password
+ *   POST   /v1/users/{id}/verify-password
  */
 final class UsersController
 {

--- a/app/Http/Controllers/Bapi/WebhookEndpointsController.php
+++ b/app/Http/Controllers/Bapi/WebhookEndpointsController.php
@@ -17,7 +17,7 @@ use Illuminate\Http\Request;
  *   GET    /v1/webhooks/endpoints/{id}
  *   PATCH  /v1/webhooks/endpoints/{id}
  *   DELETE /v1/webhooks/endpoints/{id}
- *   POST   /v1/webhooks/endpoints/{id}/rotate_secret  (returns new secret once)
+ *   POST   /v1/webhooks/endpoints/{id}/rotate-secret  (returns new secret once)
  */
 final class WebhookEndpointsController
 {

--- a/app/Http/Controllers/Fapi/MagicLinkController.php
+++ b/app/Http/Controllers/Fapi/MagicLinkController.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\DB;
 /**
  * Click-time handler for the email_link strategy.
  *
- *   GET /v1/client/magic_link/redeem?__authn_magic_link=<jwt>&redirect_url=<url>
+ *   GET /v1/client/magic-link/redeem?__authn_magic_link=<jwt>&redirect_url=<url>
  *
  * Verifies the JWT against the env's signing keys, marks the matching
  * VerificationCode consumed (replay protection), flips the parent

--- a/app/Http/Controllers/Fapi/MeOrganizationController.php
+++ b/app/Http/Controllers/Fapi/MeOrganizationController.php
@@ -27,11 +27,11 @@ use Illuminate\Support\Facades\DB;
  * `/v1/me` org-related collections (PLAN §4.4 / OA-3 / AU-7). All endpoints
  * are scoped to the authenticated user.
  *
- *   GET    /v1/me/organization_memberships
- *   GET    /v1/me/organization_invitations
- *   POST   /v1/me/organization_invitations/{invitation_id}/accept
- *   GET    /v1/me/organization_membership_requests
- *   PUT    /v1/me/active_organization
+ *   GET    /v1/me/organization-memberships
+ *   GET    /v1/me/organization-invitations
+ *   POST   /v1/me/organization-invitations/{invitation_id}/accept
+ *   GET    /v1/me/organization-membership-requests
+ *   PUT    /v1/me/active-organization
  */
 final class MeOrganizationController
 {

--- a/app/Http/Controllers/Fapi/OrganizationMembershipRequestController.php
+++ b/app/Http/Controllers/Fapi/OrganizationMembershipRequestController.php
@@ -22,9 +22,9 @@ use Illuminate\Support\Facades\DB;
 /**
  * FAPI per-org admin surface for membership requests (PLAN §4.4 / OA-3 / AU-7).
  *
- *   GET    /v1/organizations/{organization_id}/membership_requests
- *   POST   /v1/organizations/{organization_id}/membership_requests/{request_id}/accept
- *   POST   /v1/organizations/{organization_id}/membership_requests/{request_id}/reject
+ *   GET    /v1/organizations/{organization_id}/membership-requests
+ *   POST   /v1/organizations/{organization_id}/membership-requests/{request_id}/accept
+ *   POST   /v1/organizations/{organization_id}/membership-requests/{request_id}/reject
  */
 final class OrganizationMembershipRequestController
 {

--- a/app/Http/Controllers/Fapi/SignInController.php
+++ b/app/Http/Controllers/Fapi/SignInController.php
@@ -31,13 +31,13 @@ use Symfony\Component\HttpFoundation\Cookie;
  * FAPI sign-in state-machine controller.
  *
  * Endpoints:
- *   POST   /v1/client/sign_ins
- *   GET    /v1/client/sign_ins/{id}
- *   POST   /v1/client/sign_ins/{id}/prepare_first_factor
- *   POST   /v1/client/sign_ins/{id}/attempt_first_factor
- *   POST   /v1/client/sign_ins/{id}/prepare_second_factor   (404 in v0.1)
- *   POST   /v1/client/sign_ins/{id}/attempt_second_factor   (404 in v0.1)
- *   POST   /v1/client/sign_ins/{id}/reset_password
+ *   POST   /v1/client/sign-ins
+ *   GET    /v1/client/sign-ins/{id}
+ *   POST   /v1/client/sign-ins/{id}/prepare-first-factor
+ *   POST   /v1/client/sign-ins/{id}/attempt-first-factor
+ *   POST   /v1/client/sign-ins/{id}/prepare-second-factor   (404 in v0.1)
+ *   POST   /v1/client/sign-ins/{id}/attempt-second-factor   (404 in v0.1)
+ *   POST   /v1/client/sign-ins/{id}/reset-password
  *
  * v0.1 strategies: password, email_code, reset_password_email_code, ticket.
  * Captcha trio is captured but not enforced (AU-18). MFA, OAuth, SAML,

--- a/app/Http/Controllers/Fapi/SignUpController.php
+++ b/app/Http/Controllers/Fapi/SignUpController.php
@@ -42,11 +42,11 @@ use Symfony\Component\HttpFoundation\Cookie;
  * FAPI sign-up state-machine controller.
  *
  * Endpoints (PLAN §3.3 / §9.4):
- *   POST   /v1/client/sign_ups
- *   GET    /v1/client/sign_ups/{id}
- *   PATCH  /v1/client/sign_ups/{id}
- *   POST   /v1/client/sign_ups/{id}/prepare_verification
- *   POST   /v1/client/sign_ups/{id}/attempt_verification
+ *   POST   /v1/client/sign-ups
+ *   GET    /v1/client/sign-ups/{id}
+ *   PATCH  /v1/client/sign-ups/{id}
+ *   POST   /v1/client/sign-ups/{id}/prepare-verification
+ *   POST   /v1/client/sign-ups/{id}/attempt-verification
  *
  * v0.1 strategies for verification: email_code (and ticket at create-time).
  * email_link, OAuth transfer, organization-creation, phone are all v0.2+.

--- a/app/Models/Invitation.php
+++ b/app/Models/Invitation.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 /**
  * BAPI-issued sign-up invitation. The full CRUD surface (issue, list, revoke,
  * resend) lands in AU-13; AU-10 only needs the columns here so the FAPI
- * `/v1/client/sign_ups` controller can redeem a `ticket` claim.
+ * `/v1/client/sign-ups` controller can redeem a `ticket` claim.
  *
  * @property string $id
  * @property string $environment_id

--- a/app/Models/SignInAttempt.php
+++ b/app/Models/SignInAttempt.php
@@ -14,7 +14,7 @@ use InvalidArgumentException;
 
 /**
  * State machine for one in-progress sign-in. Drives the FAPI
- * `/v1/client/sign_ins/...` surface in AU-9.
+ * `/v1/client/sign-ins/...` surface in AU-9.
  *
  * Status flow (PLAN §9.1):
  *   needs_identifier

--- a/app/Models/SignUpAttempt.php
+++ b/app/Models/SignUpAttempt.php
@@ -14,7 +14,7 @@ use InvalidArgumentException;
 
 /**
  * State machine for one in-progress sign-up. Drives the FAPI
- * `/v1/client/sign_ups/...` surface in AU-10.
+ * `/v1/client/sign-ups/...` surface in AU-10.
  *
  * Status flow (PLAN §9.2):
  *   missing_requirements

--- a/app/Services/MagicLink/MagicLinkIssuer.php
+++ b/app/Services/MagicLink/MagicLinkIssuer.php
@@ -91,7 +91,7 @@ final class MagicLinkIssuer
             'redirect_url' => $redirectUrl,
         ], fn ($v): bool => $v !== null && $v !== ''));
 
-        return rtrim($base, '/').'/v1/client/magic_link/redeem?'.$query;
+        return rtrim($base, '/').'/v1/client/magic-link/redeem?'.$query;
     }
 
     private function mintJti(): string

--- a/app/Services/Verification/VerificationManager.php
+++ b/app/Services/Verification/VerificationManager.php
@@ -16,7 +16,7 @@ use InvalidArgumentException;
  * Orchestrates Verification + VerificationCode lifecycle. Used by:
  *   - AU-9 sign-in flow (start a new email_code, attempt to verify it)
  *   - AU-10 sign-up flow (start an email verification on the staged email)
- *   - AU-12 /v1/me/email_addresses/{id}/prepare_verification etc.
+ *   - AU-12 /v1/me/email-addresses/{id}/prepare-verification etc.
  *   - AU-19's reaper for the `expired` transition.
  */
 final class VerificationManager

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
-    "name": "html",
+    "name": "authn",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "dependencies": {
-                "@authn-sh/sdk-js": "^0.1.0",
-                "@authn-sh/sdk-react": "^0.1.0",
-                "@authn-sh/types": "^0.1.0",
-                "@authn-sh/ui": "^0.1.0"
+                "@authn-sh/sdk-js": "0.2.0-alpha.0",
+                "@authn-sh/sdk-react": "1.0.0-alpha.0",
+                "@authn-sh/types": "0.2.0-alpha.0",
+                "@authn-sh/ui": "0.2.0-alpha.0"
             },
             "devDependencies": {
                 "@inertiajs/react": "^3.0.3",
@@ -28,33 +28,33 @@
             }
         },
         "node_modules/@authn-sh/sdk-js": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.1.0.tgz",
-            "integrity": "sha512-bYmp8P7ufd7W6QG+/LETB9KDMYdEfM4kiUsIcOtLiCP1yulw7hNv+0udUF7ePpg4HV6eD+mFWc1wYnhoT8m9ug==",
+            "version": "0.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.2.0-alpha.0.tgz",
+            "integrity": "sha512-1j6R3QEvRjnSQXXYFTw/vS/jzG08ldPK5rAcrH+kKzagdCclj/BucCXyLaJ8N/VfSpVddrErGbxhLMeYTr8hTw==",
             "license": "AGPL-3.0-only"
         },
         "node_modules/@authn-sh/sdk-react": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-0.1.0.tgz",
-            "integrity": "sha512-OIu59tchGHkBkf3acJx3qj1rgNds895lZeGrGeP/WTSrrpxX8soylhmWhZ3EBCgRv6qD56DeSDx+n49TWRn4zg==",
+            "version": "1.0.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-1.0.0-alpha.0.tgz",
+            "integrity": "sha512-30zrx3pZ13hAiD9MYG91ea+UGi8D/kJvN4D0GVCFAUSu2yoj4BdhP/A0ea6KYcs6sqevlpeM4Bd2xQLNOKwguQ==",
             "license": "AGPL-3.0-only",
             "peerDependencies": {
-                "@authn-sh/sdk-js": "*",
-                "@authn-sh/ui": "*",
+                "@authn-sh/sdk-js": "0.2.0-alpha.0",
+                "@authn-sh/ui": "0.2.0-alpha.0",
                 "react": "^18 || ^19",
                 "react-dom": "^18 || ^19"
             }
         },
         "node_modules/@authn-sh/types": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.1.0.tgz",
-            "integrity": "sha512-nPYe9lHsV4+EaY0mFESM5kDQM86craZKLhqna9Fl4YFqPcLK6EaiPY1t2+/0+NdkIrF1FfquQqvxNgsETW5fBg==",
+            "version": "0.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.2.0-alpha.0.tgz",
+            "integrity": "sha512-utL2ddp+UwSobFubwJJSEjvwivQG7xEJ9sW0lBsxPG3C8mn21gPy54LkzoBwb9N+FPxcsgn88d/DZrQgtCBrpg==",
             "license": "AGPL-3.0-only"
         },
         "node_modules/@authn-sh/ui": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/ui/-/ui-0.1.0.tgz",
-            "integrity": "sha512-cpMqDUWDZ6lTqu4GvvxgFvsmvooSqfT2W/+K5qmejqVCw63L3kAS750sNJar8tUlMaVREkzTCQVJy5e4QY9QaA==",
+            "version": "0.2.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@authn-sh/ui/-/ui-0.2.0-alpha.0.tgz",
+            "integrity": "sha512-vdPndgVs8Mde4OWu5WqJ7Am8Oz+tVuidoby8IfnhQz36dJHy6kIM/AfPnIxPSHZ4Dc3aniO1IQKdGw6KEDGtLA==",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@radix-ui/react-avatar": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
         "vite": "^8.0.0"
     },
     "dependencies": {
-        "@authn-sh/sdk-js": "^0.1.0",
-        "@authn-sh/sdk-react": "^0.1.0",
-        "@authn-sh/types": "^0.1.0",
-        "@authn-sh/ui": "^0.1.0"
+        "@authn-sh/sdk-js": "0.2.0-alpha.0",
+        "@authn-sh/sdk-react": "1.0.0-alpha.0",
+        "@authn-sh/types": "0.2.0-alpha.0",
+        "@authn-sh/ui": "0.2.0-alpha.0"
     }
 }

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -48,10 +48,10 @@ Route::post('/users/{id}/ban', [UsersController::class, 'ban'])->middleware(Rate
 Route::post('/users/{id}/unban', [UsersController::class, 'unban'])->middleware(RateLimit::class.':users.action,60,60')->name('bapi.users.unban');
 Route::post('/users/{id}/lock', [UsersController::class, 'lock'])->middleware(RateLimit::class.':users.action,60,60')->name('bapi.users.lock');
 Route::post('/users/{id}/unlock', [UsersController::class, 'unlock'])->middleware(RateLimit::class.':users.action,60,60')->name('bapi.users.unlock');
-Route::post('/users/{id}/profile_image', [UsersController::class, 'uploadProfileImage'])->middleware(RateLimit::class.':users.image,30,60')->name('bapi.users.profile_image.upload');
-Route::delete('/users/{id}/profile_image', [UsersController::class, 'deleteProfileImage'])->middleware(RateLimit::class.':users.image,30,60')->name('bapi.users.profile_image.delete');
+Route::post('/users/{id}/profile-image', [UsersController::class, 'uploadProfileImage'])->middleware(RateLimit::class.':users.image,30,60')->name('bapi.users.profile_image.upload');
+Route::delete('/users/{id}/profile-image', [UsersController::class, 'deleteProfileImage'])->middleware(RateLimit::class.':users.image,30,60')->name('bapi.users.profile_image.delete');
 Route::patch('/users/{id}/metadata', [UsersController::class, 'updateMetadata'])->middleware(RateLimit::class.':users.update,60,60')->name('bapi.users.metadata');
-Route::post('/users/{id}/verify_password', [UsersController::class, 'verifyPassword'])->middleware(RateLimit::class.':users.verify,60,60')->name('bapi.users.verify_password');
+Route::post('/users/{id}/verify-password', [UsersController::class, 'verifyPassword'])->middleware(RateLimit::class.':users.verify,60,60')->name('bapi.users.verify_password');
 
 // Sessions
 Route::get('/sessions', [SessionsController::class, 'index'])->middleware(RateLimit::class.':sessions.list,300,60')->name('bapi.sessions.index');
@@ -67,19 +67,19 @@ Route::post('/invitations/bulk', [InvitationsController::class, 'bulk'])->middle
 Route::post('/invitations/{id}/revoke', [InvitationsController::class, 'revoke'])->middleware(RateLimit::class.':invitations.action,60,60')->name('bapi.invitations.revoke');
 
 // Allowlist / Blocklist
-Route::get('/allowlist_identifiers', [AllowlistIdentifiersController::class, 'index'])->middleware(RateLimit::class.':lists.list,300,60');
-Route::post('/allowlist_identifiers', [AllowlistIdentifiersController::class, 'store'])->middleware(RateLimit::class.':lists.create,60,60');
-Route::delete('/allowlist_identifiers/{id}', [AllowlistIdentifiersController::class, 'destroy'])->middleware(RateLimit::class.':lists.destroy,60,60');
+Route::get('/allowlist-identifiers', [AllowlistIdentifiersController::class, 'index'])->middleware(RateLimit::class.':lists.list,300,60');
+Route::post('/allowlist-identifiers', [AllowlistIdentifiersController::class, 'store'])->middleware(RateLimit::class.':lists.create,60,60');
+Route::delete('/allowlist-identifiers/{id}', [AllowlistIdentifiersController::class, 'destroy'])->middleware(RateLimit::class.':lists.destroy,60,60');
 
-Route::get('/blocklist_identifiers', [BlocklistIdentifiersController::class, 'index'])->middleware(RateLimit::class.':lists.list,300,60');
-Route::post('/blocklist_identifiers', [BlocklistIdentifiersController::class, 'store'])->middleware(RateLimit::class.':lists.create,60,60');
-Route::delete('/blocklist_identifiers/{id}', [BlocklistIdentifiersController::class, 'destroy'])->middleware(RateLimit::class.':lists.destroy,60,60');
+Route::get('/blocklist-identifiers', [BlocklistIdentifiersController::class, 'index'])->middleware(RateLimit::class.':lists.list,300,60');
+Route::post('/blocklist-identifiers', [BlocklistIdentifiersController::class, 'store'])->middleware(RateLimit::class.':lists.create,60,60');
+Route::delete('/blocklist-identifiers/{id}', [BlocklistIdentifiersController::class, 'destroy'])->middleware(RateLimit::class.':lists.destroy,60,60');
 
 // Redirect URLs
-Route::get('/redirect_urls', [RedirectUrlsController::class, 'index'])->middleware(RateLimit::class.':redirect_urls.list,300,60');
-Route::post('/redirect_urls', [RedirectUrlsController::class, 'store'])->middleware(RateLimit::class.':redirect_urls.create,60,60');
-Route::get('/redirect_urls/{id}', [RedirectUrlsController::class, 'show'])->middleware(RateLimit::class.':redirect_urls.read,300,60');
-Route::delete('/redirect_urls/{id}', [RedirectUrlsController::class, 'destroy'])->middleware(RateLimit::class.':redirect_urls.destroy,60,60');
+Route::get('/redirect-urls', [RedirectUrlsController::class, 'index'])->middleware(RateLimit::class.':redirect_urls.list,300,60');
+Route::post('/redirect-urls', [RedirectUrlsController::class, 'store'])->middleware(RateLimit::class.':redirect_urls.create,60,60');
+Route::get('/redirect-urls/{id}', [RedirectUrlsController::class, 'show'])->middleware(RateLimit::class.':redirect_urls.read,300,60');
+Route::delete('/redirect-urls/{id}', [RedirectUrlsController::class, 'destroy'])->middleware(RateLimit::class.':redirect_urls.destroy,60,60');
 
 // Webhooks
 Route::get('/webhooks/endpoints', [WebhookEndpointsController::class, 'index'])->middleware(RateLimit::class.':webhooks.list,300,60');
@@ -87,7 +87,7 @@ Route::post('/webhooks/endpoints', [WebhookEndpointsController::class, 'store'])
 Route::get('/webhooks/endpoints/{id}', [WebhookEndpointsController::class, 'show'])->middleware(RateLimit::class.':webhooks.read,300,60');
 Route::patch('/webhooks/endpoints/{id}', [WebhookEndpointsController::class, 'update'])->middleware(RateLimit::class.':webhooks.update,60,60');
 Route::delete('/webhooks/endpoints/{id}', [WebhookEndpointsController::class, 'destroy'])->middleware(RateLimit::class.':webhooks.destroy,30,60');
-Route::post('/webhooks/endpoints/{id}/rotate_secret', [WebhookEndpointsController::class, 'rotateSecret'])->middleware(RateLimit::class.':webhooks.rotate,10,60');
+Route::post('/webhooks/endpoints/{id}/rotate-secret', [WebhookEndpointsController::class, 'rotateSecret'])->middleware(RateLimit::class.':webhooks.rotate,10,60');
 
 Route::get('/webhooks/deliveries', [WebhookDeliveriesController::class, 'index'])->middleware(RateLimit::class.':webhooks.list,300,60');
 Route::get('/webhooks/deliveries/{id}', [WebhookDeliveriesController::class, 'show'])->middleware(RateLimit::class.':webhooks.read,300,60');
@@ -131,4 +131,4 @@ Route::get('/permissions', [PermissionController::class, 'index'])->middleware(R
 Route::get('/instance', [InstanceController::class, 'show'])->middleware(RateLimit::class.':instance.read,300,60');
 Route::patch('/instance', [InstanceController::class, 'update'])->middleware(RateLimit::class.':instance.update,30,60');
 Route::patch('/instance/restrictions', [InstanceController::class, 'updateRestrictions'])->middleware(RateLimit::class.':instance.update,30,60');
-Route::patch('/instance/organization_settings', [InstanceController::class, 'updateOrganizationSettings'])->middleware(RateLimit::class.':instance.update,30,60');
+Route::patch('/instance/organization-settings', [InstanceController::class, 'updateOrganizationSettings'])->middleware(RateLimit::class.':instance.update,30,60');

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -65,25 +65,25 @@ Route::prefix('v1')->group(function (): void {
 
         // Magic-link click handler (AU-10). Top-level browser navigation
         // from the email — no Origin header, no Client cookie required.
-        Route::get('/client/magic_link/redeem', [MagicLinkController::class, 'redeem'])->name('fapi.magic_link.redeem');
+        Route::get('/client/magic-link/redeem', [MagicLinkController::class, 'redeem'])->name('fapi.magic_link.redeem');
     });
 
     // Sign-in: POST creates the attempt (and, if needed, the Client). The
     // remaining endpoints require an existing Client cookie.
-    Route::post('/client/sign_ins', [SignInController::class, 'store'])->name('fapi.sign_in.store');
-    Route::post('/client/sign_ups', [SignUpController::class, 'store'])->name('fapi.sign_up.store');
+    Route::post('/client/sign-ins', [SignInController::class, 'store'])->name('fapi.sign_in.store');
+    Route::post('/client/sign-ups', [SignUpController::class, 'store'])->name('fapi.sign_up.store');
     Route::middleware(ResolveClientFromCookie::class)->group(function (): void {
-        Route::get('/client/sign_ins/{sid}', [SignInController::class, 'show'])->name('fapi.sign_in.show');
-        Route::post('/client/sign_ins/{sid}/prepare_first_factor', [SignInController::class, 'prepareFirstFactor'])->name('fapi.sign_in.prepare_first_factor');
-        Route::post('/client/sign_ins/{sid}/attempt_first_factor', [SignInController::class, 'attemptFirstFactor'])->name('fapi.sign_in.attempt_first_factor');
-        Route::post('/client/sign_ins/{sid}/prepare_second_factor', [SignInController::class, 'prepareSecondFactor'])->name('fapi.sign_in.prepare_second_factor');
-        Route::post('/client/sign_ins/{sid}/attempt_second_factor', [SignInController::class, 'attemptSecondFactor'])->name('fapi.sign_in.attempt_second_factor');
-        Route::post('/client/sign_ins/{sid}/reset_password', [SignInController::class, 'resetPassword'])->name('fapi.sign_in.reset_password');
+        Route::get('/client/sign-ins/{sid}', [SignInController::class, 'show'])->name('fapi.sign_in.show');
+        Route::post('/client/sign-ins/{sid}/prepare-first-factor', [SignInController::class, 'prepareFirstFactor'])->name('fapi.sign_in.prepare_first_factor');
+        Route::post('/client/sign-ins/{sid}/attempt-first-factor', [SignInController::class, 'attemptFirstFactor'])->name('fapi.sign_in.attempt_first_factor');
+        Route::post('/client/sign-ins/{sid}/prepare-second-factor', [SignInController::class, 'prepareSecondFactor'])->name('fapi.sign_in.prepare_second_factor');
+        Route::post('/client/sign-ins/{sid}/attempt-second-factor', [SignInController::class, 'attemptSecondFactor'])->name('fapi.sign_in.attempt_second_factor');
+        Route::post('/client/sign-ins/{sid}/reset-password', [SignInController::class, 'resetPassword'])->name('fapi.sign_in.reset_password');
 
-        Route::get('/client/sign_ups/{sid}', [SignUpController::class, 'show'])->name('fapi.sign_up.show');
-        Route::patch('/client/sign_ups/{sid}', [SignUpController::class, 'patch'])->name('fapi.sign_up.patch');
-        Route::post('/client/sign_ups/{sid}/prepare_verification', [SignUpController::class, 'prepareVerification'])->name('fapi.sign_up.prepare_verification');
-        Route::post('/client/sign_ups/{sid}/attempt_verification', [SignUpController::class, 'attemptVerification'])->name('fapi.sign_up.attempt_verification');
+        Route::get('/client/sign-ups/{sid}', [SignUpController::class, 'show'])->name('fapi.sign_up.show');
+        Route::patch('/client/sign-ups/{sid}', [SignUpController::class, 'patch'])->name('fapi.sign_up.patch');
+        Route::post('/client/sign-ups/{sid}/prepare-verification', [SignUpController::class, 'prepareVerification'])->name('fapi.sign_up.prepare_verification');
+        Route::post('/client/sign-ups/{sid}/attempt-verification', [SignUpController::class, 'attemptVerification'])->name('fapi.sign_up.attempt_verification');
 
         Route::get('/client/sessions/{sid}', [SessionsController::class, 'show'])->name('fapi.session.show');
         Route::post('/client/sessions/{sid}/touch', [SessionsController::class, 'touch'])->name('fapi.session.touch');
@@ -99,18 +99,18 @@ Route::prefix('v1')->group(function (): void {
         Route::get('/me', [MeController::class, 'show'])->name('fapi.me.show');
         Route::patch('/me', [MeController::class, 'update'])->name('fapi.me.update');
         Route::delete('/me', [MeController::class, 'destroy'])->name('fapi.me.destroy');
-        Route::post('/me/delete_self', [MeController::class, 'deleteSelf'])->name('fapi.me.delete_self');
+        Route::post('/me/delete-self', [MeController::class, 'deleteSelf'])->name('fapi.me.delete_self');
 
-        Route::get('/me/email_addresses', [MeController::class, 'listEmails'])->name('fapi.me.emails.list');
-        Route::post('/me/email_addresses', [MeController::class, 'createEmail'])->name('fapi.me.emails.create');
-        Route::get('/me/email_addresses/{eid}', [MeController::class, 'showEmail'])->name('fapi.me.emails.show');
-        Route::patch('/me/email_addresses/{eid}', [MeController::class, 'updateEmail'])->name('fapi.me.emails.update');
-        Route::delete('/me/email_addresses/{eid}', [MeController::class, 'deleteEmail'])->name('fapi.me.emails.destroy');
-        Route::post('/me/email_addresses/{eid}/prepare_verification', [MeController::class, 'prepareEmailVerification'])->name('fapi.me.emails.prepare_verification');
-        Route::post('/me/email_addresses/{eid}/attempt_verification', [MeController::class, 'attemptEmailVerification'])->name('fapi.me.emails.attempt_verification');
+        Route::get('/me/email-addresses', [MeController::class, 'listEmails'])->name('fapi.me.emails.list');
+        Route::post('/me/email-addresses', [MeController::class, 'createEmail'])->name('fapi.me.emails.create');
+        Route::get('/me/email-addresses/{eid}', [MeController::class, 'showEmail'])->name('fapi.me.emails.show');
+        Route::patch('/me/email-addresses/{eid}', [MeController::class, 'updateEmail'])->name('fapi.me.emails.update');
+        Route::delete('/me/email-addresses/{eid}', [MeController::class, 'deleteEmail'])->name('fapi.me.emails.destroy');
+        Route::post('/me/email-addresses/{eid}/prepare-verification', [MeController::class, 'prepareEmailVerification'])->name('fapi.me.emails.prepare_verification');
+        Route::post('/me/email-addresses/{eid}/attempt-verification', [MeController::class, 'attemptEmailVerification'])->name('fapi.me.emails.attempt_verification');
 
         Route::get('/me/sessions', [MeController::class, 'listSessions'])->name('fapi.me.sessions.list');
-        Route::post('/me/change_password', [MeController::class, 'changePassword'])->name('fapi.me.change_password');
+        Route::post('/me/change-password', [MeController::class, 'changePassword'])->name('fapi.me.change_password');
 
         // Organizations — user-scoped CRUD (PLAN §4.4 / OA-3 / AU-6).
         Route::post('/organizations', [FapiOrganizationController::class, 'store'])->name('fapi.organizations.store');
@@ -153,22 +153,22 @@ Route::prefix('v1')->group(function (): void {
             ->name('fapi.organizations.invitations.revoke');
 
         // Per-org membership-request approve/reject (AU-7).
-        Route::get('/organizations/{organization_id}/membership_requests', [FapiOrganizationMembershipRequestController::class, 'index'])
+        Route::get('/organizations/{organization_id}/membership-requests', [FapiOrganizationMembershipRequestController::class, 'index'])
             ->middleware(EnsureOrgPermission::class.':org:sys_memberships:read')
             ->name('fapi.organizations.membership_requests.index');
-        Route::post('/organizations/{organization_id}/membership_requests/{request_id}/accept', [FapiOrganizationMembershipRequestController::class, 'accept'])
+        Route::post('/organizations/{organization_id}/membership-requests/{request_id}/accept', [FapiOrganizationMembershipRequestController::class, 'accept'])
             ->middleware(EnsureOrgPermission::class.':org:sys_memberships:manage')
             ->name('fapi.organizations.membership_requests.accept');
-        Route::post('/organizations/{organization_id}/membership_requests/{request_id}/reject', [FapiOrganizationMembershipRequestController::class, 'reject'])
+        Route::post('/organizations/{organization_id}/membership-requests/{request_id}/reject', [FapiOrganizationMembershipRequestController::class, 'reject'])
             ->middleware(EnsureOrgPermission::class.':org:sys_memberships:manage')
             ->name('fapi.organizations.membership_requests.reject');
 
         // /v1/me org-related collections + active-org switching (AU-7).
-        Route::get('/me/organization_memberships', [MeOrganizationController::class, 'listMemberships'])->name('fapi.me.organization_memberships');
-        Route::get('/me/organization_invitations', [MeOrganizationController::class, 'listInvitations'])->name('fapi.me.organization_invitations');
-        Route::post('/me/organization_invitations/{invitation_id}/accept', [MeOrganizationController::class, 'acceptInvitation'])->name('fapi.me.organization_invitations.accept');
-        Route::get('/me/organization_membership_requests', [MeOrganizationController::class, 'listMembershipRequests'])->name('fapi.me.organization_membership_requests');
-        Route::put('/me/active_organization', [MeOrganizationController::class, 'setActiveOrganization'])->name('fapi.me.active_organization');
+        Route::get('/me/organization-memberships', [MeOrganizationController::class, 'listMemberships'])->name('fapi.me.organization_memberships');
+        Route::get('/me/organization-invitations', [MeOrganizationController::class, 'listInvitations'])->name('fapi.me.organization_invitations');
+        Route::post('/me/organization-invitations/{invitation_id}/accept', [MeOrganizationController::class, 'acceptInvitation'])->name('fapi.me.organization_invitations.accept');
+        Route::get('/me/organization-membership-requests', [MeOrganizationController::class, 'listMembershipRequests'])->name('fapi.me.organization_membership_requests');
+        Route::put('/me/active-organization', [MeOrganizationController::class, 'setActiveOrganization'])->name('fapi.me.active_organization');
     });
 });
 

--- a/tests/Feature/Http/Bapi/InstanceTest.php
+++ b/tests/Feature/Http/Bapi/InstanceTest.php
@@ -38,9 +38,9 @@ it('PATCH /instance/restrictions mirrors allowlist_enabled into signup_mode', fu
     expect($env->user_settings['restrictions']['block_email_subaddresses'])->toBeTrue();
 });
 
-it('PATCH /instance/organization_settings is a v0.1 placeholder', function (): void {
+it('PATCH /instance/organization-settings is a v0.1 placeholder', function (): void {
     $f = BapiTestSupport::bootEnv();
     $this->withHeaders(BapiTestSupport::headers($f['token']))
-        ->patchJson(BapiTestSupport::url('/instance/organization_settings'), ['enabled' => true])
+        ->patchJson(BapiTestSupport::url('/instance/organization-settings'), ['enabled' => true])
         ->assertOk()->assertJsonPath('enabled', false);
 });

--- a/tests/Feature/Http/Bapi/ListsAndRedirectsTest.php
+++ b/tests/Feature/Http/Bapi/ListsAndRedirectsTest.php
@@ -8,40 +8,40 @@ it('CRUDs allowlist identifiers', function (): void {
     $f = BapiTestSupport::bootEnv();
 
     $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
-        ->postJson(BapiTestSupport::url('/allowlist_identifiers'), ['identifier' => '@team.com', 'notify' => true]);
+        ->postJson(BapiTestSupport::url('/allowlist-identifiers'), ['identifier' => '@team.com', 'notify' => true]);
     $r->assertStatus(201)
         ->assertJsonPath('identifier', '@team.com')
         ->assertJsonPath('notify', true);
     $id = $r->json('id');
 
     $this->withHeaders(BapiTestSupport::headers($f['token']))
-        ->getJson(BapiTestSupport::url('/allowlist_identifiers'))
+        ->getJson(BapiTestSupport::url('/allowlist-identifiers'))
         ->assertOk()->assertJsonPath('total_count', 1);
 
     $this->withHeaders(BapiTestSupport::headers($f['token']))
-        ->deleteJson(BapiTestSupport::url("/allowlist_identifiers/{$id}"))
+        ->deleteJson(BapiTestSupport::url("/allowlist-identifiers/{$id}"))
         ->assertOk()->assertJsonPath('deleted', true);
 });
 
 it('CRUDs blocklist identifiers', function (): void {
     $f = BapiTestSupport::bootEnv();
     $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
-        ->postJson(BapiTestSupport::url('/blocklist_identifiers'), ['identifier' => 'bad@example.com']);
+        ->postJson(BapiTestSupport::url('/blocklist-identifiers'), ['identifier' => 'bad@example.com']);
     $r->assertStatus(201)->assertJsonPath('identifier', 'bad@example.com');
 });
 
 it('CRUDs redirect URLs', function (): void {
     $f = BapiTestSupport::bootEnv();
     $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
-        ->postJson(BapiTestSupport::url('/redirect_urls'), ['url' => 'https://app.example.com/sso']);
+        ->postJson(BapiTestSupport::url('/redirect-urls'), ['url' => 'https://app.example.com/sso']);
     $r->assertStatus(201)->assertJsonPath('url', 'https://app.example.com/sso');
     $id = $r->json('id');
 
     $this->withHeaders(BapiTestSupport::headers($f['token']))
-        ->getJson(BapiTestSupport::url("/redirect_urls/{$id}"))
+        ->getJson(BapiTestSupport::url("/redirect-urls/{$id}"))
         ->assertOk()->assertJsonPath('url', 'https://app.example.com/sso');
 
     $this->withHeaders(BapiTestSupport::headers($f['token']))
-        ->deleteJson(BapiTestSupport::url("/redirect_urls/{$id}"))
+        ->deleteJson(BapiTestSupport::url("/redirect-urls/{$id}"))
         ->assertOk()->assertJsonPath('deleted', true);
 });

--- a/tests/Feature/Http/Bapi/UsersTest.php
+++ b/tests/Feature/Http/Bapi/UsersTest.php
@@ -132,11 +132,11 @@ it('verify_password returns the right boolean', function (): void {
     $userId = $created->json('id');
 
     $this->withHeaders(BapiTestSupport::headers($f['token']))
-        ->postJson(BapiTestSupport::url("/users/{$userId}/verify_password"), ['password' => 'right-password-here'])
+        ->postJson(BapiTestSupport::url("/users/{$userId}/verify-password"), ['password' => 'right-password-here'])
         ->assertOk()->assertJsonPath('verified', true);
 
     $this->withHeaders(BapiTestSupport::headers($f['token']))
-        ->postJson(BapiTestSupport::url("/users/{$userId}/verify_password"), ['password' => 'nope'])
+        ->postJson(BapiTestSupport::url("/users/{$userId}/verify-password"), ['password' => 'nope'])
         ->assertOk()->assertJsonPath('verified', false);
 });
 

--- a/tests/Feature/Http/Fapi/MeOrganizationsTest.php
+++ b/tests/Feature/Http/Fapi/MeOrganizationsTest.php
@@ -49,17 +49,17 @@ function makeOrgWithMembership(Environment $env, User $user, string $roleKey, st
     return $org->fresh();
 }
 
-it('GET /v1/me/organization_memberships lists the caller memberships', function (): void {
+it('GET /v1/me/organization-memberships lists the caller memberships', function (): void {
     $f = MeTestSupport::bootEnv();
     $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
     makeOrgWithMembership($f['env'], $auth['user'], 'org:admin', 'a');
     makeOrgWithMembership($f['env'], $auth['user'], 'org:member', 'b');
 
-    $r = meOrgReq('GET', '/me/organization_memberships', $auth['jwt']);
+    $r = meOrgReq('GET', '/me/organization-memberships', $auth['jwt']);
     $r->assertOk()->assertJsonPath('total_count', 2);
 });
 
-it('GET /v1/me/organization_invitations lists pending invitations addressed to the caller', function (): void {
+it('GET /v1/me/organization-invitations lists pending invitations addressed to the caller', function (): void {
     $f = MeTestSupport::bootEnv();
     $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
     $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'A', 'slug' => 'a']);
@@ -72,11 +72,11 @@ it('GET /v1/me/organization_invitations lists pending invitations addressed to t
         'status' => OrganizationInvitation::STATUS_PENDING,
     ]);
 
-    $r = meOrgReq('GET', '/me/organization_invitations', $auth['jwt']);
+    $r = meOrgReq('GET', '/me/organization-invitations', $auth['jwt']);
     $r->assertOk()->assertJsonPath('total_count', 1)->assertJsonPath('data.0.email_address', 'alice@example.com');
 });
 
-it('POST /v1/me/organization_invitations/{id}/accept creates a membership and fires events', function (): void {
+it('POST /v1/me/organization-invitations/{id}/accept creates a membership and fires events', function (): void {
     Event::fake([OrganizationInvitationAccepted::class, OrganizationMembershipCreated::class]);
     $f = MeTestSupport::bootEnv();
     $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
@@ -91,7 +91,7 @@ it('POST /v1/me/organization_invitations/{id}/accept creates a membership and fi
     ]);
     Organization::query()->withoutGlobalScopes()->where('id', $org->id)->increment('pending_invitations_count');
 
-    $r = meOrgReq('POST', "/me/organization_invitations/{$invitation->id}/accept", $auth['jwt']);
+    $r = meOrgReq('POST', "/me/organization-invitations/{$invitation->id}/accept", $auth['jwt']);
     $r->assertOk()->assertJsonPath('response.object', 'organization_membership');
     expect(OrganizationMembership::query()->where('organization_id', $org->id)->where('user_id', $auth['user']->id)->exists())->toBeTrue();
     expect($invitation->fresh()->status)->toBe('accepted');
@@ -113,7 +113,7 @@ it('POST /accept on an already-accepted invitation 409s', function (): void {
         'status' => OrganizationInvitation::STATUS_ACCEPTED,
     ]);
 
-    meOrgReq('POST', "/me/organization_invitations/{$invitation->id}/accept", $auth['jwt'])
+    meOrgReq('POST', "/me/organization-invitations/{$invitation->id}/accept", $auth['jwt'])
         ->assertStatus(409)
         ->assertJsonPath('errors.0.code', 'organization_invitation_already_accepted');
 });
@@ -131,11 +131,11 @@ it('POST /accept on an invitation for someone else 404s', function (): void {
         'status' => OrganizationInvitation::STATUS_PENDING,
     ]);
 
-    meOrgReq('POST', "/me/organization_invitations/{$invitation->id}/accept", $auth['jwt'])
+    meOrgReq('POST', "/me/organization-invitations/{$invitation->id}/accept", $auth['jwt'])
         ->assertStatus(404);
 });
 
-it('GET /v1/me/organization_membership_requests lists my requests', function (): void {
+it('GET /v1/me/organization-membership-requests lists my requests', function (): void {
     $f = MeTestSupport::bootEnv();
     $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
     $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'A', 'slug' => 'a']);
@@ -146,40 +146,40 @@ it('GET /v1/me/organization_membership_requests lists my requests', function ():
         'status' => 'pending',
     ]);
 
-    meOrgReq('GET', '/me/organization_membership_requests', $auth['jwt'])
+    meOrgReq('GET', '/me/organization-membership-requests', $auth['jwt'])
         ->assertOk()->assertJsonPath('total_count', 1);
 });
 
-it('PUT /v1/me/active_organization updates Session.last_active_organization_id', function (): void {
+it('PUT /v1/me/active-organization updates Session.last_active_organization_id', function (): void {
     $f = MeTestSupport::bootEnv();
     $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
     $org = makeOrgWithMembership($f['env'], $auth['user'], 'org:member');
 
-    $r = meOrgReq('PUT', '/me/active_organization', $auth['jwt'], ['organization_id' => $org->id]);
+    $r = meOrgReq('PUT', '/me/active-organization', $auth['jwt'], ['organization_id' => $org->id]);
     $r->assertOk()->assertJsonPath('response.organization_id', $org->id);
 
     $session = Session::query()->withoutGlobalScopes()->where('id', $auth['session']->id)->firstOrFail();
     expect($session->last_active_organization_id)->toBe($org->id);
 });
 
-it('PUT /v1/me/active_organization with null clears the active org', function (): void {
+it('PUT /v1/me/active-organization with null clears the active org', function (): void {
     $f = MeTestSupport::bootEnv();
     $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
     $org = makeOrgWithMembership($f['env'], $auth['user'], 'org:admin');
     Session::query()->withoutGlobalScopes()->where('id', $auth['session']->id)->update(['last_active_organization_id' => $org->id]);
 
-    $r = meOrgReq('PUT', '/me/active_organization', $auth['jwt'], ['organization_id' => null]);
+    $r = meOrgReq('PUT', '/me/active-organization', $auth['jwt'], ['organization_id' => null]);
     $r->assertOk()->assertJsonPath('response.organization_id', null);
 });
 
-it('PUT /v1/me/active_organization 404s for an org the user is not in', function (): void {
+it('PUT /v1/me/active-organization 404s for an org the user is not in', function (): void {
     $f = MeTestSupport::bootEnv();
     $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
     $other = new User(['environment_id' => $f['env']->id, 'username' => 'other']);
     $other->save();
     $org = makeOrgWithMembership($f['env'], $other, 'org:admin');
 
-    meOrgReq('PUT', '/me/active_organization', $auth['jwt'], ['organization_id' => $org->id])
+    meOrgReq('PUT', '/me/active-organization', $auth['jwt'], ['organization_id' => $org->id])
         ->assertStatus(404);
 });
 
@@ -242,7 +242,7 @@ it('POST /v1/organizations/{id}/invitations/{id}/revoke flips status', function 
     Event::assertDispatched(OrganizationInvitationRevoked::class, 1);
 });
 
-it('POST /v1/organizations/{id}/membership_requests/{rid}/accept creates a membership', function (): void {
+it('POST /v1/organizations/{id}/membership-requests/{rid}/accept creates a membership', function (): void {
     Event::fake([OrganizationMembershipRequestApproved::class, OrganizationMembershipCreated::class]);
     $f = MeTestSupport::bootEnv();
     $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
@@ -257,7 +257,7 @@ it('POST /v1/organizations/{id}/membership_requests/{rid}/accept creates a membe
         'status' => 'pending',
     ]);
 
-    $r = meOrgReq('POST', "/organizations/{$org->id}/membership_requests/{$req->id}/accept", $auth['jwt']);
+    $r = meOrgReq('POST', "/organizations/{$org->id}/membership-requests/{$req->id}/accept", $auth['jwt']);
     $r->assertOk()->assertJsonPath('response.status', 'accepted');
     expect(OrganizationMembership::query()->where('organization_id', $org->id)->where('user_id', $applicant->id)->exists())->toBeTrue();
 
@@ -265,7 +265,7 @@ it('POST /v1/organizations/{id}/membership_requests/{rid}/accept creates a membe
     Event::assertDispatched(OrganizationMembershipCreated::class, 1);
 });
 
-it('POST /v1/organizations/{id}/membership_requests/{rid}/reject flips status', function (): void {
+it('POST /v1/organizations/{id}/membership-requests/{rid}/reject flips status', function (): void {
     Event::fake([OrganizationMembershipRequestRejected::class]);
     $f = MeTestSupport::bootEnv();
     $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
@@ -280,7 +280,7 @@ it('POST /v1/organizations/{id}/membership_requests/{rid}/reject flips status', 
         'status' => 'pending',
     ]);
 
-    $r = meOrgReq('POST', "/organizations/{$org->id}/membership_requests/{$req->id}/reject", $auth['jwt']);
+    $r = meOrgReq('POST', "/organizations/{$org->id}/membership-requests/{$req->id}/reject", $auth['jwt']);
     $r->assertOk()->assertJsonPath('response.status', 'revoked');
     Event::assertDispatched(OrganizationMembershipRequestRejected::class, 1);
 });

--- a/tests/Feature/Http/Me/MeEndpointsTest.php
+++ b/tests/Feature/Http/Me/MeEndpointsTest.php
@@ -48,17 +48,17 @@ it('PATCH /v1/me updates writable fields and ignores unknown', function (): void
         ->assertJsonPath('client.object', 'client');
 });
 
-it('POST /v1/me/email_addresses creates an unverified row; verifies via prepare + attempt', function (): void {
+it('POST /v1/me/email-addresses creates an unverified row; verifies via prepare + attempt', function (): void {
     $f = MeTestSupport::bootEnv();
     $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
 
-    $created = meReq('POST', '/me/email_addresses', $auth['jwt'], ['email_address' => 'alt@example.com']);
+    $created = meReq('POST', '/me/email-addresses', $auth['jwt'], ['email_address' => 'alt@example.com']);
     $created->assertOk()
         ->assertJsonPath('response.email_address', 'alt@example.com')
         ->assertJsonPath('response.verification', null);
     $eid = $created->json('response.id');
 
-    meReq('POST', "/me/email_addresses/{$eid}/prepare_verification", $auth['jwt'], [
+    meReq('POST', "/me/email-addresses/{$eid}/prepare-verification", $auth['jwt'], [
         'strategy' => 'email_code',
     ])->assertOk();
 
@@ -68,7 +68,7 @@ it('POST /v1/me/email_addresses creates an unverified row; verifies via prepare 
     $known = '424242';
     $codeRow->forceFill(['code_hash' => hash('sha256', $known)])->save();
 
-    meReq('POST', "/me/email_addresses/{$eid}/attempt_verification", $auth['jwt'], [
+    meReq('POST', "/me/email-addresses/{$eid}/attempt-verification", $auth['jwt'], [
         'strategy' => 'email_code',
         'code' => $known,
     ])->assertOk()->assertJsonPath('response.verification.status', 'verified');
@@ -76,11 +76,11 @@ it('POST /v1/me/email_addresses creates an unverified row; verifies via prepare 
     expect(EmailAddress::query()->withoutGlobalScopes()->where('id', $eid)->first()->isVerified())->toBeTrue();
 });
 
-it('POST /v1/me/change_password rotates the hash; wrong current returns form_password_incorrect', function (): void {
+it('POST /v1/me/change-password rotates the hash; wrong current returns form_password_incorrect', function (): void {
     $f = MeTestSupport::bootEnv();
     $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
 
-    meReq('POST', '/me/change_password', $auth['jwt'], [
+    meReq('POST', '/me/change-password', $auth['jwt'], [
         'current_password' => 'super-secret-password',
         'new_password' => 'brand-new-password-9000',
     ])->assertOk()->assertJsonPath('response.success', true);
@@ -88,7 +88,7 @@ it('POST /v1/me/change_password rotates the hash; wrong current returns form_pas
     expect(User::query()->withoutGlobalScopes()->where('id', $auth['user']->id)->first()->checkPassword('brand-new-password-9000'))->toBeTrue();
 
     // Wrong current → 422 form_password_incorrect.
-    meReq('POST', '/me/change_password', $auth['jwt'], [
+    meReq('POST', '/me/change-password', $auth['jwt'], [
         'current_password' => 'definitely-wrong',
         'new_password' => 'something-else-12345',
     ])->assertStatus(422)->assertJsonPath('errors.0.code', 'form_password_incorrect');
@@ -117,7 +117,7 @@ it('actor sessions cannot mutate /v1/me/* but can read', function (): void {
     // Mutating endpoints are forbidden.
     meReq('PATCH', '/me', $auth['jwt'], ['first_name' => 'Hacked'])
         ->assertStatus(403)->assertJsonPath('errors.0.code', 'actor_session_forbidden');
-    meReq('POST', '/me/change_password', $auth['jwt'], [
+    meReq('POST', '/me/change-password', $auth['jwt'], [
         'current_password' => 'super-secret-password',
         'new_password' => 'definitely-not-good',
     ])->assertStatus(403)->assertJsonPath('errors.0.code', 'actor_session_forbidden');

--- a/tests/Feature/Http/Sessions/ActiveOrganizationTest.php
+++ b/tests/Feature/Http/Sessions/ActiveOrganizationTest.php
@@ -41,12 +41,12 @@ function setupSessionWithMembership(): array
     return ['env' => $f['env'], 'auth' => $auth, 'org' => $org];
 }
 
-it('PUT /me/active_organization bumps Session.token_version on change', function (): void {
+it('PUT /me/active-organization bumps Session.token_version on change', function (): void {
     $ctx = setupSessionWithMembership();
     $session = $ctx['auth']['session'];
     $beforeVersion = (int) $session->fresh()->token_version;
 
-    activeOrgFapiReq('PUT', '/me/active_organization', $ctx['auth']['jwt'], [
+    activeOrgFapiReq('PUT', '/me/active-organization', $ctx['auth']['jwt'], [
         'organization_id' => $ctx['org']->id,
     ])->assertOk();
 
@@ -55,12 +55,12 @@ it('PUT /me/active_organization bumps Session.token_version on change', function
     expect($after->last_active_organization_id)->toBe($ctx['org']->id);
 });
 
-it('PUT /me/active_organization is a no-op when the org is already active', function (): void {
+it('PUT /me/active-organization is a no-op when the org is already active', function (): void {
     $ctx = setupSessionWithMembership();
     $session = $ctx['auth']['session'];
     $session->forceFill(['last_active_organization_id' => $ctx['org']->id, 'token_version' => 7])->save();
 
-    activeOrgFapiReq('PUT', '/me/active_organization', $ctx['auth']['jwt'], [
+    activeOrgFapiReq('PUT', '/me/active-organization', $ctx['auth']['jwt'], [
         'organization_id' => $ctx['org']->id,
     ])->assertOk();
 

--- a/tests/Feature/Http/SignIn/EmailCodeTest.php
+++ b/tests/Feature/Http/SignIn/EmailCodeTest.php
@@ -15,21 +15,21 @@ it('runs the prepare → attempt → complete email-code path end-to-end', funct
     $cookie = $bs['cookie'];
     $cookieName = '__client';
 
-    // 1. POST /sign_ins (identifier-only)
+    // 1. POST /sign-ins (identifier-only)
     $create = $this->withCredentials()
         ->withUnencryptedCookie($cookieName, $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'identifier' => 'alice@example.com',
         ]);
     $create->assertOk()->assertJsonPath('response.status', 'needs_first_factor');
     $sid = $create->json('response.id');
 
-    // 2. POST /prepare_first_factor strategy=email_code
+    // 2. POST /prepare-first-factor strategy=email_code
     $this->withCredentials()
         ->withUnencryptedCookie($cookieName, $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/prepare_first_factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/prepare-first-factor", [
             'strategy' => 'email_code',
         ])
         ->assertOk();
@@ -46,11 +46,11 @@ it('runs the prepare → attempt → complete email-code path end-to-end', funct
     $known = '424242';
     $codeRow->forceFill(['code_hash' => hash('sha256', $known)])->save();
 
-    // 4. POST /attempt_first_factor with the right code → complete
+    // 4. POST /attempt-first-factor with the right code → complete
     $attempt = $this->withCredentials()
         ->withUnencryptedCookie($cookieName, $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/attempt_first_factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/attempt-first-factor", [
             'strategy' => 'email_code',
             'code' => $known,
         ]);
@@ -68,7 +68,7 @@ it('flips the verification to failed after 5 wrong codes', function (): void {
     $create = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'identifier' => 'alice@example.com',
         ]);
     $sid = $create->json('response.id');
@@ -76,14 +76,14 @@ it('flips the verification to failed after 5 wrong codes', function (): void {
     $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/prepare_first_factor", ['strategy' => 'email_code'])
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/prepare-first-factor", ['strategy' => 'email_code'])
         ->assertOk();
 
     for ($i = 0; $i < 5; $i++) {
         $r = $this->withCredentials()
             ->withUnencryptedCookie('__client', $cookie)
             ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-            ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/attempt_first_factor", [
+            ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/attempt-first-factor", [
                 'strategy' => 'email_code',
                 'code' => '000000',
             ]);

--- a/tests/Feature/Http/SignIn/EmailLinkTest.php
+++ b/tests/Feature/Http/SignIn/EmailLinkTest.php
@@ -41,7 +41,7 @@ function setupMagicLinkUser(Environment $env, string $email = 'alice@example.com
     return ['user' => $user, 'email' => $emailRow];
 }
 
-it('prepare_first_factor email_link issues a magic link, dispatches the email job', function (): void {
+it('prepare-first-factor email_link issues a magic link, dispatches the email job', function (): void {
     Bus::fake([SendMagicLinkEmail::class]);
     $f = SessionsTestSupport::bootEnv();
     $u = setupMagicLinkUser($f['env']);
@@ -62,7 +62,7 @@ it('prepare_first_factor email_link issues a magic link, dispatches the email jo
             'Host' => 'acme.authn.local',
             'Origin' => $f['origin'],
         ])
-        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$attempt->id}/prepare_first_factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/prepare-first-factor", [
             'strategy' => 'email_link',
             'email_address_id' => $u['email']->id,
         ]);
@@ -82,7 +82,7 @@ it('prepare_first_factor email_link issues a magic link, dispatches the email jo
     Bus::assertDispatched(SendMagicLinkEmail::class, fn ($job) => $job->emailAddress === 'alice@example.com');
 });
 
-it('attempt_first_factor email_link returns verification_failed while link is still unredeemed', function (): void {
+it('attempt-first-factor email_link returns verification_failed while link is still unredeemed', function (): void {
     Bus::fake([SendMagicLinkEmail::class]);
     $f = SessionsTestSupport::bootEnv();
     $u = setupMagicLinkUser($f['env']);
@@ -97,14 +97,14 @@ it('attempt_first_factor email_link returns verification_failed while link is st
 
     test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$attempt->id}/prepare_first_factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/prepare-first-factor", [
             'strategy' => 'email_link',
             'email_address_id' => $u['email']->id,
         ])->assertOk();
 
     test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$attempt->id}/attempt_first_factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/attempt-first-factor", [
             'strategy' => 'email_link',
         ])->assertStatus(422)
         ->assertJsonPath('errors.0.code', 'verification_failed');
@@ -125,7 +125,7 @@ it('end-to-end same-device magic link flow: prepare → click → attempt comple
 
     test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$attempt->id}/prepare_first_factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/prepare-first-factor", [
             'strategy' => 'email_link',
             'email_address_id' => $u['email']->id,
         ])->assertOk();
@@ -148,17 +148,17 @@ it('end-to-end same-device magic link flow: prepare → click → attempt comple
 
     // Click the link.
     $click = test()->withHeaders(['Host' => 'acme.authn.local'])
-        ->getJson("https://acme.authn.local/v1/client/magic_link/redeem?__authn_magic_link={$issued['jwt']}");
+        ->getJson("https://acme.authn.local/v1/client/magic-link/redeem?__authn_magic_link={$issued['jwt']}");
     $click->assertOk()->assertJsonPath('verified', true);
 
     // Verification flipped + Client.token_version bumped.
     expect($verification->fresh()->status)->toBe('verified');
     expect((int) Client::query()->withoutGlobalScopes()->where('id', $client->id)->firstOrFail()->token_version)->toBe(1);
 
-    // Now poll attempt_first_factor — should complete and return a session.
+    // Now poll attempt-first-factor — should complete and return a session.
     $r = test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$attempt->id}/attempt_first_factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/attempt-first-factor", [
             'strategy' => 'email_link',
         ]);
     $r->assertOk()->assertJsonPath('response.status', 'complete');
@@ -187,12 +187,12 @@ it('replay protection: second click on the same link returns 410 consumed', func
     $issued = app(MagicLinkIssuer::class)->issue($verification);
 
     test()->withHeaders(['Host' => 'acme.authn.local'])
-        ->getJson("https://acme.authn.local/v1/client/magic_link/redeem?__authn_magic_link={$issued['jwt']}")
+        ->getJson("https://acme.authn.local/v1/client/magic-link/redeem?__authn_magic_link={$issued['jwt']}")
         ->assertOk();
 
     // Second click — replay.
     test()->withHeaders(['Host' => 'acme.authn.local'])
-        ->getJson("https://acme.authn.local/v1/client/magic_link/redeem?__authn_magic_link={$issued['jwt']}")
+        ->getJson("https://acme.authn.local/v1/client/magic-link/redeem?__authn_magic_link={$issued['jwt']}")
         ->assertStatus(410)
         ->assertJsonPath('errors.0.code', 'magic_link_consumed');
 });
@@ -224,7 +224,7 @@ it('expired link returns 410', function (): void {
     ]);
 
     test()->withHeaders(['Host' => 'acme.authn.local'])
-        ->getJson("https://acme.authn.local/v1/client/magic_link/redeem?__authn_magic_link={$issued['jwt']}")
+        ->getJson("https://acme.authn.local/v1/client/magic-link/redeem?__authn_magic_link={$issued['jwt']}")
         ->assertStatus(410)
         ->assertJsonPath('errors.0.code', 'magic_link_expired');
 });
@@ -233,12 +233,12 @@ it('missing/invalid token returns 400', function (): void {
     SessionsTestSupport::bootEnv();
 
     test()->withHeaders(['Host' => 'acme.authn.local'])
-        ->getJson('https://acme.authn.local/v1/client/magic_link/redeem')
+        ->getJson('https://acme.authn.local/v1/client/magic-link/redeem')
         ->assertStatus(400)
         ->assertJsonPath('errors.0.code', 'magic_link_missing');
 
     test()->withHeaders(['Host' => 'acme.authn.local'])
-        ->getJson('https://acme.authn.local/v1/client/magic_link/redeem?__authn_magic_link=garbage')
+        ->getJson('https://acme.authn.local/v1/client/magic-link/redeem?__authn_magic_link=garbage')
         ->assertStatus(400)
         ->assertJsonPath('errors.0.code', 'magic_link_invalid');
 });
@@ -265,6 +265,6 @@ it('redirect_url query param triggers a 302 redirect', function (): void {
     $issued = app(MagicLinkIssuer::class)->issue($verification, 'https://app.example.com/welcome');
 
     test()->withHeaders(['Host' => 'acme.authn.local'])
-        ->get("https://acme.authn.local/v1/client/magic_link/redeem?__authn_magic_link={$issued['jwt']}&redirect_url=https://app.example.com/welcome")
+        ->get("https://acme.authn.local/v1/client/magic-link/redeem?__authn_magic_link={$issued['jwt']}&redirect_url=https://app.example.com/welcome")
         ->assertRedirect('https://app.example.com/welcome');
 });

--- a/tests/Feature/Http/SignIn/PasswordTest.php
+++ b/tests/Feature/Http/SignIn/PasswordTest.php
@@ -11,7 +11,7 @@ it('completes a sign-in when identifier + strategy=password + password are suppl
 
     $response = $this->withCredentials()
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'identifier' => 'alice@example.com',
             'strategy' => 'password',
             'password' => 'super-secret-password',
@@ -32,7 +32,7 @@ it('returns form_password_incorrect on a wrong password', function (): void {
 
     $this->withCredentials()
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'identifier' => 'alice@example.com',
             'strategy' => 'password',
             'password' => 'wrong-password',
@@ -46,7 +46,7 @@ it('returns form_password_incorrect for an unknown identifier (no user-existence
 
     $this->withCredentials()
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'identifier' => 'ghost@example.com',
             'strategy' => 'password',
             'password' => 'whatever',
@@ -62,7 +62,7 @@ it('refuses sign-in for a banned user', function (): void {
 
     $this->withCredentials()
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'identifier' => 'alice@example.com',
             'strategy' => 'password',
             'password' => 'super-secret-password',
@@ -81,7 +81,7 @@ it('refuses sign-in for a locked user with a future lockout_expires_at', functio
 
     $this->withCredentials()
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'identifier' => 'alice@example.com',
             'strategy' => 'password',
             'password' => 'super-secret-password',
@@ -96,7 +96,7 @@ it('returns supported_first_factors on identifier-only create', function (): voi
 
     $response = $this->withCredentials()
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'identifier' => 'alice@example.com',
         ]);
 

--- a/tests/Feature/Http/SignIn/ResetPasswordTest.php
+++ b/tests/Feature/Http/SignIn/ResetPasswordTest.php
@@ -21,7 +21,7 @@ it('runs the reset_password_email_code → reset_password → complete path end-
     $create = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'identifier' => 'alice@example.com',
         ]);
     $sid = $create->json('response.id');
@@ -30,7 +30,7 @@ it('runs the reset_password_email_code → reset_password → complete path end-
     $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/prepare_first_factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/prepare-first-factor", [
             'strategy' => 'reset_password_email_code',
         ])
         ->assertOk();
@@ -44,7 +44,7 @@ it('runs the reset_password_email_code → reset_password → complete path end-
     $attempt = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/attempt_first_factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/attempt-first-factor", [
             'strategy' => 'reset_password_email_code',
             'code' => $known,
         ]);
@@ -54,7 +54,7 @@ it('runs the reset_password_email_code → reset_password → complete path end-
     $reset = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/reset_password", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/reset-password", [
             'password' => 'brand-new-password-9000',
         ]);
     $reset->assertOk()->assertJsonPath('response.status', 'complete');
@@ -65,7 +65,7 @@ it('runs the reset_password_email_code → reset_password → complete path end-
     expect($user->checkPassword('super-secret-password'))->toBeFalse();
 });
 
-it('refuses /reset_password unless the attempt is in needs_new_password state', function (): void {
+it('refuses /reset-password unless the attempt is in needs_new_password state', function (): void {
     $f = SignInTestSupport::bootEnv();
     SignInTestSupport::makeUser($f['env']);
     $bs = SignInTestSupport::clientWithCookie($f['env']);
@@ -74,7 +74,7 @@ it('refuses /reset_password unless the attempt is in needs_new_password state', 
     $create = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'identifier' => 'alice@example.com',
         ]);
     $sid = $create->json('response.id');
@@ -82,7 +82,7 @@ it('refuses /reset_password unless the attempt is in needs_new_password state', 
     $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ins/{$sid}/reset_password", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/reset-password", [
             'password' => 'whatever',
         ])
         ->assertStatus(422)

--- a/tests/Feature/Http/SignIn/TicketTest.php
+++ b/tests/Feature/Http/SignIn/TicketTest.php
@@ -17,7 +17,7 @@ it('redeems a sign_in_token ticket and lands on complete', function (): void {
 
     $response = $this->withCredentials()
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'strategy' => 'ticket',
             'ticket' => $ticket,
         ]);
@@ -39,7 +39,7 @@ it('refuses a replayed ticket (single-use jti)', function (): void {
     // First redemption succeeds.
     $first = $this->withCredentials()
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'strategy' => 'ticket',
             'ticket' => $ticket,
         ]);
@@ -50,7 +50,7 @@ it('refuses a replayed ticket (single-use jti)', function (): void {
     // attempt). We force a new client / attempt to make the replay obvious.
     $second = $this->withCredentials()
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'strategy' => 'ticket',
             'ticket' => $ticket,
         ]);
@@ -70,7 +70,7 @@ it('redeems an invitation ticket whose sub is the user email', function (): void
 
     $this->withCredentials()
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'strategy' => 'ticket',
             'ticket' => $ticket,
         ])
@@ -83,7 +83,7 @@ it('refuses a malformed ticket', function (): void {
 
     $this->withCredentials()
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ins', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
             'strategy' => 'ticket',
             'ticket' => 'not-a-jwt',
         ])

--- a/tests/Feature/Http/SignUp/EmailLinkTest.php
+++ b/tests/Feature/Http/SignUp/EmailLinkTest.php
@@ -10,7 +10,7 @@ use App\Services\Client\ClientResolver;
 use Illuminate\Support\Facades\Bus;
 use Tests\Feature\Http\Sessions\SessionsTestSupport;
 
-it('prepare_verification email_link issues a magic link, dispatches the email job', function (): void {
+it('prepare-verification email_link issues a magic link, dispatches the email job', function (): void {
     Bus::fake([SendMagicLinkEmail::class]);
     $f = SessionsTestSupport::bootEnv(userSettings: ['identifiers' => ['email_address' => ['enabled' => true, 'used_for_first_factor' => true, 'verifications' => ['email_code', 'email_link']]]]);
     $client = Client::create(['environment_id' => $f['env']->id]);
@@ -24,7 +24,7 @@ it('prepare_verification email_link issues a magic link, dispatches the email jo
 
     $r = test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ups/{$attempt->id}/prepare_verification", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$attempt->id}/prepare-verification", [
             'strategy' => 'email_link',
         ]);
     $r->assertOk();
@@ -40,7 +40,7 @@ it('prepare_verification email_link issues a magic link, dispatches the email jo
         && $job->templateSlug === 'magic_link_sign_up');
 });
 
-it('attempt_verification email_link returns verification_failed while link is unredeemed', function (): void {
+it('attempt-verification email_link returns verification_failed while link is unredeemed', function (): void {
     Bus::fake([SendMagicLinkEmail::class]);
     $f = SessionsTestSupport::bootEnv();
     $client = Client::create(['environment_id' => $f['env']->id]);
@@ -54,13 +54,13 @@ it('attempt_verification email_link returns verification_failed while link is un
 
     test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ups/{$attempt->id}/prepare_verification", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$attempt->id}/prepare-verification", [
             'strategy' => 'email_link',
         ])->assertOk();
 
     test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ups/{$attempt->id}/attempt_verification", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$attempt->id}/attempt-verification", [
             'strategy' => 'email_link',
         ])->assertStatus(422)
         ->assertJsonPath('errors.0.code', 'verification_failed');

--- a/tests/Feature/Http/SignUp/HappyPathTest.php
+++ b/tests/Feature/Http/SignUp/HappyPathTest.php
@@ -14,11 +14,11 @@ it('runs create → prepare → attempt → complete with email + password', fun
     $bs = SignUpTestSupport::clientWithCookie($f['env']);
     $cookie = $bs['cookie'];
 
-    // 1. POST /sign_ups with email + password — both required + email verify_at_sign_up.
+    // 1. POST /sign-ups with email + password — both required + email verify_at_sign_up.
     $create = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'email_address' => 'newbie@example.com',
             'password' => 'super-secret-password',
         ]);
@@ -29,11 +29,11 @@ it('runs create → prepare → attempt → complete with email + password', fun
         ->assertJsonPath('response.unverified_fields', ['email_address']);
     $sid = $create->json('response.id');
 
-    // 2. POST /prepare_verification strategy=email_code.
+    // 2. POST /prepare-verification strategy=email_code.
     $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ups/{$sid}/prepare_verification", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$sid}/prepare-verification", [
             'strategy' => 'email_code',
         ])
         ->assertOk();
@@ -44,11 +44,11 @@ it('runs create → prepare → attempt → complete with email + password', fun
     $known = '424242';
     $codeRow->forceFill(['code_hash' => hash('sha256', $known)])->save();
 
-    // 4. POST /attempt_verification → complete.
+    // 4. POST /attempt-verification → complete.
     $attempt = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ups/{$sid}/attempt_verification", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$sid}/attempt-verification", [
             'strategy' => 'email_code',
             'code' => $known,
         ]);
@@ -86,7 +86,7 @@ it('returns missing_fields when first_name is required and not provided', functi
     $create = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'email_address' => 'newbie@example.com',
             'password' => 'super-secret-password',
         ]);

--- a/tests/Feature/Http/SignUp/RestrictionsTest.php
+++ b/tests/Feature/Http/SignUp/RestrictionsTest.php
@@ -21,7 +21,7 @@ it('rejects fields the env has disabled with form_param_unknown', function (): v
     $r = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'email_address' => 'a@example.com',
             'password' => 'super-secret-password',
             'username' => 'shouldbeignored',
@@ -43,7 +43,7 @@ it('only allows allowlisted emails when signup_mode = restricted', function (): 
     $bad = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'email_address' => 'someone@outside.com',
             'password' => 'super-secret-password',
         ]);
@@ -53,7 +53,7 @@ it('only allows allowlisted emails when signup_mode = restricted', function (): 
     $good = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'email_address' => 'someone@team.com',
             'password' => 'super-secret-password',
         ]);
@@ -72,7 +72,7 @@ it('rejects blocklisted emails', function (): void {
     $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'email_address' => 'banned@example.com',
             'password' => 'super-secret-password',
         ])
@@ -99,7 +99,7 @@ it('detects subaddress collisions when block_email_subaddresses is on', function
     $r = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'email_address' => 'foo+anything@example.com',
             'password' => 'super-secret-password',
         ]);
@@ -123,7 +123,7 @@ it('treats gmail dot variants as the same identifier', function (): void {
     $r = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'email_address' => 'f.o.o@gmail.com',
             'password' => 'super-secret-password',
         ]);

--- a/tests/Feature/Http/SignUp/TestModeFlowTest.php
+++ b/tests/Feature/Http/SignUp/TestModeFlowTest.php
@@ -22,7 +22,7 @@ it('sign-up against +authn_test in dev uses fixed code 424242, no driver call', 
     $create = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'email_address' => 'alice+authn_test@example.com',
             'password' => 'super-secret-password',
         ]);
@@ -32,7 +32,7 @@ it('sign-up against +authn_test in dev uses fixed code 424242, no driver call', 
     $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ups/{$sid}/prepare_verification", ['strategy' => 'email_code'])
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$sid}/prepare-verification", ['strategy' => 'email_code'])
         ->assertOk();
 
     // The minted code is the fixed 424242 (still hashed in storage).
@@ -44,7 +44,7 @@ it('sign-up against +authn_test in dev uses fixed code 424242, no driver call', 
     $r = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign_ups/{$sid}/attempt_verification", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$sid}/attempt-verification", [
             'strategy' => 'email_code',
             'code' => '424242',
         ]);
@@ -63,7 +63,7 @@ it('sign-up against +authn_test in production returns test_identifier_forbidden'
     $r = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'email_address' => 'eve+authn_test@example.com',
             'password' => 'super-secret-password',
         ]);

--- a/tests/Feature/Http/SignUp/TicketTest.php
+++ b/tests/Feature/Http/SignUp/TicketTest.php
@@ -28,7 +28,7 @@ it('redeems an invitation ticket and completes the sign-up in one call', functio
     $r = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'ticket' => $ticket,
             'password' => 'super-secret-password',
         ]);
@@ -70,7 +70,7 @@ it('rejects a replayed ticket with ticket_invalid', function (): void {
     $first = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'ticket' => $ticket,
             'password' => 'super-secret-password',
         ]);
@@ -81,7 +81,7 @@ it('rejects a replayed ticket with ticket_invalid', function (): void {
     $second = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs2['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson('https://acme.authn.local/v1/client/sign_ups', [
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
             'ticket' => $ticket,
             'password' => 'super-secret-password',
         ]);

--- a/tests/Feature/Webhooks/BapiTest.php
+++ b/tests/Feature/Webhooks/BapiTest.php
@@ -27,7 +27,7 @@ it('POST /v1/webhooks/endpoints returns the signing_secret once', function (): v
     expect($get->json('signing_secret_prefix'))->toStartWith('whsec_');
 });
 
-it('POST /rotate_secret returns the new secret once and stashes the prior', function (): void {
+it('POST /rotate-secret returns the new secret once and stashes the prior', function (): void {
     $f = BapiTestSupport::bootEnv();
     $created = $this->withHeaders(BapiTestSupport::headers($f['token']))
         ->postJson(BapiTestSupport::url('/webhooks/endpoints'), [
@@ -37,7 +37,7 @@ it('POST /rotate_secret returns the new secret once and stashes the prior', func
     $oldDisplayed = $created->json('signing_secret');
 
     $rotate = $this->withHeaders(BapiTestSupport::headers($f['token']))
-        ->postJson(BapiTestSupport::url("/webhooks/endpoints/{$id}/rotate_secret"));
+        ->postJson(BapiTestSupport::url("/webhooks/endpoints/{$id}/rotate-secret"));
     $rotate->assertOk();
     expect($rotate->json('signing_secret'))->toStartWith('whsec_')
         ->not->toBe($oldDisplayed);


### PR DESCRIPTION
## Summary
- Aligns FAPI + BAPI URL segments with the canonical OpenAPI spec (snake → kebab on multi-word path segments).
- Route parameter names (`{user_id}`, `{organization_id}`, `{role_id}`, …), route names (`fapi.me.emails.list`, `bapi.users.profile_image.upload`, …), controller method names, and JSON request/response field names all stay snake_case — only URL segments change.
- Alpha — no compat aliases, no transitional redirects.

## Changes
- `routes/bapi.php`, `routes/fapi.php`: rewrites every multi-word path segment (e.g. `/v1/client/sign_ins/{sid}/prepare_first_factor` → `/v1/client/sign-ins/{sid}/prepare-first-factor`, `/v1/me/email_addresses` → `/v1/me/email-addresses`, `/v1/allowlist_identifiers` → `/v1/allowlist-identifiers`, `/v1/users/{id}/profile_image` → `/v1/users/{id}/profile-image`, `/v1/me/active_organization` → `/v1/me/active-organization`, etc.).
- `app/Services/MagicLink/MagicLinkIssuer.php`: emits the new `/v1/client/magic-link/redeem?...` URL.
- App-level doc-comments + the `.env.example` comment on the avatar bucket are swept to match.
- Test files under `tests/Feature/Http/**` and `tests/Feature/Webhooks/BapiTest.php`: every `postJson`/`getJson`/etc. URL literal kebabbed; affected `it(...)` descriptions updated where they quote a path.

## Not changed
- Route parameter placeholders (`{user_id}`, `{organization_id}`, `{role_id}`, `{domain_id}`, `{invitation_id}`, `{request_id}`, `{eid}`, `{sid}`, `{id}`).
- Route names (`fapi.me.emails.list`, `bapi.users.profile_image.upload`, …).
- Resource shapes; JSON request/response field names.
- Rate-limit bucket keys (`redirect_urls.create`, etc. — config, not URL).
- Account Portal pages and dashboard routes (already kebab).

## Test plan
- [x] `php artisan test` (serial): 454 passed / 1475 assertions
- [ ] CI green on the parallel runner before merge
- [ ] Spot-check the OpenAPI bundle (`../openapi/dist/`) is loaded fresh in CI so the contract validator sees the new paths