### PR TITLE
Replace per-factor prepare/attempt with Challenge sub-resource

### DIFF
--- a/app/Auth/Strategies/EmailCodeStrategy.php
+++ b/app/Auth/Strategies/EmailCodeStrategy.php
@@ -71,9 +71,7 @@ final class EmailCodeStrategy implements Strategy
             $emailAddress->id,
         );
 
-        $attempt->forceFill(['first_factor_verification_id' => $verification->id])->save();
-
-        return StrategyResult::ok($attempt);
+        return StrategyResult::ok($attempt, verification: $verification);
     }
 
     public function attempt(SignInAttempt $attempt, array $params): StrategyResult
@@ -83,26 +81,22 @@ final class EmailCodeStrategy implements Strategy
             return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'code is required.');
         }
 
-        $verification = Verification::query()
-            ->withoutGlobalScopes()
-            ->where('id', (string) $attempt->first_factor_verification_id)
-            ->first();
-        if ($verification === null) {
+        $verification = $params['verification'] ?? null;
+        if (! $verification instanceof Verification) {
             return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, 'No verification is in progress for this attempt.', 422);
         }
 
         $ok = $this->verifications->attempt($verification, $code);
         if (! $ok) {
-            $code = $verification->fresh()->status === Verification::STATUS_FAILED
+            $errCode = $verification->fresh()->status === Verification::STATUS_FAILED
                 ? ErrorCodes::VERIFICATION_FAILED
                 : ($verification->fresh()->status === Verification::STATUS_EXPIRED
                     ? ErrorCodes::VERIFICATION_EXPIRED
                     : ErrorCodes::FORM_CODE_INCORRECT);
 
-            return StrategyResult::fail($attempt, $code, 'Incorrect code.');
+            return StrategyResult::fail($attempt, $errCode, 'Incorrect code.', verification: $verification->fresh() ?? $verification);
         }
 
-        // Map verifiable -> User via EmailAddress.
         $email = EmailAddress::query()->withoutGlobalScopes()->where('id', $verification->verifiable_id)->first();
         $user = $email ? User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first() : null;
 
@@ -117,7 +111,7 @@ final class EmailCodeStrategy implements Strategy
             return StrategyResult::fail($attempt, ErrorCodes::USER_LOCKED, 'This user is temporarily locked.', 403);
         }
 
-        return StrategyResult::ok($attempt, $user);
+        return StrategyResult::ok($attempt, $user, $verification->fresh() ?? $verification);
     }
 
     private function resolveEmailAddress(SignInAttempt $attempt, array $params): ?EmailAddress

--- a/app/Auth/Strategies/EmailLinkStrategy.php
+++ b/app/Auth/Strategies/EmailLinkStrategy.php
@@ -79,34 +79,28 @@ final class EmailLinkStrategy implements Strategy
             $emailAddress->id,
         );
 
-        $attempt->forceFill(['first_factor_verification_id' => $verification->id])->save();
+        $verification->forceFill(['external_verification_redirect_url' => $minted['url']])->save();
 
-        return StrategyResult::ok($attempt);
+        return StrategyResult::ok($attempt, verification: $verification->fresh() ?? $verification);
     }
 
     public function attempt(SignInAttempt $attempt, array $params): StrategyResult
     {
-        $verification = Verification::query()
-            ->withoutGlobalScopes()
-            ->where('id', (string) $attempt->first_factor_verification_id)
-            ->first();
-        if ($verification === null) {
+        $verification = $params['verification'] ?? null;
+        if (! $verification instanceof Verification) {
             return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, 'No magic link is in flight for this attempt.', 422);
         }
 
         if ($verification->status === Verification::STATUS_UNVERIFIED) {
-            // Still pending — the user hasn't clicked the link yet. The SDK
-            // polls; we tell it to keep waiting.
-            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, 'Magic link not yet redeemed.', 422);
+            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, 'Magic link not yet redeemed.', 422, $verification);
         }
         if ($verification->status === Verification::STATUS_EXPIRED) {
-            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_EXPIRED, 'Magic link expired.', 422);
+            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_EXPIRED, 'Magic link expired.', 422, $verification);
         }
         if ($verification->status !== Verification::STATUS_VERIFIED) {
-            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, "Magic link verification is in status {$verification->status}.", 422);
+            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, "Magic link verification is in status {$verification->status}.", 422, $verification);
         }
 
-        // Verified — resolve the user via the email captured at prepare-time.
         $email = EmailAddress::query()
             ->withoutGlobalScopes()
             ->where('environment_id', $attempt->environment_id)
@@ -125,7 +119,7 @@ final class EmailLinkStrategy implements Strategy
             return StrategyResult::fail($attempt, ErrorCodes::USER_LOCKED, 'This user is temporarily locked.', 403);
         }
 
-        return StrategyResult::ok($attempt, $user);
+        return StrategyResult::ok($attempt, $user, $verification);
     }
 
     private function resolveEmailAddress(SignInAttempt $attempt, array $params): ?EmailAddress

--- a/app/Auth/Strategies/ResetPasswordEmailCodeStrategy.php
+++ b/app/Auth/Strategies/ResetPasswordEmailCodeStrategy.php
@@ -65,9 +65,7 @@ final class ResetPasswordEmailCodeStrategy implements Strategy
             $emailAddress->id,
         );
 
-        $attempt->forceFill(['first_factor_verification_id' => $verification->id])->save();
-
-        return StrategyResult::ok($attempt);
+        return StrategyResult::ok($attempt, verification: $verification);
     }
 
     public function attempt(SignInAttempt $attempt, array $params): StrategyResult
@@ -77,11 +75,8 @@ final class ResetPasswordEmailCodeStrategy implements Strategy
             return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'code is required.');
         }
 
-        $verification = Verification::query()
-            ->withoutGlobalScopes()
-            ->where('id', (string) $attempt->first_factor_verification_id)
-            ->first();
-        if ($verification === null) {
+        $verification = $params['verification'] ?? null;
+        if (! $verification instanceof Verification) {
             return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, 'No verification is in progress for this attempt.', 422);
         }
 
@@ -93,7 +88,7 @@ final class ResetPasswordEmailCodeStrategy implements Strategy
                     ? ErrorCodes::VERIFICATION_EXPIRED
                     : ErrorCodes::FORM_CODE_INCORRECT);
 
-            return StrategyResult::fail($attempt, $errorCode, 'Incorrect code.');
+            return StrategyResult::fail($attempt, $errorCode, 'Incorrect code.', verification: $verification->fresh() ?? $verification);
         }
 
         $email = EmailAddress::query()->withoutGlobalScopes()->where('id', $verification->verifiable_id)->first();
@@ -103,6 +98,6 @@ final class ResetPasswordEmailCodeStrategy implements Strategy
             return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'User not found.', 422);
         }
 
-        return StrategyResult::ok($attempt, $user);
+        return StrategyResult::ok($attempt, $user, $verification->fresh() ?? $verification);
     }
 }

--- a/app/Auth/Strategies/StrategyResult.php
+++ b/app/Auth/Strategies/StrategyResult.php
@@ -6,12 +6,13 @@ namespace App\Auth\Strategies;
 
 use App\Models\SignInAttempt;
 use App\Models\User;
+use App\Models\Verification;
 
 /**
  * Common result shape returned by every Strategy method. The controller
  * doesn't need to know about strategy internals — it inspects `success`,
- * `errorCode`, `errorMessage`, then renders the SignInAttempt with any
- * resulting Verification or User attached.
+ * `errorCode`, `errorMessage`, then wraps the resulting Verification in a
+ * Challenge envelope.
  */
 final class StrategyResult
 {
@@ -19,18 +20,19 @@ final class StrategyResult
         public readonly bool $success,
         public readonly SignInAttempt $attempt,
         public readonly ?User $user = null,
+        public readonly ?Verification $verification = null,
         public readonly ?string $errorCode = null,
         public readonly ?string $errorMessage = null,
         public readonly int $httpStatus = 200,
     ) {}
 
-    public static function ok(SignInAttempt $attempt, ?User $user = null): self
+    public static function ok(SignInAttempt $attempt, ?User $user = null, ?Verification $verification = null): self
     {
-        return new self(true, $attempt, $user);
+        return new self(true, $attempt, $user, $verification);
     }
 
-    public static function fail(SignInAttempt $attempt, string $code, string $message, int $httpStatus = 422): self
+    public static function fail(SignInAttempt $attempt, string $code, string $message, int $httpStatus = 422, ?Verification $verification = null): self
     {
-        return new self(false, $attempt, null, $code, $message, $httpStatus);
+        return new self(false, $attempt, null, $verification, $code, $message, $httpStatus);
     }
 }

--- a/app/Http/Controllers/Fapi/ChallengeController.php
+++ b/app/Http/Controllers/Fapi/ChallengeController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Fapi;
 
 use App\Auth\ErrorCodes;
+use App\Auth\SignUp\StageRequirements;
 use App\Auth\StrategyResolver;
 use App\Http\Resources\ChallengeResource;
 use App\Http\Resources\ClientResource;
@@ -586,7 +587,7 @@ final class ChallengeController
     {
         $env = app(Environment::class);
 
-        $stage = app(\App\Auth\SignUp\StageRequirements::class);
+        $stage = app(StageRequirements::class);
 
         $verifiedFlags = [];
         $emailVerified = $attempt->challenges()

--- a/app/Http/Controllers/Fapi/ChallengeController.php
+++ b/app/Http/Controllers/Fapi/ChallengeController.php
@@ -90,8 +90,10 @@ final class ChallengeController
 
         if (! $strategy->requiresPrepare()) {
             // password / ticket — no out-of-band material to issue. Persist
-            // a Verification stub so the Challenge has a 1:1 wrapped row;
-            // the answer call will overwrite its lifecycle.
+            // a Verification stub + Challenge wrapper, then if the create
+            // call carried the credential (`{strategy: "password", password}`
+            // or `{strategy: "ticket", ticket}`), run `attempt` synchronously
+            // so the SDK can complete the sign-in in a single round trip.
             $verification = Verification::query()->withoutGlobalScopes()->create([
                 'environment_id' => $attempt->environment_id,
                 'verifiable_type' => $attempt->getMorphClass(),
@@ -103,6 +105,15 @@ final class ChallengeController
             ]);
 
             $challenge = $this->createChallenge($attempt, Challenge::PARENT_SIGN_IN, $step, $strategyName, $verification);
+
+            $hasCredential = ($strategyName === Verification::STRATEGY_PASSWORD && is_string($request->input('password')))
+                || ($strategyName === Verification::STRATEGY_TICKET && is_string($request->input('ticket')));
+            if ($hasCredential) {
+                return $this->runSignInAnswer($attempt, $challenge, $verification, [
+                    'password' => $request->input('password'),
+                    'ticket' => $request->input('ticket'),
+                ], $client);
+            }
 
             return $this->signInEnvelope($client, $attempt->fresh(), $challenge);
         }
@@ -148,14 +159,24 @@ final class ChallengeController
             return $this->errorWithSignIn(422, ErrorCodes::VERIFICATION_FAILED, 'Underlying verification missing.', $client, $attempt);
         }
 
-        $strategy = $this->strategies->resolve($challenge->strategy);
-
-        $result = $strategy->attempt($attempt, [
+        return $this->runSignInAnswer($attempt, $challenge, $verification, [
             'password' => $request->input('password'),
             'code' => $request->input('code'),
             'ticket' => $request->input('ticket'),
-            'verification' => $verification,
-        ]);
+        ], $client);
+    }
+
+    private function runSignInAnswer(
+        SignInAttempt $attempt,
+        Challenge $challenge,
+        Verification $verification,
+        array $params,
+        Client $client,
+    ): JsonResponse {
+        $strategy = $this->strategies->resolve($challenge->strategy);
+
+        $params['verification'] = $verification;
+        $result = $strategy->attempt($attempt, $params);
 
         if (! $result->success) {
             $this->reflectFailure($challenge, $result->verification ?? $verification, $result->errorCode, $result->errorMessage);

--- a/app/Http/Controllers/Fapi/ChallengeController.php
+++ b/app/Http/Controllers/Fapi/ChallengeController.php
@@ -1,0 +1,830 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Auth\ErrorCodes;
+use App\Auth\StrategyResolver;
+use App\Http\Resources\ChallengeResource;
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\SignInResource;
+use App\Http\Resources\SignUpResource;
+use App\Jobs\Mail\SendMagicLinkEmail;
+use App\Jobs\Mail\SendVerificationEmail;
+use App\Models\Challenge;
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\EmailTemplate;
+use App\Models\Environment;
+use App\Models\Session;
+use App\Models\SignInAttempt;
+use App\Models\SignUpAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Models\VerificationCode;
+use App\Services\Domains\DomainEnroller;
+use App\Services\MagicLink\MagicLinkIssuer;
+use App\Services\Sessions\SessionLifecycle;
+use App\Services\Sessions\SessionTokenIssuer;
+use App\Services\Verification\VerificationManager;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Cookie;
+
+/**
+ * Uniform Challenge sub-resource for SignIn / SignUp factor flows.
+ *
+ * Replaces the per-factor `prepare-*` / `attempt-*` endpoint pairs with
+ * a CRUD-shaped Challenge resource:
+ *   POST   /v1/client/sign-{ins|ups}/{sid}/challenges        — issue
+ *   POST   /v1/client/sign-{ins|ups}/{sid}/challenges/{cid}/answer — submit
+ *   GET    /v1/client/sign-{ins|ups}/{sid}/challenges/{cid}  — poll
+ *
+ * Each Challenge wraps an underlying Verification 1:1 — the Verification
+ * still owns the cryptographic state (codes, attempt counter, expiry);
+ * the Challenge is the API-facing veneer that exposes the lifecycle in a
+ * shape that's identical across strategies.
+ */
+final class ChallengeController
+{
+    private const SIGN_UP_EMAIL_VERIFICATION_TTL = 600;
+
+    private const SESSION_COOKIE_TTL_SECONDS = 86400;
+
+    public function __construct(
+        private readonly StrategyResolver $strategies,
+        private readonly VerificationManager $verifications,
+    ) {}
+
+    /* ============================ sign-in surface ============================ */
+
+    public function storeForSignIn(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $client = app(Client::class);
+        $attempt = $this->loadSignInAttempt($sid, $client);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        $strategyName = (string) $request->input('strategy', '');
+        if ($strategyName === '') {
+            return $this->errorWithSignIn(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', $client, $attempt);
+        }
+        if (! in_array($strategyName, $this->signInSupportedStrategies($attempt), true)) {
+            return $this->errorWithSignIn(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategyName} is not supported on this sign-in.", $client, $attempt);
+        }
+
+        try {
+            $strategy = $this->strategies->resolve($strategyName);
+        } catch (InvalidArgumentException) {
+            return $this->errorWithSignIn(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategyName} is not enabled in v0.1.", $client, $attempt);
+        }
+
+        $step = $this->resolveSignInStep($attempt);
+
+        if (! $strategy->requiresPrepare()) {
+            // password / ticket — no out-of-band material to issue. Persist
+            // a Verification stub so the Challenge has a 1:1 wrapped row;
+            // the answer call will overwrite its lifecycle.
+            $verification = Verification::query()->withoutGlobalScopes()->create([
+                'environment_id' => $attempt->environment_id,
+                'verifiable_type' => $attempt->getMorphClass(),
+                'verifiable_id' => $attempt->id,
+                'strategy' => $strategyName,
+                'status' => Verification::STATUS_UNVERIFIED,
+                'attempts' => 0,
+                'expire_at' => now()->addMinutes(10),
+            ]);
+
+            $challenge = $this->createChallenge($attempt, Challenge::PARENT_SIGN_IN, $step, $strategyName, $verification);
+
+            return $this->signInEnvelope($client, $attempt->fresh(), $challenge);
+        }
+
+        $result = $strategy->prepare($attempt, [
+            'email_address_id' => $request->input('email_address_id'),
+            'redirect_url' => $request->input('redirect_url'),
+        ]);
+
+        if (! $result->success || $result->verification === null) {
+            return $this->errorWithSignIn(
+                $result->httpStatus,
+                $result->errorCode ?? ErrorCodes::VERIFICATION_FAILED,
+                $result->errorMessage ?? '',
+                $client,
+                $attempt->fresh(),
+            );
+        }
+
+        $challenge = $this->createChallenge($attempt, Challenge::PARENT_SIGN_IN, $step, $strategyName, $result->verification);
+
+        return $this->signInEnvelope($client, $attempt->fresh(), $challenge);
+    }
+
+    public function answerForSignIn(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $cid = (string) $request->route('cid');
+        $client = app(Client::class);
+
+        $attempt = $this->loadSignInAttempt($sid, $client);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        $challenge = $this->loadChallenge($cid, $attempt, Challenge::PARENT_SIGN_IN);
+        if ($challenge instanceof JsonResponse) {
+            return $challenge;
+        }
+
+        $verification = Verification::query()->withoutGlobalScopes()->where('id', $challenge->verification_id)->first();
+        if ($verification === null) {
+            return $this->errorWithSignIn(422, ErrorCodes::VERIFICATION_FAILED, 'Underlying verification missing.', $client, $attempt);
+        }
+
+        $strategy = $this->strategies->resolve($challenge->strategy);
+
+        $result = $strategy->attempt($attempt, [
+            'password' => $request->input('password'),
+            'code' => $request->input('code'),
+            'ticket' => $request->input('ticket'),
+            'verification' => $verification,
+        ]);
+
+        if (! $result->success) {
+            $this->reflectFailure($challenge, $result->verification ?? $verification, $result->errorCode, $result->errorMessage);
+
+            return $this->errorWithSignIn(
+                $result->httpStatus,
+                $result->errorCode ?? ErrorCodes::VERIFICATION_FAILED,
+                $result->errorMessage ?? '',
+                $client,
+                $attempt->fresh(),
+                $challenge->fresh(),
+            );
+        }
+
+        $attempt = $result->attempt;
+        $user = $result->user;
+
+        $this->markChallengeVerified($challenge, $result->verification ?? $verification);
+
+        // reset_password_email_code: parent transitions to needs_new_password
+        // and the SDK follows up with PATCH /sign-ins/{sid} { password }.
+        if ($challenge->strategy === Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE) {
+            $attempt->status = SignInAttempt::STATUS_NEEDS_NEW_PASSWORD;
+            $attempt->save();
+
+            return $this->signInEnvelope($client, $attempt->fresh(), $challenge->fresh());
+        }
+
+        $session = $this->createSessionForSignIn($attempt, $user);
+
+        return $this->signInEnvelope($client, $attempt->fresh(), $challenge->fresh(), $session);
+    }
+
+    public function showForSignIn(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $cid = (string) $request->route('cid');
+        $client = app(Client::class);
+
+        $attempt = $this->loadSignInAttempt($sid, $client, allowTerminal: true);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        $challenge = $this->loadChallenge($cid, $attempt, Challenge::PARENT_SIGN_IN);
+        if ($challenge instanceof JsonResponse) {
+            return $challenge;
+        }
+
+        $this->refreshChallengeFromVerification($challenge);
+
+        return response()->json(ChallengeResource::from($challenge->fresh()))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    /* ============================ sign-up surface ============================ */
+
+    public function storeForSignUp(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $client = app(Client::class);
+        $attempt = $this->loadSignUpAttempt($sid, $client);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        $strategyName = (string) $request->input('strategy', '');
+        if ($strategyName === '') {
+            return $this->errorWithSignUp(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', $client, $attempt);
+        }
+        if (! in_array($strategyName, $this->signUpSupportedStrategies($attempt), true)) {
+            return $this->errorWithSignUp(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategyName} is not supported on this sign-up.", $client, $attempt);
+        }
+        if (! is_string($attempt->email_address) || $attempt->email_address === '') {
+            return $this->errorWithSignUp(422, ErrorCodes::FORM_PARAM_NIL, 'email_address is required before issuing a challenge.', $client, $attempt);
+        }
+
+        if ($strategyName === Verification::STRATEGY_EMAIL_LINK) {
+            return $this->issueSignUpEmailLink($client, $attempt, $request);
+        }
+
+        $verification = $this->verifications->start($attempt, Verification::STRATEGY_EMAIL_CODE, self::SIGN_UP_EMAIL_VERIFICATION_TTL);
+        $code = $this->verifications->mintNumericCode($verification, VerificationCode::PURPOSE_EMAIL_CODE, self::SIGN_UP_EMAIL_VERIFICATION_TTL);
+
+        SendVerificationEmail::dispatch(
+            $attempt->environment_id,
+            $attempt->email_address,
+            $code,
+            VerificationCode::PURPOSE_EMAIL_CODE,
+            $verification->id,
+        );
+
+        $challenge = $this->createChallenge($attempt, Challenge::PARENT_SIGN_UP, Challenge::STEP_SINGLE, Verification::STRATEGY_EMAIL_CODE, $verification);
+
+        return $this->signUpEnvelope($client, $attempt->fresh(), $challenge);
+    }
+
+    public function answerForSignUp(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $cid = (string) $request->route('cid');
+        $client = app(Client::class);
+
+        $attempt = $this->loadSignUpAttempt($sid, $client);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        $challenge = $this->loadChallenge($cid, $attempt, Challenge::PARENT_SIGN_UP);
+        if ($challenge instanceof JsonResponse) {
+            return $challenge;
+        }
+
+        $verification = Verification::query()->withoutGlobalScopes()->where('id', $challenge->verification_id)->first();
+        if ($verification === null) {
+            return $this->errorWithSignUp(422, ErrorCodes::VERIFICATION_FAILED, 'Underlying verification missing.', $client, $attempt);
+        }
+
+        if ($challenge->strategy === Verification::STRATEGY_EMAIL_LINK) {
+            // Empty body — commits the SDK to polling; the click flips the
+            // Verification out-of-band.
+            $this->refreshChallengeFromVerification($challenge);
+            $fresh = $challenge->fresh();
+            if ($fresh === null) {
+                return $this->errorWithSignUp(422, ErrorCodes::VERIFICATION_FAILED, 'Challenge missing.', $client, $attempt);
+            }
+            if ($fresh->status === Challenge::STATUS_PENDING) {
+                return $this->errorWithSignUp(422, ErrorCodes::VERIFICATION_FAILED, 'Magic link not yet redeemed.', $client, $attempt, $fresh);
+            }
+            if ($fresh->status === Challenge::STATUS_EXPIRED) {
+                return $this->errorWithSignUp(422, ErrorCodes::VERIFICATION_EXPIRED, 'Magic link expired.', $client, $attempt, $fresh);
+            }
+            if ($fresh->status !== Challenge::STATUS_VERIFIED) {
+                return $this->errorWithSignUp(422, ErrorCodes::VERIFICATION_FAILED, "Challenge in status {$fresh->status}.", $client, $attempt, $fresh);
+            }
+
+            return $this->finalizeSignUpIfReady($client, $attempt, $fresh);
+        }
+
+        $code = $request->input('code');
+        if (! is_string($code) || $code === '') {
+            return $this->errorWithSignUp(422, ErrorCodes::FORM_PARAM_NIL, 'code is required.', $client, $attempt, $challenge);
+        }
+
+        $ok = $this->verifications->attempt($verification, $code);
+        if (! $ok) {
+            $fresh = $verification->fresh();
+            $errCode = $fresh->status === Verification::STATUS_FAILED
+                ? ErrorCodes::VERIFICATION_FAILED
+                : ($fresh->status === Verification::STATUS_EXPIRED
+                    ? ErrorCodes::VERIFICATION_EXPIRED
+                    : ErrorCodes::FORM_CODE_INCORRECT);
+            $this->reflectFailure($challenge, $fresh, $errCode, 'Incorrect code.');
+
+            return $this->errorWithSignUp(422, $errCode, 'Incorrect code.', $client, $attempt, $challenge->fresh());
+        }
+
+        $this->markChallengeVerified($challenge, $verification->fresh() ?? $verification);
+
+        return $this->finalizeSignUpIfReady($client, $attempt, $challenge->fresh());
+    }
+
+    public function showForSignUp(Request $request): JsonResponse
+    {
+        $sid = (string) $request->route('sid');
+        $cid = (string) $request->route('cid');
+        $client = app(Client::class);
+
+        $attempt = $this->loadSignUpAttempt($sid, $client, allowTerminal: true);
+        if ($attempt instanceof JsonResponse) {
+            return $attempt;
+        }
+
+        $challenge = $this->loadChallenge($cid, $attempt, Challenge::PARENT_SIGN_UP);
+        if ($challenge instanceof JsonResponse) {
+            return $challenge;
+        }
+
+        $this->refreshChallengeFromVerification($challenge);
+
+        return response()->json(ChallengeResource::from($challenge->fresh()))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    /* ================================ helpers ================================ */
+
+    private function issueSignUpEmailLink(Client $client, SignUpAttempt $attempt, Request $request): JsonResponse
+    {
+        $verification = $this->verifications->start(
+            $attempt,
+            Verification::STRATEGY_EMAIL_LINK,
+            MagicLinkIssuer::TTL_SECONDS,
+        );
+        $redirectUrl = $request->input('redirect_url');
+        $minted = app(MagicLinkIssuer::class)->issue(
+            $verification,
+            is_string($redirectUrl) && $redirectUrl !== '' ? $redirectUrl : null,
+        );
+
+        SendMagicLinkEmail::dispatch(
+            $attempt->environment_id,
+            (string) $attempt->email_address,
+            $minted['url'],
+            EmailTemplate::SLUG_MAGIC_LINK_SIGN_UP,
+            $verification->id,
+        );
+
+        $verification->forceFill(['external_verification_redirect_url' => $minted['url']])->save();
+
+        $challenge = $this->createChallenge(
+            $attempt,
+            Challenge::PARENT_SIGN_UP,
+            Challenge::STEP_SINGLE,
+            Verification::STRATEGY_EMAIL_LINK,
+            $verification->fresh() ?? $verification,
+        );
+
+        return $this->signUpEnvelope($client, $attempt->fresh(), $challenge);
+    }
+
+    private function createChallenge(
+        Model $attempt,
+        string $parentType,
+        string $step,
+        string $strategy,
+        Verification $verification,
+    ): Challenge {
+        return DB::transaction(function () use ($attempt, $parentType, $step, $strategy, $verification): Challenge {
+            $challenge = Challenge::query()->withoutGlobalScopes()->create([
+                'environment_id' => $attempt->environment_id,
+                'parent_type' => $parentType,
+                'parent_id' => $attempt->getKey(),
+                'step' => $step,
+                'strategy' => $strategy,
+                'status' => $this->mapVerificationStatus($verification->status),
+                'verification_id' => $verification->id,
+                'attempts' => (int) $verification->attempts,
+                'nonce' => $verification->nonce,
+                'external_verification_redirect_url' => $verification->external_verification_redirect_url,
+                'error_code' => $verification->error_code,
+                'error_message' => $verification->error_message,
+                'expire_at' => $verification->expire_at,
+            ]);
+
+            $attempt->forceFill(['current_challenge_id' => $challenge->id])->save();
+
+            return $challenge;
+        });
+    }
+
+    private function refreshChallengeFromVerification(Challenge $challenge): void
+    {
+        $verification = Verification::query()->withoutGlobalScopes()->where('id', $challenge->verification_id)->first();
+        if ($verification === null) {
+            return;
+        }
+        $challenge->forceFill([
+            'status' => $this->mapVerificationStatus($verification->status),
+            'attempts' => (int) $verification->attempts,
+            'nonce' => $verification->nonce,
+            'external_verification_redirect_url' => $verification->external_verification_redirect_url,
+            'error_code' => $verification->error_code,
+            'error_message' => $verification->error_message,
+        ])->save();
+    }
+
+    private function reflectFailure(Challenge $challenge, ?Verification $verification, ?string $errorCode, ?string $errorMessage): void
+    {
+        $update = [
+            'attempts' => $verification !== null ? (int) $verification->attempts : (int) $challenge->attempts + 1,
+            'error_code' => $errorCode,
+            'error_message' => $errorMessage,
+        ];
+        if ($verification !== null) {
+            $update['status'] = $this->mapVerificationStatus($verification->status);
+        }
+        $challenge->forceFill($update)->save();
+
+        if ($verification !== null && $verification->status !== Verification::STATUS_UNVERIFIED) {
+            $this->clearParentCurrentChallenge($challenge);
+        }
+    }
+
+    private function markChallengeVerified(Challenge $challenge, Verification $verification): void
+    {
+        $challenge->forceFill([
+            'status' => Challenge::STATUS_VERIFIED,
+            'attempts' => (int) $verification->attempts,
+            'error_code' => null,
+            'error_message' => null,
+        ])->save();
+
+        $this->clearParentCurrentChallenge($challenge);
+    }
+
+    /**
+     * Clears `current_challenge_id` on the parent SignIn / SignUp once
+     * the challenge has left `pending`. Keeps the SDK polling story
+     * unambiguous: `current_challenge_id` always points at a live
+     * challenge worth interacting with, never at a terminal one.
+     */
+    private function clearParentCurrentChallenge(Challenge $challenge): void
+    {
+        $parentClass = Challenge::MORPH_MAP[$challenge->parent_type] ?? null;
+        if ($parentClass === null) {
+            return;
+        }
+        /** @var class-string<Model> $parentClass */
+        $parentClass::query()
+            ->withoutGlobalScopes()
+            ->where('id', $challenge->parent_id)
+            ->where('current_challenge_id', $challenge->id)
+            ->update(['current_challenge_id' => null]);
+    }
+
+    private function mapVerificationStatus(string $status): string
+    {
+        return match ($status) {
+            Verification::STATUS_UNVERIFIED => Challenge::STATUS_PENDING,
+            Verification::STATUS_VERIFIED => Challenge::STATUS_VERIFIED,
+            Verification::STATUS_TRANSFERABLE => Challenge::STATUS_TRANSFERABLE,
+            Verification::STATUS_FAILED => Challenge::STATUS_FAILED,
+            Verification::STATUS_EXPIRED => Challenge::STATUS_EXPIRED,
+            default => Challenge::STATUS_PENDING,
+        };
+    }
+
+    private function resolveSignInStep(SignInAttempt $attempt): string
+    {
+        return match ($attempt->status) {
+            SignInAttempt::STATUS_NEEDS_SECOND_FACTOR => Challenge::STEP_SECOND,
+            default => Challenge::STEP_FIRST,
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function signInSupportedStrategies(SignInAttempt $attempt): array
+    {
+        return match ($attempt->status) {
+            SignInAttempt::STATUS_NEEDS_FIRST_FACTOR => [
+                Verification::STRATEGY_PASSWORD,
+                Verification::STRATEGY_EMAIL_CODE,
+                Verification::STRATEGY_EMAIL_LINK,
+                Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE,
+                Verification::STRATEGY_TICKET,
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function signUpSupportedStrategies(SignUpAttempt $attempt): array
+    {
+        $unverified = is_array($attempt->unverified_fields) ? $attempt->unverified_fields : [];
+        if (! in_array('email_address', $unverified, true)) {
+            return [];
+        }
+
+        return [
+            Verification::STRATEGY_EMAIL_CODE,
+            Verification::STRATEGY_EMAIL_LINK,
+        ];
+    }
+
+    private function loadSignInAttempt(string $sid, Client $client, bool $allowTerminal = false): SignInAttempt|JsonResponse
+    {
+        $attempt = SignInAttempt::query()
+            ->withoutGlobalScopes()
+            ->where('id', $sid)
+            ->where('client_id', $client->id)
+            ->first();
+        if ($attempt === null) {
+            return $this->bareError(404, ErrorCodes::SIGN_IN_NOT_FOUND, 'Sign-in attempt not found on this device.', $client);
+        }
+        if (! $allowTerminal) {
+            if ($attempt->isAbandoned()) {
+                return $this->errorWithSignIn(422, ErrorCodes::SIGN_IN_ABANDONED, 'This sign-in attempt has been abandoned.', $client, $attempt);
+            }
+            if ($attempt->status === SignInAttempt::STATUS_COMPLETE) {
+                return $this->errorWithSignIn(422, ErrorCodes::SIGN_IN_ALREADY_COMPLETE, 'This sign-in attempt is already complete.', $client, $attempt);
+            }
+        }
+
+        return $attempt;
+    }
+
+    private function loadSignUpAttempt(string $sid, Client $client, bool $allowTerminal = false): SignUpAttempt|JsonResponse
+    {
+        $attempt = SignUpAttempt::query()
+            ->withoutGlobalScopes()
+            ->where('id', $sid)
+            ->where('client_id', $client->id)
+            ->first();
+        if ($attempt === null) {
+            return $this->bareError(404, ErrorCodes::SIGN_UP_NOT_FOUND, 'Sign-up attempt not found on this device.', $client);
+        }
+        if (! $allowTerminal) {
+            if ($attempt->status === SignUpAttempt::STATUS_ABANDONED) {
+                return $this->errorWithSignUp(422, ErrorCodes::SIGN_UP_ABANDONED, 'This sign-up attempt has been abandoned.', $client, $attempt);
+            }
+            if ($attempt->status === SignUpAttempt::STATUS_COMPLETE) {
+                return $this->errorWithSignUp(422, ErrorCodes::SIGN_UP_ALREADY_COMPLETE, 'This sign-up attempt is already complete.', $client, $attempt);
+            }
+        }
+
+        return $attempt;
+    }
+
+    private function loadChallenge(string $cid, Model $attempt, string $expectedParentType): Challenge|JsonResponse
+    {
+        $challenge = Challenge::query()
+            ->withoutGlobalScopes()
+            ->where('id', $cid)
+            ->where('parent_type', $expectedParentType)
+            ->where('parent_id', $attempt->getKey())
+            ->first();
+        if ($challenge === null) {
+            return $this->bareError(404, ErrorCodes::VERIFICATION_FAILED, 'Challenge not found.', app(Client::class));
+        }
+
+        return $challenge;
+    }
+
+    private function finalizeSignUpIfReady(Client $client, SignUpAttempt $attempt, ?Challenge $challenge): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        $stage = app(\App\Auth\SignUp\StageRequirements::class);
+
+        $verifiedFlags = [];
+        $emailVerified = $attempt->challenges()
+            ->where('status', Challenge::STATUS_VERIFIED)
+            ->whereIn('strategy', [Verification::STRATEGY_EMAIL_CODE, Verification::STRATEGY_EMAIL_LINK])
+            ->exists();
+        if ($emailVerified) {
+            $verifiedFlags['email_address'] = true;
+        }
+
+        $supplied = [
+            'email_address' => $attempt->email_address,
+            'username' => $attempt->username,
+            'first_name' => $attempt->first_name,
+            'last_name' => $attempt->last_name,
+            'password' => $attempt->password_hash !== null ? '__present__' : null,
+        ];
+        $eval = $stage->evaluate($env, $supplied, $verifiedFlags);
+
+        $attempt->missing_fields = $eval['missing_fields'];
+        $attempt->unverified_fields = $eval['unverified_fields'];
+
+        if (! empty($eval['missing_fields']) || ! empty($eval['unverified_fields'])) {
+            $attempt->save();
+
+            return $this->signUpEnvelope($client, $attempt->fresh(), $challenge);
+        }
+
+        return DB::transaction(function () use ($env, $client, $attempt, $challenge): JsonResponse {
+            $user = User::query()->withoutGlobalScopes()->create([
+                'environment_id' => $env->id,
+                'first_name' => $attempt->first_name,
+                'last_name' => $attempt->last_name,
+                'username' => $attempt->username,
+                'password_hash' => $attempt->password_hash,
+                'password_changed_at' => $attempt->password_hash !== null ? now() : null,
+                'public_metadata' => is_array($attempt->public_metadata) ? $attempt->public_metadata : [],
+                'unsafe_metadata' => is_array($attempt->unsafe_metadata) ? $attempt->unsafe_metadata : [],
+            ]);
+
+            $email = EmailAddress::query()->withoutGlobalScopes()->create([
+                'environment_id' => $env->id,
+                'user_id' => $user->id,
+                'email_address' => (string) $attempt->email_address,
+                'verified_at' => now(),
+                'is_primary' => true,
+            ]);
+
+            $user->forceFill(['primary_email_address_id' => $email->id])->saveQuietly();
+
+            $session = Session::create([
+                'environment_id' => $env->id,
+                'client_id' => $client->id,
+                'user_id' => $user->id,
+                'status' => Session::STATUS_ACTIVE,
+                'was_test' => (bool) $attempt->was_test,
+            ]);
+
+            $attempt->forceFill([
+                'created_user_id' => $user->id,
+                'created_session_id' => $session->id,
+                'status' => SignUpAttempt::STATUS_COMPLETE,
+                'missing_fields' => [],
+                'unverified_fields' => [],
+            ])->save();
+
+            Client::query()
+                ->withoutGlobalScopes()
+                ->where('id', $client->id)
+                ->update(['last_active_session_id' => $session->id, 'last_active_at' => now()]);
+
+            $reloadedClient = Client::query()->withoutGlobalScopes()->where('id', $client->id)->first();
+            if ($reloadedClient !== null) {
+                app(SessionLifecycle::class)
+                    ->enforceMultiSessionPolicy($env, $reloadedClient, $session);
+            }
+            app(SessionLifecycle::class)->notifyCreated($session->fresh() ?? $session);
+
+            app(DomainEnroller::class)->enroll($env, $email->fresh());
+
+            return $this->signUpEnvelope($client, $attempt->fresh(), $challenge, $session);
+        });
+    }
+
+    private function createSessionForSignIn(SignInAttempt $attempt, ?User $user): Session
+    {
+        if ($user === null) {
+            throw new InvalidArgumentException('createSessionForSignIn requires a user.');
+        }
+        $session = Session::create([
+            'environment_id' => $attempt->environment_id,
+            'client_id' => $attempt->client_id,
+            'user_id' => $user->id,
+            'status' => Session::STATUS_ACTIVE,
+            'was_test' => (bool) $attempt->was_test,
+        ]);
+
+        $attempt->forceFill([
+            'created_session_id' => $session->id,
+            'status' => SignInAttempt::STATUS_COMPLETE,
+        ])->save();
+
+        Client::query()
+            ->withoutGlobalScopes()
+            ->where('id', $attempt->client_id)
+            ->update(['last_active_session_id' => $session->id, 'last_active_at' => now()]);
+
+        $user->forceFill(['last_sign_in_at' => now(), 'last_active_at' => now()])->saveQuietly();
+
+        $client = Client::query()->withoutGlobalScopes()->where('id', $attempt->client_id)->first();
+        if ($client !== null) {
+            app(SessionLifecycle::class)
+                ->enforceMultiSessionPolicy(app(Environment::class), $client, $session);
+        }
+
+        app(SessionLifecycle::class)->notifyCreated($session->fresh() ?? $session);
+
+        return $session;
+    }
+
+    /* --------------------------- response envelopes --------------------------- */
+
+    private function signInEnvelope(
+        Client $client,
+        ?SignInAttempt $attempt,
+        ?Challenge $challenge,
+        ?Session $newSession = null,
+    ): JsonResponse {
+        $response = response()->json([
+            'response' => ChallengeResource::from($challenge),
+            'client' => ClientResource::from($client->fresh()),
+        ], 200)->header('Cache-Control', 'no-store');
+
+        if ($newSession !== null) {
+            $response = $response->withCookie($this->buildSessionCookie($newSession));
+        }
+
+        return $response;
+    }
+
+    private function signUpEnvelope(
+        Client $client,
+        ?SignUpAttempt $attempt,
+        ?Challenge $challenge,
+        ?Session $newSession = null,
+    ): JsonResponse {
+        $response = response()->json([
+            'response' => ChallengeResource::from($challenge),
+            'client' => ClientResource::from($client->fresh()),
+        ], 200)->header('Cache-Control', 'no-store');
+
+        if ($newSession !== null) {
+            $response = $response->withCookie($this->buildSessionCookie($newSession));
+        }
+
+        return $response;
+    }
+
+    private function errorWithSignIn(int $status, string $code, string $message, ?Client $client, ?SignInAttempt $attempt = null, ?Challenge $challenge = null): JsonResponse
+    {
+        $body = [
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ];
+        if ($client !== null) {
+            $body['client'] = ClientResource::from($client->fresh());
+        }
+        if ($attempt !== null) {
+            $body['sign_in'] = SignInResource::from($attempt->fresh());
+        }
+        if ($challenge !== null) {
+            $body['response'] = ChallengeResource::from($challenge);
+        }
+
+        return response()->json($body, $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function errorWithSignUp(int $status, string $code, string $message, ?Client $client, ?SignUpAttempt $attempt = null, ?Challenge $challenge = null): JsonResponse
+    {
+        $body = [
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ];
+        if ($client !== null) {
+            $body['client'] = ClientResource::from($client->fresh());
+        }
+        if ($attempt !== null) {
+            $body['sign_up'] = SignUpResource::from($attempt->fresh());
+        }
+        if ($challenge !== null) {
+            $body['response'] = ChallengeResource::from($challenge);
+        }
+
+        return response()->json($body, $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function bareError(int $status, string $code, string $message, ?Client $client): JsonResponse
+    {
+        $body = [
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ];
+        if ($client !== null) {
+            $body['client'] = ClientResource::from($client->fresh());
+        }
+
+        return response()->json($body, $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function buildSessionCookie(Session $newSession): Cookie
+    {
+        $minted = app(SessionTokenIssuer::class)->mint($newSession, lifetimeOverride: self::SESSION_COOKIE_TTL_SECONDS);
+
+        return \Illuminate\Support\Facades\Cookie::make(
+            name: '__session',
+            value: (string) $minted['jwt'],
+            minutes: (int) ceil(self::SESSION_COOKIE_TTL_SECONDS / 60),
+            path: '/',
+            domain: null,
+            secure: request()->secure(),
+            httpOnly: true,
+            raw: false,
+            sameSite: 'lax',
+        );
+    }
+}

--- a/app/Http/Controllers/Fapi/SignInController.php
+++ b/app/Http/Controllers/Fapi/SignInController.php
@@ -11,6 +11,7 @@ use App\Auth\TestMode\Policy as TestModePolicy;
 use App\Http\Resources\ClientResource;
 use App\Http\Resources\SignInResource;
 use App\Jobs\Mail\SendPasswordChangedNotification;
+use App\Models\Challenge;
 use App\Models\Client;
 use App\Models\EmailAddress;
 use App\Models\Environment;
@@ -24,24 +25,22 @@ use App\Services\Sessions\SessionTokenIssuer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Cookie;
 
 /**
- * FAPI sign-in state-machine controller.
+ * FAPI sign-in state-machine controller. The factor verification surface
+ * (formerly prepare-/attempt-first-factor and reset-password) is now
+ * served by ChallengeController under `/sign-ins/{sid}/challenges`.
  *
  * Endpoints:
  *   POST   /v1/client/sign-ins
  *   GET    /v1/client/sign-ins/{id}
- *   POST   /v1/client/sign-ins/{id}/prepare-first-factor
- *   POST   /v1/client/sign-ins/{id}/attempt-first-factor
- *   POST   /v1/client/sign-ins/{id}/prepare-second-factor   (404 in v0.1)
- *   POST   /v1/client/sign-ins/{id}/attempt-second-factor   (404 in v0.1)
- *   POST   /v1/client/sign-ins/{id}/reset-password
+ *   PATCH  /v1/client/sign-ins/{id}              (set new password during reset)
  *
- * v0.1 strategies: password, email_code, reset_password_email_code, ticket.
- * Captcha trio is captured but not enforced (AU-18). MFA, OAuth, SAML,
- * passkey strategies are out of scope for v0.1.
+ * The store path keeps a one-shot inline-strategy shortcut for
+ * `password` and `ticket` so the SDK can complete a sign-in in one
+ * round-trip; under the hood it issues a single Challenge + answer
+ * synchronously and exposes `current_challenge_id` on the SignIn shape.
  */
 final class SignInController
 {
@@ -57,8 +56,6 @@ final class SignInController
             return $this->error(422, ErrorCodes::TRANSFER_NOT_SUPPORTED_IN_V0_1, 'transfer flow lands in a later milestone.', $client);
         }
 
-        // Test-mode gate: in `production` envs (default test_mode=rejected),
-        // a reserved test identifier returns 422 without creating any state.
         $identifier = $request->input('identifier');
         $policy = TestModePolicy::resolve($env, is_string($identifier) ? $identifier : null);
         if ($policy === TestModePolicy::STATUS_REJECTED) {
@@ -82,7 +79,6 @@ final class SignInController
         }
 
         return DB::transaction(function () use ($request, $env, $client, $strategy, $createdClient, $isTestAttempt): JsonResponse {
-            // Idempotency: if the Client already has a non-terminal attempt, return it.
             $existing = $client->current_sign_in_attempt_id !== null
                 ? SignInAttempt::query()->withoutGlobalScopes()->where('id', $client->current_sign_in_attempt_id)->first()
                 : null;
@@ -102,11 +98,8 @@ final class SignInController
 
             $client->forceFill(['current_sign_in_attempt_id' => $attempt->id])->saveQuietly();
 
-            // Inline-strategy short-circuits: when the create call carries a
-            // strategy + the credential, run it immediately so the SDK gets
-            // the terminal status in one round trip.
             if ($strategy === Verification::STRATEGY_TICKET) {
-                return $this->runStrategy($attempt, $strategy, ['ticket' => $request->input('ticket')], $client, terminalAdvance: true, attachClientCookie: $createdClient);
+                return $this->runOneShot($attempt, $strategy, ['ticket' => $request->input('ticket')], $client, $createdClient);
             }
 
             if ($strategy === Verification::STRATEGY_PASSWORD && is_string($request->input('password'))) {
@@ -116,7 +109,7 @@ final class SignInController
                 $attempt->status = SignInAttempt::STATUS_NEEDS_FIRST_FACTOR;
                 $attempt->save();
 
-                return $this->runStrategy($attempt, $strategy, ['password' => $request->input('password')], $client, terminalAdvance: true, attachClientCookie: $createdClient);
+                return $this->runOneShot($attempt, $strategy, ['password' => $request->input('password')], $client, $createdClient);
             }
 
             if (is_string($attempt->identifier)) {
@@ -144,7 +137,13 @@ final class SignInController
         return $this->envelope($client, $attempt);
     }
 
-    public function prepareFirstFactor(Request $request): JsonResponse
+    /**
+     * PATCH /v1/client/sign-ins/{sid}
+     * Currently the only supported field is `password`, used to set the
+     * new password during the reset_password_email_code flow once the
+     * SignIn has reached `needs_new_password`.
+     */
+    public function patch(Request $request): JsonResponse
     {
         $sid = (string) $request->route('sid');
         $client = app(Client::class);
@@ -153,77 +152,8 @@ final class SignInController
             return $attempt;
         }
 
-        $strategyName = (string) $request->input('strategy', '');
-        if ($strategyName === '') {
-            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', $client);
-        }
-
-        try {
-            $strategy = $this->strategies->resolve($strategyName);
-        } catch (InvalidArgumentException) {
-            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategyName} is not enabled in v0.1.", $client);
-        }
-
-        if (! $strategy->requiresPrepare()) {
-            return $this->error(422, ErrorCodes::PREPARE_NOT_REQUIRED, "{$strategyName} does not need a prepare step.", $client);
-        }
-
-        $result = $strategy->prepare($attempt, [
-            'email_address_id' => $request->input('email_address_id'),
-            'redirect_url' => $request->input('redirect_url'),
-        ]);
-
-        if (! $result->success) {
-            return $this->error($result->httpStatus, $result->errorCode ?? ErrorCodes::VERIFICATION_FAILED, $result->errorMessage ?? '', $client, $result->attempt);
-        }
-
-        return $this->envelope($client, $result->attempt->fresh());
-    }
-
-    public function attemptFirstFactor(Request $request): JsonResponse
-    {
-        $sid = (string) $request->route('sid');
-        $client = app(Client::class);
-        $attempt = $this->loadAttempt($sid, $client);
-        if ($attempt instanceof JsonResponse) {
-            return $attempt;
-        }
-
-        $strategyName = (string) $request->input('strategy', '');
-        if ($strategyName === '') {
-            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', $client);
-        }
-
-        try {
-            $strategy = $this->strategies->resolve($strategyName);
-        } catch (InvalidArgumentException) {
-            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategyName} is not enabled in v0.1.", $client);
-        }
-
-        return $this->runStrategy($attempt, $strategyName, [
-            'password' => $request->input('password'),
-            'code' => $request->input('code'),
-            'ticket' => $request->input('ticket'),
-        ], $client, terminalAdvance: true);
-    }
-
-    public function prepareSecondFactor(Request $request): JsonResponse
-    {
-        return $this->error(404, ErrorCodes::MFA_NOT_ENABLED_IN_V0_1, 'Two-step verification lands in v0.3.');
-    }
-
-    public function attemptSecondFactor(Request $request): JsonResponse
-    {
-        return $this->error(404, ErrorCodes::MFA_NOT_ENABLED_IN_V0_1, 'Two-step verification lands in v0.3.');
-    }
-
-    public function resetPassword(Request $request): JsonResponse
-    {
-        $sid = (string) $request->route('sid');
-        $client = app(Client::class);
-        $attempt = $this->loadAttempt($sid, $client);
-        if ($attempt instanceof JsonResponse) {
-            return $attempt;
+        if (! $request->has('password')) {
+            return $this->envelope($client, $attempt);
         }
 
         if ($attempt->status !== SignInAttempt::STATUS_NEEDS_NEW_PASSWORD) {
@@ -238,14 +168,28 @@ final class SignInController
             return $this->error(422, ErrorCodes::FORM_PASSWORD_VALIDATION_FAILED, 'Password must be at least 8 characters.', $client, $attempt);
         }
 
-        $verification = Verification::query()->withoutGlobalScopes()->where('id', (string) $attempt->first_factor_verification_id)->first();
-        $email = $verification ? EmailAddress::query()->withoutGlobalScopes()->where('id', $verification->verifiable_id)->first() : null;
-        $user = $email ? User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first() : null;
+        // Resolve the user via the verified reset-password challenge.
+        $challenge = Challenge::query()
+            ->withoutGlobalScopes()
+            ->where('parent_type', Challenge::PARENT_SIGN_IN)
+            ->where('parent_id', $attempt->id)
+            ->where('strategy', Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE)
+            ->where('status', Challenge::STATUS_VERIFIED)
+            ->latest('id')
+            ->first();
+        $verification = $challenge !== null
+            ? Verification::query()->withoutGlobalScopes()->where('id', $challenge->verification_id)->first()
+            : null;
+        $email = $verification !== null
+            ? EmailAddress::query()->withoutGlobalScopes()->where('id', $verification->verifiable_id)->first()
+            : null;
+        $user = $email !== null
+            ? User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first()
+            : null;
         if ($user === null) {
             return $this->error(422, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'User not found.', $client, $attempt);
         }
 
-        // (HIBP breach check is a stub for v0.1; AU-18 wires the real call.)
         $user->setPassword($password);
         $user->save();
 
@@ -264,44 +208,68 @@ final class SignInController
 
     /* -------------------- helpers -------------------- */
 
-    private function runStrategy(
+    private function runOneShot(
         SignInAttempt $attempt,
         string $strategyName,
         array $params,
         Client $client,
-        bool $terminalAdvance,
-        bool $attachClientCookie = false,
+        bool $attachClientCookie,
     ): JsonResponse {
         $strategy = $this->strategies->resolve($strategyName);
+
+        // Issue a Verification stub so the Challenge has a wrapped row even
+        // for one-shot strategies (password / ticket).
+        $verification = Verification::query()->withoutGlobalScopes()->create([
+            'environment_id' => $attempt->environment_id,
+            'verifiable_type' => $attempt->getMorphClass(),
+            'verifiable_id' => $attempt->id,
+            'strategy' => $strategyName,
+            'status' => Verification::STATUS_UNVERIFIED,
+            'attempts' => 0,
+            'expire_at' => now()->addMinutes(10),
+        ]);
+
+        $challenge = Challenge::query()->withoutGlobalScopes()->create([
+            'environment_id' => $attempt->environment_id,
+            'parent_type' => Challenge::PARENT_SIGN_IN,
+            'parent_id' => $attempt->id,
+            'step' => Challenge::STEP_FIRST,
+            'strategy' => $strategyName,
+            'status' => Challenge::STATUS_PENDING,
+            'verification_id' => $verification->id,
+            'attempts' => 0,
+            'expire_at' => $verification->expire_at,
+        ]);
+        $attempt->forceFill(['current_challenge_id' => $challenge->id])->save();
+
+        $params['verification'] = $verification;
         $result = $strategy->attempt($attempt, $params);
 
         if (! $result->success) {
+            $challenge->forceFill([
+                'status' => Challenge::STATUS_FAILED,
+                'error_code' => $result->errorCode,
+                'error_message' => $result->errorMessage,
+            ])->save();
+
             return $this->error($result->httpStatus, $result->errorCode ?? ErrorCodes::VERIFICATION_FAILED, $result->errorMessage ?? '', $client, $result->attempt);
         }
 
-        $attempt = $result->attempt;
-        $user = $result->user;
+        $challenge->forceFill([
+            'status' => Challenge::STATUS_VERIFIED,
+            'attempts' => (int) ($result->verification?->attempts ?? 0),
+        ])->save();
 
-        if (! $terminalAdvance) {
-            return $this->envelope($client, $attempt->fresh(), 200, null, $attachClientCookie);
-        }
+        $session = $this->createSession($result->attempt, $result->user);
 
-        // Reset-password strategy: hand-off to the new-password endpoint.
-        if ($strategyName === Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE) {
-            $attempt->status = SignInAttempt::STATUS_NEEDS_NEW_PASSWORD;
-            $attempt->save();
-
-            return $this->envelope($client, $attempt->fresh(), 200, null, $attachClientCookie);
-        }
-
-        // Otherwise create a Session and complete.
-        $session = $this->createSession($attempt, $user);
-
-        return $this->envelope($client, $attempt->fresh(), 200, $session, $attachClientCookie);
+        return $this->envelope($client, $result->attempt->fresh(), 200, $session, $attachClientCookie);
     }
 
-    private function createSession(SignInAttempt $attempt, User $user): Session
+    private function createSession(SignInAttempt $attempt, ?User $user): Session
     {
+        if ($user === null) {
+            throw new \InvalidArgumentException('createSession requires a user.');
+        }
         $session = Session::create([
             'environment_id' => $attempt->environment_id,
             'client_id' => $attempt->client_id,
@@ -315,18 +283,13 @@ final class SignInController
             'status' => SignInAttempt::STATUS_COMPLETE,
         ])->save();
 
-        // Bump the Client's last_active_session_id.
         Client::query()
             ->withoutGlobalScopes()
             ->where('id', $attempt->client_id)
             ->update(['last_active_session_id' => $session->id, 'last_active_at' => now()]);
 
-        // Stamp the user as recently signed in.
         $user->forceFill(['last_sign_in_at' => now(), 'last_active_at' => now()])->saveQuietly();
 
-        // Apply the env's multi-session policy: in single-session mode, evict
-        // every other live session on this client; in multi-session mode,
-        // enforce the per-client cap by evicting LRU sessions.
         $client = Client::query()->withoutGlobalScopes()->where('id', $attempt->client_id)->first();
         if ($client !== null) {
             app(SessionLifecycle::class)
@@ -405,12 +368,6 @@ final class SignInController
      * operator's session without the SDK having to inject Authorization
      * headers. Tenants doing pure cross-origin Bearer-only auth can safely
      * ignore the cookie — they read the JWT from the response body.
-     *
-     * The cookie JWT outlives the in-memory access token (default 60s)
-     * because the browser only re-attaches it on top-level navigations,
-     * not on every API call where the SDK can refresh from /tokens. A
-     * 24h ceiling is short enough that a stolen cookie expires within a
-     * day and long enough that operators don't get bounced mid-shift.
      */
     private const SESSION_COOKIE_TTL_SECONDS = 86400;
 

--- a/app/Http/Controllers/Fapi/SignUpController.php
+++ b/app/Http/Controllers/Fapi/SignUpController.php
@@ -13,24 +13,19 @@ use App\Auth\SignUp\TicketRedeemer;
 use App\Auth\TestMode\Policy as TestModePolicy;
 use App\Http\Resources\ClientResource;
 use App\Http\Resources\SignUpResource;
-use App\Jobs\Mail\SendMagicLinkEmail;
-use App\Jobs\Mail\SendVerificationEmail;
+use App\Models\Challenge;
 use App\Models\Client;
 use App\Models\EmailAddress;
-use App\Models\EmailTemplate;
 use App\Models\Environment;
 use App\Models\Invitation;
 use App\Models\Session;
 use App\Models\SignUpAttempt;
 use App\Models\User;
 use App\Models\Verification;
-use App\Models\VerificationCode;
 use App\Services\Client\ClientResolver;
 use App\Services\Domains\DomainEnroller;
-use App\Services\MagicLink\MagicLinkIssuer;
 use App\Services\Sessions\SessionLifecycle;
 use App\Services\Sessions\SessionTokenIssuer;
-use App\Services\Verification\VerificationManager;
 use App\Webhooks\Emitter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -39,28 +34,26 @@ use Illuminate\Support\Facades\Hash;
 use Symfony\Component\HttpFoundation\Cookie;
 
 /**
- * FAPI sign-up state-machine controller.
+ * FAPI sign-up state-machine controller. The factor verification surface
+ * (formerly prepare-/attempt-verification) is now served by
+ * ChallengeController under `/sign-ups/{sid}/challenges`.
  *
  * Endpoints (PLAN §3.3 / §9.4):
  *   POST   /v1/client/sign-ups
  *   GET    /v1/client/sign-ups/{id}
  *   PATCH  /v1/client/sign-ups/{id}
- *   POST   /v1/client/sign-ups/{id}/prepare-verification
- *   POST   /v1/client/sign-ups/{id}/attempt-verification
  *
- * v0.1 strategies for verification: email_code (and ticket at create-time).
- * email_link, OAuth transfer, organization-creation, phone are all v0.2+.
+ * v0.2 verification strategies: email_code, email_link (challenge resource).
+ * Ticket flows still ride POST /sign-ups at create time. OAuth transfer,
+ * phone, and organization-creation strategies land in later milestones.
  */
 final class SignUpController
 {
-    private const EMAIL_VERIFICATION_TTL = 600;
-
     public function __construct(
         private readonly StageRequirements $stage,
         private readonly IdentifierRestrictions $restrictions,
         private readonly IdentifierNormalizer $normalizer,
         private readonly TicketRedeemer $ticketRedeemer,
-        private readonly VerificationManager $verifications,
     ) {}
 
     public function store(Request $request): JsonResponse
@@ -141,145 +134,6 @@ final class SignUpController
         return $this->envelope($client, $attempt->fresh());
     }
 
-    public function prepareVerification(Request $request): JsonResponse
-    {
-        $sid = (string) $request->route('sid');
-        $client = app(Client::class);
-        $attempt = $this->loadAttempt($sid, $client);
-        if ($attempt instanceof JsonResponse) {
-            return $attempt;
-        }
-
-        $strategy = (string) $request->input('strategy', '');
-        if ($strategy === '') {
-            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', $client, $attempt);
-        }
-        if (! in_array($strategy, [Verification::STRATEGY_EMAIL_CODE, Verification::STRATEGY_EMAIL_LINK], true)) {
-            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategy} is not enabled in v0.1.", $client, $attempt);
-        }
-
-        if (! is_string($attempt->email_address) || $attempt->email_address === '') {
-            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'email_address is required before preparing email verification.', $client, $attempt);
-        }
-
-        if ($strategy === Verification::STRATEGY_EMAIL_LINK) {
-            return $this->prepareEmailLink($client, $attempt, $request);
-        }
-
-        // For sign-up the email isn't yet on an EmailAddress row — start the
-        // Verification on the SignUpAttempt itself so the morph is consistent
-        // (the staged email lives on the attempt).
-        $verification = $this->verifications->start($attempt, Verification::STRATEGY_EMAIL_CODE, self::EMAIL_VERIFICATION_TTL);
-        $code = $this->verifications->mintNumericCode($verification, VerificationCode::PURPOSE_EMAIL_CODE, self::EMAIL_VERIFICATION_TTL);
-
-        SendVerificationEmail::dispatch(
-            $attempt->environment_id,
-            $attempt->email_address,
-            $code,
-            VerificationCode::PURPOSE_EMAIL_CODE,
-            $verification->id,
-        );
-
-        $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
-        $verifications['email_address'] = $verification->id;
-        $attempt->verifications = $verifications;
-        $attempt->save();
-
-        return $this->envelope($client, $attempt->fresh());
-    }
-
-    private function prepareEmailLink(Client $client, SignUpAttempt $attempt, Request $request): JsonResponse
-    {
-        $verification = $this->verifications->start(
-            $attempt,
-            Verification::STRATEGY_EMAIL_LINK,
-            MagicLinkIssuer::TTL_SECONDS,
-        );
-        $redirectUrl = $request->input('redirect_url');
-        $minted = app(MagicLinkIssuer::class)->issue(
-            $verification,
-            is_string($redirectUrl) && $redirectUrl !== '' ? $redirectUrl : null,
-        );
-
-        SendMagicLinkEmail::dispatch(
-            $attempt->environment_id,
-            (string) $attempt->email_address,
-            $minted['url'],
-            EmailTemplate::SLUG_MAGIC_LINK_SIGN_UP,
-            $verification->id,
-        );
-
-        $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
-        $verifications['email_address'] = $verification->id;
-        $attempt->verifications = $verifications;
-        $attempt->save();
-
-        return $this->envelope($client, $attempt->fresh());
-    }
-
-    public function attemptVerification(Request $request): JsonResponse
-    {
-        $sid = (string) $request->route('sid');
-        $client = app(Client::class);
-        $attempt = $this->loadAttempt($sid, $client);
-        if ($attempt instanceof JsonResponse) {
-            return $attempt;
-        }
-
-        $strategy = (string) $request->input('strategy', '');
-        if (! in_array($strategy, [Verification::STRATEGY_EMAIL_CODE, Verification::STRATEGY_EMAIL_LINK], true)) {
-            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategy} is not enabled in v0.1.", $client, $attempt);
-        }
-
-        $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
-        $vid = $verifications['email_address'] ?? null;
-        if (! is_string($vid)) {
-            return $this->error(422, ErrorCodes::NO_VERIFICATION_IN_PROGRESS, 'No email verification has been prepared.', $client, $attempt);
-        }
-        $verification = Verification::query()->withoutGlobalScopes()->where('id', $vid)->first();
-        if ($verification === null) {
-            return $this->error(422, ErrorCodes::NO_VERIFICATION_IN_PROGRESS, 'No email verification has been prepared.', $client, $attempt);
-        }
-
-        if ($strategy === Verification::STRATEGY_EMAIL_LINK) {
-            // Polling shape: the click flips Verification.status out-of-band.
-            if ($verification->status === Verification::STATUS_UNVERIFIED) {
-                return $this->error(422, ErrorCodes::VERIFICATION_FAILED, 'Magic link not yet redeemed.', $client, $attempt);
-            }
-            if ($verification->status === Verification::STATUS_EXPIRED) {
-                return $this->error(422, ErrorCodes::VERIFICATION_EXPIRED, 'Magic link expired.', $client, $attempt);
-            }
-            if ($verification->status !== Verification::STATUS_VERIFIED) {
-                return $this->error(422, ErrorCodes::VERIFICATION_FAILED, "Magic link verification is in status {$verification->status}.", $client, $attempt);
-            }
-
-            $env = app(Environment::class);
-
-            return $this->finalizeIfReady($env, $client, $attempt, ['email_address' => true]);
-        }
-
-        $code = $request->input('code');
-        if (! is_string($code) || $code === '') {
-            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'code is required.', $client, $attempt);
-        }
-
-        $ok = $this->verifications->attempt($verification, $code);
-        if (! $ok) {
-            $fresh = $verification->fresh();
-            $errCode = $fresh->status === Verification::STATUS_FAILED
-                ? ErrorCodes::VERIFICATION_FAILED
-                : ($fresh->status === Verification::STATUS_EXPIRED
-                    ? ErrorCodes::VERIFICATION_EXPIRED
-                    : ErrorCodes::FORM_CODE_INCORRECT);
-
-            return $this->error(422, $errCode, 'Incorrect code.', $client, $attempt);
-        }
-
-        $env = app(Environment::class);
-
-        return $this->finalizeIfReady($env, $client, $attempt, ['email_address' => true]);
-    }
-
     /* -------------------- create branches -------------------- */
 
     private function createInteractive(Request $request, Environment $env, Client $client, bool $createdClient): JsonResponse
@@ -352,9 +206,6 @@ final class SignUpController
 
         $attempt = SignUpAttempt::create(['environment_id' => $env->id, 'client_id' => $client->id]);
         $this->stageOnto($attempt, $supplied, $eval);
-        $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
-        $verifications['email_address'] = '__ticket__';
-        $attempt->verifications = $verifications;
         if (! empty($result['metadata'])) {
             $attempt->public_metadata = array_merge(is_array($attempt->public_metadata) ? $attempt->public_metadata : [], $result['metadata']);
         }
@@ -505,18 +356,13 @@ final class SignUpController
 
     private function verifiedFlags(SignUpAttempt $attempt): array
     {
-        $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
         $flags = [];
-        if (isset($verifications['email_address'])) {
-            $vid = $verifications['email_address'];
-            if ($vid === '__ticket__') {
-                $flags['email_address'] = true;
-            } elseif (is_string($vid)) {
-                $verification = Verification::query()->withoutGlobalScopes()->where('id', $vid)->first();
-                if ($verification !== null && $verification->status === Verification::STATUS_VERIFIED) {
-                    $flags['email_address'] = true;
-                }
-            }
+        $emailVerified = $attempt->challenges()
+            ->where('status', Challenge::STATUS_VERIFIED)
+            ->whereIn('strategy', [Verification::STRATEGY_EMAIL_CODE, Verification::STRATEGY_EMAIL_LINK])
+            ->exists();
+        if ($emailVerified) {
+            $flags['email_address'] = true;
         }
 
         return $flags;

--- a/app/Http/Controllers/Fapi/SignUpController.php
+++ b/app/Http/Controllers/Fapi/SignUpController.php
@@ -98,9 +98,13 @@ final class SignUpController
     {
         $sid = (string) $request->route('sid');
         $client = app(Client::class);
-        $attempt = $this->loadAttempt($sid, $client);
-        if ($attempt instanceof JsonResponse) {
-            return $attempt;
+        $attempt = SignUpAttempt::query()
+            ->withoutGlobalScopes()
+            ->where('id', $sid)
+            ->where('client_id', $client->id)
+            ->first();
+        if ($attempt === null) {
+            return $this->error(404, ErrorCodes::SIGN_UP_NOT_FOUND, 'Sign-up attempt not found on this device.', $client);
         }
 
         return $this->envelope($client, $attempt);

--- a/app/Http/Resources/ChallengeResource.php
+++ b/app/Http/Resources/ChallengeResource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Challenge;
+
+/**
+ * Mirrors openapi `Challenge.yaml`. The shape is uniform across sign-in
+ * and sign-up parents — `sign_in_id` / `sign_up_id` are mutually exclusive
+ * and exactly one is non-null.
+ */
+final class ChallengeResource
+{
+    public static function from(?Challenge $challenge): ?array
+    {
+        if ($challenge === null) {
+            return null;
+        }
+
+        return [
+            'object' => 'challenge',
+            'id' => $challenge->id,
+            'sign_in_id' => $challenge->parent_type === Challenge::PARENT_SIGN_IN ? $challenge->parent_id : null,
+            'sign_up_id' => $challenge->parent_type === Challenge::PARENT_SIGN_UP ? $challenge->parent_id : null,
+            'step' => $challenge->step,
+            'strategy' => $challenge->strategy,
+            'status' => $challenge->status,
+            'attempts' => (int) $challenge->attempts,
+            'expire_at' => $challenge->expire_at->getTimestampMs(),
+            'nonce' => $challenge->nonce,
+            'external_verification_redirect_url' => $challenge->external_verification_redirect_url,
+            'error' => $challenge->error_code !== null ? [
+                'code' => $challenge->error_code,
+                'message' => (string) $challenge->error_message,
+            ] : null,
+            'created_at' => $challenge->created_at?->getTimestampMs(),
+            'updated_at' => $challenge->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/app/Http/Resources/SignInResource.php
+++ b/app/Http/Resources/SignInResource.php
@@ -10,10 +10,10 @@ use App\Models\User;
 use App\Models\Verification;
 
 /**
- * Mirrors PLAN §3.2's SignIn shape — what FAPI returns for any
- * sign-in state-machine endpoint. Surfaces just enough of the user
- * to render an avatar / name preview without revealing private data
- * before authentication completes.
+ * Mirrors openapi `SignIn`. Factor verification state is no longer
+ * inlined — it lives on the Challenge sub-resource. The SignIn exposes
+ * the live Challenge id (`current_challenge_id`) plus the strategies the
+ * client may issue next, narrowed to its current state.
  */
 final class SignInResource
 {
@@ -29,14 +29,8 @@ final class SignInResource
             'status' => $attempt->status,
             'identifier' => $attempt->identifier,
             'supported_identifiers' => ['email_address'],
-            'supported_first_factors' => self::supportedFirstFactors($attempt),
-            'supported_second_factors' => [],
-            'first_factor_verification' => self::verificationShape(
-                $attempt->first_factor_verification_id !== null
-                    ? Verification::query()->withoutGlobalScopes()->where('id', $attempt->first_factor_verification_id)->first()
-                    : null
-            ),
-            'second_factor_verification' => null,
+            'supported_strategies' => self::supportedStrategies($attempt),
+            'current_challenge_id' => $attempt->current_challenge_id,
             'user_data' => self::userDataPreview($attempt),
             'created_session_id' => $attempt->created_session_id,
             'abandon_at' => $attempt->abandon_at->getTimestampMs(),
@@ -44,10 +38,17 @@ final class SignInResource
     }
 
     /**
-     * @return list<array<string, mixed>>
+     * Strategies the client may issue next via `POST /sign-ins/{sid}/challenges`.
+     * Narrowed by the SignIn's current status — terminal states return [].
+     *
+     * @return list<string>
      */
-    private static function supportedFirstFactors(SignInAttempt $attempt): array
+    private static function supportedStrategies(SignInAttempt $attempt): array
     {
+        if ($attempt->status !== SignInAttempt::STATUS_NEEDS_FIRST_FACTOR) {
+            return [];
+        }
+
         if ($attempt->identifier === null) {
             return [];
         }
@@ -60,48 +61,20 @@ final class SignInResource
         if ($email === null) {
             return [];
         }
-
         $user = User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first();
         if ($user === null) {
             return [];
         }
 
-        $factors = [];
+        $strategies = [];
         if ($user->password_hash !== null) {
-            $factors[] = ['strategy' => Verification::STRATEGY_PASSWORD];
+            $strategies[] = Verification::STRATEGY_PASSWORD;
         }
-        $factors[] = [
-            'strategy' => Verification::STRATEGY_EMAIL_CODE,
-            'email_address_id' => $email->id,
-            'safe_identifier' => self::redactEmail($email->email_address),
-        ];
-        $factors[] = [
-            'strategy' => Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE,
-            'email_address_id' => $email->id,
-            'safe_identifier' => self::redactEmail($email->email_address),
-        ];
+        $strategies[] = Verification::STRATEGY_EMAIL_CODE;
+        $strategies[] = Verification::STRATEGY_EMAIL_LINK;
+        $strategies[] = Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE;
 
-        return $factors;
-    }
-
-    private static function verificationShape(?Verification $verification): ?array
-    {
-        if ($verification === null) {
-            return null;
-        }
-
-        return [
-            'status' => $verification->status,
-            'strategy' => $verification->strategy,
-            'attempts' => $verification->attempts,
-            'expire_at' => $verification->expire_at->getTimestampMs(),
-            'external_verification_redirect_url' => $verification->external_verification_redirect_url,
-            'nonce' => $verification->nonce,
-            'error' => $verification->error_code !== null ? [
-                'code' => $verification->error_code,
-                'message' => $verification->error_message,
-            ] : null,
-        ];
+        return $strategies;
     }
 
     private static function userDataPreview(SignInAttempt $attempt): ?array
@@ -129,16 +102,5 @@ final class SignInResource
             'image_url' => $user->image_url,
             'has_image' => (bool) $user->has_image,
         ];
-    }
-
-    private static function redactEmail(string $email): string
-    {
-        if (! str_contains($email, '@')) {
-            return $email;
-        }
-        [$local, $domain] = explode('@', $email, 2);
-        $first = $local !== '' ? $local[0] : '';
-
-        return $first.str_repeat('*', max(1, strlen($local) - 1)).'@'.$domain;
     }
 }

--- a/app/Http/Resources/SignUpResource.php
+++ b/app/Http/Resources/SignUpResource.php
@@ -8,8 +8,10 @@ use App\Models\SignUpAttempt;
 use App\Models\Verification;
 
 /**
- * Mirrors PLAN §3.3's SignUp shape — what FAPI returns for any sign-up
- * state-machine endpoint. Excludes secrets (password_hash, transfer_token).
+ * Mirrors openapi `SignUp`. Verification state is no longer inlined as
+ * a per-identifier map — it lives on the Challenge sub-resource. The
+ * SignUp exposes the live Challenge id (`current_challenge_id`) plus
+ * the strategies the client may issue next.
  */
 final class SignUpResource
 {
@@ -19,12 +21,6 @@ final class SignUpResource
             return null;
         }
 
-        $verifications = is_array($attempt->verifications) ? $attempt->verifications : [];
-        $emailVerificationId = $verifications['email_address'] ?? null;
-        $emailVerification = is_string($emailVerificationId)
-            ? Verification::query()->withoutGlobalScopes()->where('id', $emailVerificationId)->first()
-            : null;
-
         return [
             'object' => 'sign_up_attempt',
             'id' => $attempt->id,
@@ -33,12 +29,8 @@ final class SignUpResource
             'optional_fields' => [],
             'missing_fields' => self::expandFields($attempt->missing_fields),
             'unverified_fields' => self::expandFields($attempt->unverified_fields),
-            'verifications' => [
-                'email_address' => self::verificationShape($emailVerification),
-                'phone_number' => null,
-                'web3_wallet' => null,
-                'external_account' => null,
-            ],
+            'supported_strategies' => self::supportedStrategies($attempt),
+            'current_challenge_id' => $attempt->current_challenge_id,
             'email_address' => $attempt->email_address,
             'username' => $attempt->username,
             'phone_number' => $attempt->phone_number,
@@ -66,23 +58,22 @@ final class SignUpResource
         return array_values(array_map('strval', $fields));
     }
 
-    private static function verificationShape(?Verification $verification): ?array
+    /**
+     * @return list<string>
+     */
+    private static function supportedStrategies(SignUpAttempt $attempt): array
     {
-        if ($verification === null) {
-            return null;
+        if ($attempt->status !== SignUpAttempt::STATUS_MISSING_REQUIREMENTS) {
+            return [];
+        }
+        $unverified = is_array($attempt->unverified_fields) ? $attempt->unverified_fields : [];
+        if (! in_array('email_address', $unverified, true)) {
+            return [];
         }
 
         return [
-            'status' => $verification->status,
-            'strategy' => $verification->strategy,
-            'attempts' => $verification->attempts,
-            'expire_at' => $verification->expire_at->getTimestampMs(),
-            'external_verification_redirect_url' => $verification->external_verification_redirect_url,
-            'nonce' => $verification->nonce,
-            'error' => $verification->error_code !== null ? [
-                'code' => $verification->error_code,
-                'message' => $verification->error_message,
-            ] : null,
+            Verification::STRATEGY_EMAIL_CODE,
+            Verification::STRATEGY_EMAIL_LINK,
         ];
     }
 }

--- a/app/Models/Challenge.php
+++ b/app/Models/Challenge.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Verification challenge attached to a SignInAttempt or SignUpAttempt. The
+ * uniform sub-resource that replaces the per-factor `prepare-*` /
+ * `attempt-*` endpoint pairs: the SDK creates a Challenge by picking a
+ * strategy, then submits the user's response via `answer`. The Challenge
+ * wraps an underlying Verification 1:1 — the Verification still does the
+ * cryptographic work; the Challenge is the API-facing veneer.
+ *
+ * Lifecycle (mirror of openapi `Challenge.status`):
+ *   created → pending
+ *   on success → verified (parent state machine advances)
+ *              → transferable (cross-flow handoff)
+ *   on max_attempts → failed
+ *   on TTL elapse  → expired
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $parent_type      'sign_in' | 'sign_up'
+ * @property string $parent_id
+ * @property string $step             'first' | 'second' | 'single'
+ * @property string $strategy
+ * @property string $status
+ * @property string $verification_id
+ * @property int $attempts
+ * @property ?string $nonce
+ * @property ?string $external_verification_redirect_url
+ * @property ?string $error_code
+ * @property ?string $error_message
+ * @property \DateTimeInterface $expire_at
+ */
+class Challenge extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_VERIFIED = 'verified';
+
+    public const STATUS_TRANSFERABLE = 'transferable';
+
+    public const STATUS_FAILED = 'failed';
+
+    public const STATUS_EXPIRED = 'expired';
+
+    public const STATUSES = [
+        self::STATUS_PENDING,
+        self::STATUS_VERIFIED,
+        self::STATUS_TRANSFERABLE,
+        self::STATUS_FAILED,
+        self::STATUS_EXPIRED,
+    ];
+
+    public const STEP_FIRST = 'first';
+
+    public const STEP_SECOND = 'second';
+
+    public const STEP_SINGLE = 'single';
+
+    public const STEPS = [
+        self::STEP_FIRST,
+        self::STEP_SECOND,
+        self::STEP_SINGLE,
+    ];
+
+    public const PARENT_SIGN_IN = 'sign_in';
+
+    public const PARENT_SIGN_UP = 'sign_up';
+
+    public const PARENT_TYPES = [
+        self::PARENT_SIGN_IN,
+        self::PARENT_SIGN_UP,
+    ];
+
+    public const MORPH_MAP = [
+        self::PARENT_SIGN_IN => SignInAttempt::class,
+        self::PARENT_SIGN_UP => SignUpAttempt::class,
+    ];
+
+    protected string $idPrefix = 'chal_';
+
+    protected $fillable = [
+        'environment_id',
+        'parent_type',
+        'parent_id',
+        'step',
+        'strategy',
+        'status',
+        'verification_id',
+        'attempts',
+        'nonce',
+        'external_verification_redirect_url',
+        'error_code',
+        'error_message',
+        'expire_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'attempts' => 'int',
+            'expire_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function verification(): BelongsTo
+    {
+        return $this->belongsTo(Verification::class);
+    }
+
+    /**
+     * Resolves the parent attempt. `parent_type` is the short discriminator
+     * ('sign_in' | 'sign_up'); MORPH_MAP translates it to the concrete model
+     * class without registering a global Laravel morph map.
+     */
+    public function parent(): ?Model
+    {
+        $class = self::MORPH_MAP[$this->parent_type] ?? null;
+        if ($class === null) {
+            return null;
+        }
+
+        /** @var Model $class */
+        return $class::query()->withoutGlobalScopes()->where('id', $this->parent_id)->first();
+    }
+
+    public function isLive(): bool
+    {
+        return $this->status === self::STATUS_PENDING && ! $this->isExpired();
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expire_at->isPast();
+    }
+}

--- a/app/Models/Challenge.php
+++ b/app/Models/Challenge.php
@@ -27,9 +27,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property string $id
  * @property string $environment_id
- * @property string $parent_type      'sign_in' | 'sign_up'
+ * @property string $parent_type 'sign_in' | 'sign_up'
  * @property string $parent_id
- * @property string $step             'first' | 'second' | 'single'
+ * @property string $step 'first' | 'second' | 'single'
  * @property string $strategy
  * @property string $status
  * @property string $verification_id

--- a/app/Models/SignInAttempt.php
+++ b/app/Models/SignInAttempt.php
@@ -9,6 +9,7 @@ use App\Database\Scopes\EnvironmentScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use InvalidArgumentException;
 
@@ -32,8 +33,7 @@ use InvalidArgumentException;
  * @property string $client_id
  * @property string $status
  * @property ?string $identifier
- * @property ?string $first_factor_verification_id
- * @property ?string $second_factor_verification_id
+ * @property ?string $current_challenge_id
  * @property ?string $created_session_id
  * @property \DateTimeInterface $abandon_at
  * @property ?string $transfer_token
@@ -114,8 +114,7 @@ class SignInAttempt extends Model
         'client_id',
         'status',
         'identifier',
-        'first_factor_verification_id',
-        'second_factor_verification_id',
+        'current_challenge_id',
         'created_session_id',
         'abandon_at',
         'transfer_token',
@@ -177,14 +176,15 @@ class SignInAttempt extends Model
         return $this->belongsTo(Client::class);
     }
 
-    public function firstFactorVerification(): BelongsTo
+    public function currentChallenge(): BelongsTo
     {
-        return $this->belongsTo(Verification::class, 'first_factor_verification_id');
+        return $this->belongsTo(Challenge::class, 'current_challenge_id');
     }
 
-    public function secondFactorVerification(): BelongsTo
+    public function challenges(): HasMany
     {
-        return $this->belongsTo(Verification::class, 'second_factor_verification_id');
+        return $this->hasMany(Challenge::class, 'parent_id')
+            ->where('parent_type', Challenge::PARENT_SIGN_IN);
     }
 
     public function createdSession(): BelongsTo

--- a/app/Models/SignUpAttempt.php
+++ b/app/Models/SignUpAttempt.php
@@ -9,6 +9,7 @@ use App\Database\Scopes\EnvironmentScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use InvalidArgumentException;
 
@@ -34,9 +35,9 @@ use InvalidArgumentException;
  * @property ?string $password_hash
  * @property array $unsafe_metadata
  * @property array $public_metadata
- * @property array $verifications
  * @property array $missing_fields
  * @property array $unverified_fields
+ * @property ?string $current_challenge_id
  * @property ?string $created_session_id
  * @property ?string $created_user_id
  * @property \DateTimeInterface $abandon_at
@@ -96,9 +97,9 @@ class SignUpAttempt extends Model
         'password_hash',
         'unsafe_metadata',
         'public_metadata',
-        'verifications',
         'missing_fields',
         'unverified_fields',
+        'current_challenge_id',
         'created_session_id',
         'created_user_id',
         'abandon_at',
@@ -121,7 +122,6 @@ class SignUpAttempt extends Model
             'was_test' => 'boolean',
             'unsafe_metadata' => 'array',
             'public_metadata' => 'array',
-            'verifications' => 'array',
             'missing_fields' => 'array',
             'unverified_fields' => 'array',
         ];
@@ -140,7 +140,7 @@ class SignUpAttempt extends Model
             }
             // SQLite (test) and Postgres differ in how they surface jsonb
             // defaults — pin the model layer so consumers always see arrays.
-            foreach (['unsafe_metadata', 'public_metadata', 'verifications', 'missing_fields', 'unverified_fields'] as $col) {
+            foreach (['unsafe_metadata', 'public_metadata', 'missing_fields', 'unverified_fields'] as $col) {
                 if ($attempt->getAttribute($col) === null) {
                     $attempt->setAttribute($col, []);
                 }
@@ -187,6 +187,17 @@ class SignUpAttempt extends Model
     public function verifications(): MorphMany
     {
         return $this->morphMany(Verification::class, 'verifiable');
+    }
+
+    public function currentChallenge(): BelongsTo
+    {
+        return $this->belongsTo(Challenge::class, 'current_challenge_id');
+    }
+
+    public function challenges(): HasMany
+    {
+        return $this->hasMany(Challenge::class, 'parent_id')
+            ->where('parent_type', Challenge::PARENT_SIGN_UP);
     }
 
     public function isComplete(): bool

--- a/app/Support/IdPrefix.php
+++ b/app/Support/IdPrefix.php
@@ -25,7 +25,7 @@ final class IdPrefix
         'user_', 'idn_', 'eml_', 'phn_', 'ext_', 'entacc_', 'pkey_', 'totp_', 'bcc_',
 
         // Verification + flow state
-        'ver_', 'client_', 'sess_', 'sact_', 'sia_', 'sui_', 'sit_', 'act_',
+        'ver_', 'client_', 'sess_', 'sact_', 'sia_', 'sui_', 'sit_', 'act_', 'chal_',
 
         // Organizations
         'org_', 'orgmem_', 'orginv_', 'orgdom_', 'orgreq_', 'role_', 'perm_',

--- a/database/migrations/0005_01_01_000000_create_flow_state_models.php
+++ b/database/migrations/0005_01_01_000000_create_flow_state_models.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Facades\Schema;
  *                            install; identified by the `__client` cookie)
  *   - sign_in_attempts     — in-progress sign-in state machines
  *   - sign_up_attempts     — in-progress sign-up state machines
+ *   - challenges           — uniform verification sub-resource attached to
+ *                            sign_in_attempts / sign_up_attempts
  *   - sessions             — live authenticated sessions
  *   - session_activities   — append-only touch log per session
  *
@@ -55,8 +57,7 @@ return new class extends Migration
             $table->string('status', 32);
             $table->string('identifier')->nullable();
 
-            $table->string('first_factor_verification_id', 64)->nullable();
-            $table->string('second_factor_verification_id', 64)->nullable();
+            $table->string('current_challenge_id', 64)->nullable();
 
             $table->string('created_session_id', 64)->nullable();
 
@@ -73,8 +74,6 @@ return new class extends Migration
 
             $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
             $table->foreign('client_id')->references('id')->on('clients')->cascadeOnDelete();
-            $table->foreign('first_factor_verification_id')->references('id')->on('verifications')->nullOnDelete();
-            $table->foreign('second_factor_verification_id')->references('id')->on('verifications')->nullOnDelete();
             $table->index(['status', 'abandon_at']);
         });
 
@@ -98,9 +97,10 @@ return new class extends Migration
 
             $table->jsonb('unsafe_metadata')->default(json_encode((object) []));
             $table->jsonb('public_metadata')->default(json_encode((object) []));
-            $table->jsonb('verifications')->default(json_encode((object) []));
             $table->jsonb('missing_fields')->default(json_encode([]));
             $table->jsonb('unverified_fields')->default(json_encode([]));
+
+            $table->string('current_challenge_id', 64)->nullable();
 
             $table->string('created_session_id', 64)->nullable();
             $table->string('created_user_id', 64)->nullable();
@@ -120,6 +120,46 @@ return new class extends Migration
             $table->foreign('client_id')->references('id')->on('clients')->cascadeOnDelete();
             $table->foreign('created_user_id')->references('id')->on('users')->nullOnDelete();
             $table->index(['status', 'abandon_at']);
+        });
+
+        // ----------------------------------------------------- challenges
+
+        Schema::create('challenges', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+
+            // Polymorphic parent: 'sign_in' | 'sign_up'. The parent_id points
+            // at sign_in_attempts.id or sign_up_attempts.id; no DB-level FK
+            // because the type column disambiguates the target table.
+            $table->string('parent_type', 16);
+            $table->string('parent_id', 64);
+
+            $table->string('step', 16);
+            $table->string('strategy', 64);
+            $table->string('status', 32);
+
+            $table->string('verification_id', 64);
+            $table->unsignedInteger('attempts')->default(0);
+
+            $table->string('nonce')->nullable();
+            $table->string('external_verification_redirect_url', 2048)->nullable();
+            $table->string('error_code', 64)->nullable();
+            $table->string('error_message')->nullable();
+
+            $table->timestamp('expire_at');
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('verification_id')->references('id')->on('verifications')->cascadeOnDelete();
+            $table->index(['parent_type', 'parent_id', 'status']);
+        });
+
+        Schema::table('sign_in_attempts', function (Blueprint $table): void {
+            $table->foreign('current_challenge_id')->references('id')->on('challenges')->nullOnDelete();
+        });
+
+        Schema::table('sign_up_attempts', function (Blueprint $table): void {
+            $table->foreign('current_challenge_id')->references('id')->on('challenges')->nullOnDelete();
         });
 
         // ----------------------------------------------------- sessions
@@ -195,9 +235,11 @@ return new class extends Migration
     {
         Schema::table('sign_up_attempts', function (Blueprint $table): void {
             $table->dropForeign(['created_session_id']);
+            $table->dropForeign(['current_challenge_id']);
         });
         Schema::table('sign_in_attempts', function (Blueprint $table): void {
             $table->dropForeign(['created_session_id']);
+            $table->dropForeign(['current_challenge_id']);
         });
         Schema::table('clients', function (Blueprint $table): void {
             $table->dropForeign(['last_active_session_id']);
@@ -207,6 +249,7 @@ return new class extends Migration
 
         Schema::dropIfExists('session_activities');
         Schema::dropIfExists('sessions');
+        Schema::dropIfExists('challenges');
         Schema::dropIfExists('sign_up_attempts');
         Schema::dropIfExists('sign_in_attempts');
         Schema::dropIfExists('clients');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
     "packages": {
         "": {
             "dependencies": {
-                "@authn-sh/sdk-js": "0.2.0-alpha.0",
-                "@authn-sh/sdk-react": "1.0.0-alpha.0",
-                "@authn-sh/types": "0.2.0-alpha.0",
+                "@authn-sh/sdk-js": "0.2.0-alpha.1",
+                "@authn-sh/sdk-react": "1.0.0-alpha.1",
+                "@authn-sh/types": "0.2.0-alpha.1",
                 "@authn-sh/ui": "0.2.0-alpha.0"
             },
             "devDependencies": {
@@ -28,27 +28,27 @@
             }
         },
         "node_modules/@authn-sh/sdk-js": {
-            "version": "0.2.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.2.0-alpha.0.tgz",
-            "integrity": "sha512-1j6R3QEvRjnSQXXYFTw/vS/jzG08ldPK5rAcrH+kKzagdCclj/BucCXyLaJ8N/VfSpVddrErGbxhLMeYTr8hTw==",
+            "version": "0.2.0-alpha.1",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.2.0-alpha.1.tgz",
+            "integrity": "sha512-F6ENqAUZrejWNsCQuN4y3fSFWaQbtQx3RD+OTzv5yyrbm2I0TfRn4rqjHo0+0JjMTgJr3HqELYCtmv/Bb3f/rA==",
             "license": "AGPL-3.0-only"
         },
         "node_modules/@authn-sh/sdk-react": {
-            "version": "1.0.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-1.0.0-alpha.0.tgz",
-            "integrity": "sha512-30zrx3pZ13hAiD9MYG91ea+UGi8D/kJvN4D0GVCFAUSu2yoj4BdhP/A0ea6KYcs6sqevlpeM4Bd2xQLNOKwguQ==",
+            "version": "1.0.0-alpha.1",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-1.0.0-alpha.1.tgz",
+            "integrity": "sha512-kxrvHS35MC4hZWxq1jaDGn7uQ3QGy7BQJMZv6tGeUCgiZhwupgE0i6VnGfwthJG9PRi7R9BoVltBgK2A8kD/Rg==",
             "license": "AGPL-3.0-only",
             "peerDependencies": {
-                "@authn-sh/sdk-js": "0.2.0-alpha.0",
+                "@authn-sh/sdk-js": "0.2.0-alpha.1",
                 "@authn-sh/ui": "0.2.0-alpha.0",
                 "react": "^18 || ^19",
                 "react-dom": "^18 || ^19"
             }
         },
         "node_modules/@authn-sh/types": {
-            "version": "0.2.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.2.0-alpha.0.tgz",
-            "integrity": "sha512-utL2ddp+UwSobFubwJJSEjvwivQG7xEJ9sW0lBsxPG3C8mn21gPy54LkzoBwb9N+FPxcsgn88d/DZrQgtCBrpg==",
+            "version": "0.2.0-alpha.1",
+            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.2.0-alpha.1.tgz",
+            "integrity": "sha512-1vV18Gc2Tc3lWu0WF/C+YIn7joN3P+gf7pBUANZVIAFlZjvrvT9GrNkN6SByXlq3HCorL1G3I4r/RJWMpXt11w==",
             "license": "AGPL-3.0-only"
         },
         "node_modules/@authn-sh/ui": {

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
         "vite": "^8.0.0"
     },
     "dependencies": {
-        "@authn-sh/sdk-js": "0.2.0-alpha.0",
-        "@authn-sh/sdk-react": "1.0.0-alpha.0",
-        "@authn-sh/types": "0.2.0-alpha.0",
+        "@authn-sh/sdk-js": "0.2.0-alpha.1",
+        "@authn-sh/sdk-react": "1.0.0-alpha.1",
+        "@authn-sh/types": "0.2.0-alpha.1",
         "@authn-sh/ui": "0.2.0-alpha.0"
     }
 }

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\AccountPortal\AccountPortalController;
+use App\Http\Controllers\Fapi\ChallengeController;
 use App\Http\Controllers\Fapi\ClientController;
 use App\Http\Controllers\Fapi\EnvironmentController;
 use App\Http\Controllers\Fapi\MagicLinkController;
@@ -74,16 +75,18 @@ Route::prefix('v1')->group(function (): void {
     Route::post('/client/sign-ups', [SignUpController::class, 'store'])->name('fapi.sign_up.store');
     Route::middleware(ResolveClientFromCookie::class)->group(function (): void {
         Route::get('/client/sign-ins/{sid}', [SignInController::class, 'show'])->name('fapi.sign_in.show');
-        Route::post('/client/sign-ins/{sid}/prepare-first-factor', [SignInController::class, 'prepareFirstFactor'])->name('fapi.sign_in.prepare_first_factor');
-        Route::post('/client/sign-ins/{sid}/attempt-first-factor', [SignInController::class, 'attemptFirstFactor'])->name('fapi.sign_in.attempt_first_factor');
-        Route::post('/client/sign-ins/{sid}/prepare-second-factor', [SignInController::class, 'prepareSecondFactor'])->name('fapi.sign_in.prepare_second_factor');
-        Route::post('/client/sign-ins/{sid}/attempt-second-factor', [SignInController::class, 'attemptSecondFactor'])->name('fapi.sign_in.attempt_second_factor');
-        Route::post('/client/sign-ins/{sid}/reset-password', [SignInController::class, 'resetPassword'])->name('fapi.sign_in.reset_password');
+        Route::patch('/client/sign-ins/{sid}', [SignInController::class, 'patch'])->name('fapi.sign_in.patch');
+
+        Route::post('/client/sign-ins/{sid}/challenges', [ChallengeController::class, 'storeForSignIn'])->name('fapi.sign_in.challenges.store');
+        Route::post('/client/sign-ins/{sid}/challenges/{cid}/answer', [ChallengeController::class, 'answerForSignIn'])->name('fapi.sign_in.challenges.answer');
+        Route::get('/client/sign-ins/{sid}/challenges/{cid}', [ChallengeController::class, 'showForSignIn'])->name('fapi.sign_in.challenges.show');
 
         Route::get('/client/sign-ups/{sid}', [SignUpController::class, 'show'])->name('fapi.sign_up.show');
         Route::patch('/client/sign-ups/{sid}', [SignUpController::class, 'patch'])->name('fapi.sign_up.patch');
-        Route::post('/client/sign-ups/{sid}/prepare-verification', [SignUpController::class, 'prepareVerification'])->name('fapi.sign_up.prepare_verification');
-        Route::post('/client/sign-ups/{sid}/attempt-verification', [SignUpController::class, 'attemptVerification'])->name('fapi.sign_up.attempt_verification');
+
+        Route::post('/client/sign-ups/{sid}/challenges', [ChallengeController::class, 'storeForSignUp'])->name('fapi.sign_up.challenges.store');
+        Route::post('/client/sign-ups/{sid}/challenges/{cid}/answer', [ChallengeController::class, 'answerForSignUp'])->name('fapi.sign_up.challenges.answer');
+        Route::get('/client/sign-ups/{sid}/challenges/{cid}', [ChallengeController::class, 'showForSignUp'])->name('fapi.sign_up.challenges.show');
 
         Route::get('/client/sessions/{sid}', [SessionsController::class, 'show'])->name('fapi.session.show');
         Route::post('/client/sessions/{sid}/touch', [SessionsController::class, 'touch'])->name('fapi.session.touch');

--- a/tests/Feature/Http/SignIn/EmailCodeTest.php
+++ b/tests/Feature/Http/SignIn/EmailCodeTest.php
@@ -2,15 +2,14 @@
 
 declare(strict_types=1);
 
+use App\Models\SignInAttempt;
 use App\Models\Verification;
 use App\Models\VerificationCode;
 use Tests\Feature\Http\SignIn\SignInTestSupport;
 
-it('runs the prepare → attempt → complete email-code path end-to-end', function (): void {
+it('runs the create-challenge → answer → complete email-code path end-to-end', function (): void {
     $f = SignInTestSupport::bootEnv();
     $bundle = SignInTestSupport::makeUser($f['env']);
-    // Pre-create the Client + cookie so we don't have to round-trip the
-    // Set-Cookie header through the test harness's cookie jar.
     $bs = SignInTestSupport::clientWithCookie($f['env']);
     $cookie = $bs['cookie'];
     $cookieName = '__client';
@@ -25,41 +24,45 @@ it('runs the prepare → attempt → complete email-code path end-to-end', funct
     $create->assertOk()->assertJsonPath('response.status', 'needs_first_factor');
     $sid = $create->json('response.id');
 
-    // 2. POST /prepare-first-factor strategy=email_code
-    $this->withCredentials()
+    // 2. POST /challenges strategy=email_code — issues the code.
+    $issue = $this->withCredentials()
         ->withUnencryptedCookie($cookieName, $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/prepare-first-factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", [
             'strategy' => 'email_code',
-        ])
-        ->assertOk();
+        ]);
+    $issue->assertOk()
+        ->assertJsonPath('response.object', 'challenge')
+        ->assertJsonPath('response.strategy', 'email_code')
+        ->assertJsonPath('response.status', 'pending')
+        ->assertJsonPath('response.step', 'first');
+    $cid = $issue->json('response.id');
 
-    // 3. Pull the cleartext code from the verification_codes table by re-hashing
-    //    the candidate sent in step 4.
+    // 3. Stamp a known cleartext on the persisted code so the answer call matches.
     $verification = Verification::query()->withoutGlobalScopes()->latest('id')->first();
     expect($verification)->not->toBeNull();
     $codeRow = VerificationCode::query()->where('verification_id', $verification->id)->latest('id')->first();
     expect($codeRow)->not->toBeNull();
-
-    // The cleartext is gone — but for the purpose of the test we mint a new
-    // code via the manager and stamp it on the row so we know the secret.
     $known = '424242';
     $codeRow->forceFill(['code_hash' => hash('sha256', $known)])->save();
 
-    // 4. POST /attempt-first-factor with the right code → complete
-    $attempt = $this->withCredentials()
+    // 4. POST /challenges/{cid}/answer with the right code → SignIn complete.
+    $answer = $this->withCredentials()
         ->withUnencryptedCookie($cookieName, $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/attempt-first-factor", [
-            'strategy' => 'email_code',
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges/{$cid}/answer", [
             'code' => $known,
         ]);
 
-    $attempt->assertOk()->assertJsonPath('response.status', 'complete');
-    expect($attempt->json('response.created_session_id'))->toStartWith('sess_');
+    $answer->assertOk()
+        ->assertJsonPath('response.status', 'verified');
+
+    $signIn = SignInAttempt::query()->withoutGlobalScopes()->where('id', $sid)->firstOrFail();
+    expect($signIn->status)->toBe('complete');
+    expect($signIn->created_session_id)->toStartWith('sess_');
 });
 
-it('flips the verification to failed after 5 wrong codes', function (): void {
+it('flips the challenge to failed after 5 wrong codes', function (): void {
     $f = SignInTestSupport::bootEnv();
     SignInTestSupport::makeUser($f['env']);
     $bs = SignInTestSupport::clientWithCookie($f['env']);
@@ -73,18 +76,18 @@ it('flips the verification to failed after 5 wrong codes', function (): void {
         ]);
     $sid = $create->json('response.id');
 
-    $this->withCredentials()
+    $issue = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/prepare-first-factor", ['strategy' => 'email_code'])
-        ->assertOk();
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", ['strategy' => 'email_code']);
+    $issue->assertOk();
+    $cid = $issue->json('response.id');
 
     for ($i = 0; $i < 5; $i++) {
         $r = $this->withCredentials()
             ->withUnencryptedCookie('__client', $cookie)
             ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-            ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/attempt-first-factor", [
-                'strategy' => 'email_code',
+            ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges/{$cid}/answer", [
                 'code' => '000000',
             ]);
         $r->assertStatus(422);

--- a/tests/Feature/Http/SignIn/EmailLinkTest.php
+++ b/tests/Feature/Http/SignIn/EmailLinkTest.php
@@ -41,12 +41,11 @@ function setupMagicLinkUser(Environment $env, string $email = 'alice@example.com
     return ['user' => $user, 'email' => $emailRow];
 }
 
-it('prepare-first-factor email_link issues a magic link, dispatches the email job', function (): void {
+it('challenge email_link issues a magic link, dispatches the email job', function (): void {
     Bus::fake([SendMagicLinkEmail::class]);
     $f = SessionsTestSupport::bootEnv();
     $u = setupMagicLinkUser($f['env']);
 
-    // Create a sign-in attempt directly (mirrors what FAPI POST does).
     $client = Client::create(['environment_id' => $f['env']->id]);
     $cookie = app(ClientResolver::class)->mintCookieValue($client);
     $attempt = SignInAttempt::create([
@@ -62,11 +61,14 @@ it('prepare-first-factor email_link issues a magic link, dispatches the email jo
             'Host' => 'acme.authn.local',
             'Origin' => $f['origin'],
         ])
-        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/prepare-first-factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/challenges", [
             'strategy' => 'email_link',
             'email_address_id' => $u['email']->id,
         ]);
-    $r->assertOk();
+    $r->assertOk()
+        ->assertJsonPath('response.object', 'challenge')
+        ->assertJsonPath('response.strategy', 'email_link')
+        ->assertJsonPath('response.status', 'pending');
 
     $verification = Verification::query()->withoutGlobalScopes()
         ->where('verifiable_type', $attempt->getMorphClass())
@@ -82,7 +84,7 @@ it('prepare-first-factor email_link issues a magic link, dispatches the email jo
     Bus::assertDispatched(SendMagicLinkEmail::class, fn ($job) => $job->emailAddress === 'alice@example.com');
 });
 
-it('attempt-first-factor email_link returns verification_failed while link is still unredeemed', function (): void {
+it('answer email_link returns verification_failed while link is still unredeemed', function (): void {
     Bus::fake([SendMagicLinkEmail::class]);
     $f = SessionsTestSupport::bootEnv();
     $u = setupMagicLinkUser($f['env']);
@@ -95,22 +97,23 @@ it('attempt-first-factor email_link returns verification_failed while link is st
         'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
     ]);
 
-    test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
+    $issue = test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/prepare-first-factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/challenges", [
             'strategy' => 'email_link',
             'email_address_id' => $u['email']->id,
-        ])->assertOk();
+        ]);
+    $issue->assertOk();
+    $cid = $issue->json('response.id');
 
     test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/attempt-first-factor", [
-            'strategy' => 'email_link',
-        ])->assertStatus(422)
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/challenges/{$cid}/answer", [])
+        ->assertStatus(422)
         ->assertJsonPath('errors.0.code', 'verification_failed');
 });
 
-it('end-to-end same-device magic link flow: prepare → click → attempt completes', function (): void {
+it('end-to-end same-device magic link flow: issue → click → answer completes', function (): void {
     Bus::fake([SendMagicLinkEmail::class]);
     $f = SessionsTestSupport::bootEnv();
     $u = setupMagicLinkUser($f['env']);
@@ -123,23 +126,20 @@ it('end-to-end same-device magic link flow: prepare → click → attempt comple
         'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
     ]);
 
-    test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
+    $issue = test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/prepare-first-factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/challenges", [
             'strategy' => 'email_link',
             'email_address_id' => $u['email']->id,
-        ])->assertOk();
+        ]);
+    $issue->assertOk();
+    $cid = $issue->json('response.id');
 
-    // Mint a magic link directly (simulates the email click). The issuer
-    // returns the click URL so we extract the JWT from it.
     $verification = Verification::query()->withoutGlobalScopes()
         ->where('verifiable_type', $attempt->getMorphClass())
         ->where('verifiable_id', $attempt->id)
         ->where('strategy', 'email_link')
         ->firstOrFail();
-    // Re-mint a fresh JWT so the test exercises the click path. The
-    // VerificationCode persisted on prepare is what the verifier matches
-    // against — we use that one.
     $code = VerificationCode::query()->where('verification_id', $verification->id)->firstOrFail();
     expect($code->consumed_at)->toBeNull();
 
@@ -151,17 +151,16 @@ it('end-to-end same-device magic link flow: prepare → click → attempt comple
         ->getJson("https://acme.authn.local/v1/client/magic-link/redeem?__authn_magic_link={$issued['jwt']}");
     $click->assertOk()->assertJsonPath('verified', true);
 
-    // Verification flipped + Client.token_version bumped.
     expect($verification->fresh()->status)->toBe('verified');
     expect((int) Client::query()->withoutGlobalScopes()->where('id', $client->id)->firstOrFail()->token_version)->toBe(1);
 
-    // Now poll attempt-first-factor — should complete and return a session.
+    // Now answer the challenge — should complete and return a session.
     $r = test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/attempt-first-factor", [
-            'strategy' => 'email_link',
-        ]);
-    $r->assertOk()->assertJsonPath('response.status', 'complete');
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$attempt->id}/challenges/{$cid}/answer", []);
+    $r->assertOk()->assertJsonPath('response.status', 'verified');
+
+    expect($attempt->fresh()->status)->toBe('complete');
 });
 
 it('replay protection: second click on the same link returns 410 consumed', function (): void {

--- a/tests/Feature/Http/SignIn/PasswordTest.php
+++ b/tests/Feature/Http/SignIn/PasswordTest.php
@@ -90,7 +90,7 @@ it('refuses sign-in for a locked user with a future lockout_expires_at', functio
         ->assertJsonPath('errors.0.code', 'user_locked');
 });
 
-it('returns supported_first_factors on identifier-only create', function (): void {
+it('returns supported_strategies on identifier-only create', function (): void {
     $f = SignInTestSupport::bootEnv();
     SignInTestSupport::makeUser($f['env']);
 
@@ -103,8 +103,9 @@ it('returns supported_first_factors on identifier-only create', function (): voi
     $response->assertOk()
         ->assertJsonPath('response.status', 'needs_first_factor');
 
-    $strategies = collect($response->json('response.supported_first_factors'))->pluck('strategy');
+    $strategies = collect($response->json('response.supported_strategies'));
     expect($strategies->contains('password'))->toBeTrue();
     expect($strategies->contains('email_code'))->toBeTrue();
+    expect($strategies->contains('email_link'))->toBeTrue();
     expect($strategies->contains('reset_password_email_code'))->toBeTrue();
 });

--- a/tests/Feature/Http/SignIn/ResetPasswordTest.php
+++ b/tests/Feature/Http/SignIn/ResetPasswordTest.php
@@ -2,22 +2,20 @@
 
 declare(strict_types=1);
 
-use App\Models\Session;
+use App\Models\SignInAttempt;
 use App\Models\User;
 use App\Models\Verification;
 use App\Models\VerificationCode;
 use Illuminate\Support\Facades\Bus;
 use Tests\Feature\Http\SignIn\SignInTestSupport;
 
-it('runs the reset_password_email_code → reset_password → complete path end-to-end', function (): void {
+it('runs the reset_password_email_code → set new password → complete path end-to-end', function (): void {
     Bus::fake();
     $f = SignInTestSupport::bootEnv();
     $bundle = SignInTestSupport::makeUser($f['env']);
     $bs = SignInTestSupport::clientWithCookie($f['env']);
     $cookie = $bs['cookie'];
 
-    // 1. Open the attempt with strategy=reset_password_email_code (no prepare needed
-    //    yet — just stash the strategy intent).
     $create = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
@@ -26,46 +24,49 @@ it('runs the reset_password_email_code → reset_password → complete path end-
         ]);
     $sid = $create->json('response.id');
 
-    // 2. Prepare the reset code.
-    $this->withCredentials()
+    // 1. Issue a reset-password challenge.
+    $issue = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/prepare-first-factor", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", [
             'strategy' => 'reset_password_email_code',
-        ])
-        ->assertOk();
+        ]);
+    $issue->assertOk()->assertJsonPath('response.strategy', 'reset_password_email_code');
+    $cid = $issue->json('response.id');
 
     $verification = Verification::query()->withoutGlobalScopes()->latest('id')->first();
     $codeRow = VerificationCode::query()->where('verification_id', $verification->id)->latest('id')->first();
     $known = '424242';
     $codeRow->forceFill(['code_hash' => hash('sha256', $known)])->save();
 
-    // 3. Attempt with the right code → status flips to needs_new_password.
-    $attempt = $this->withCredentials()
+    // 2. Answer the challenge — SignIn flips to needs_new_password.
+    $answer = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/attempt-first-factor", [
-            'strategy' => 'reset_password_email_code',
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges/{$cid}/answer", [
             'code' => $known,
         ]);
-    $attempt->assertOk()->assertJsonPath('response.status', 'needs_new_password');
+    $answer->assertOk()->assertJsonPath('response.status', 'verified');
 
-    // 4. Submit a new password → complete + Session minted.
+    expect(SignInAttempt::query()->withoutGlobalScopes()->where('id', $sid)->firstOrFail()->status)
+        ->toBe('needs_new_password');
+
+    // 3. PATCH the SignIn with the new password — completes + Session minted.
     $reset = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/reset-password", [
+        ->patchJson("https://acme.authn.local/v1/client/sign-ins/{$sid}", [
             'password' => 'brand-new-password-9000',
         ]);
     $reset->assertOk()->assertJsonPath('response.status', 'complete');
 
-    // 5. The new password works.
+    // 4. The new password works.
     $user = User::query()->withoutGlobalScopes()->where('id', $bundle['user']->id)->first();
     expect($user->checkPassword('brand-new-password-9000'))->toBeTrue();
     expect($user->checkPassword('super-secret-password'))->toBeFalse();
 });
 
-it('refuses /reset-password unless the attempt is in needs_new_password state', function (): void {
+it('refuses PATCH /sign-ins/{sid} with password unless the attempt is in needs_new_password state', function (): void {
     $f = SignInTestSupport::bootEnv();
     SignInTestSupport::makeUser($f['env']);
     $bs = SignInTestSupport::clientWithCookie($f['env']);
@@ -82,7 +83,7 @@ it('refuses /reset-password unless the attempt is in needs_new_password state', 
     $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/reset-password", [
+        ->patchJson("https://acme.authn.local/v1/client/sign-ins/{$sid}", [
             'password' => 'whatever',
         ])
         ->assertStatus(422)

--- a/tests/Feature/Http/SignUp/EmailLinkTest.php
+++ b/tests/Feature/Http/SignUp/EmailLinkTest.php
@@ -10,7 +10,7 @@ use App\Services\Client\ClientResolver;
 use Illuminate\Support\Facades\Bus;
 use Tests\Feature\Http\Sessions\SessionsTestSupport;
 
-it('prepare-verification email_link issues a magic link, dispatches the email job', function (): void {
+it('challenge email_link issues a magic link, dispatches the email job', function (): void {
     Bus::fake([SendMagicLinkEmail::class]);
     $f = SessionsTestSupport::bootEnv(userSettings: ['identifiers' => ['email_address' => ['enabled' => true, 'used_for_first_factor' => true, 'verifications' => ['email_code', 'email_link']]]]);
     $client = Client::create(['environment_id' => $f['env']->id]);
@@ -20,14 +20,18 @@ it('prepare-verification email_link issues a magic link, dispatches the email jo
         'client_id' => $client->id,
         'email_address' => 'newbie@example.com',
         'status' => SignUpAttempt::STATUS_MISSING_REQUIREMENTS,
+        'unverified_fields' => ['email_address'],
     ]);
 
     $r = test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$attempt->id}/prepare-verification", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$attempt->id}/challenges", [
             'strategy' => 'email_link',
         ]);
-    $r->assertOk();
+    $r->assertOk()
+        ->assertJsonPath('response.object', 'challenge')
+        ->assertJsonPath('response.strategy', 'email_link')
+        ->assertJsonPath('response.status', 'pending');
 
     $verification = Verification::query()->withoutGlobalScopes()
         ->where('verifiable_type', $attempt->getMorphClass())
@@ -40,7 +44,7 @@ it('prepare-verification email_link issues a magic link, dispatches the email jo
         && $job->templateSlug === 'magic_link_sign_up');
 });
 
-it('attempt-verification email_link returns verification_failed while link is unredeemed', function (): void {
+it('answer email_link returns verification_failed while link is unredeemed', function (): void {
     Bus::fake([SendMagicLinkEmail::class]);
     $f = SessionsTestSupport::bootEnv();
     $client = Client::create(['environment_id' => $f['env']->id]);
@@ -50,18 +54,20 @@ it('attempt-verification email_link returns verification_failed while link is un
         'client_id' => $client->id,
         'email_address' => 'newbie@example.com',
         'status' => SignUpAttempt::STATUS_MISSING_REQUIREMENTS,
+        'unverified_fields' => ['email_address'],
     ]);
 
-    test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
+    $issue = test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$attempt->id}/prepare-verification", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$attempt->id}/challenges", [
             'strategy' => 'email_link',
-        ])->assertOk();
+        ]);
+    $issue->assertOk();
+    $cid = $issue->json('response.id');
 
     test()->withCredentials()->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$attempt->id}/attempt-verification", [
-            'strategy' => 'email_link',
-        ])->assertStatus(422)
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$attempt->id}/challenges/{$cid}/answer", [])
+        ->assertStatus(422)
         ->assertJsonPath('errors.0.code', 'verification_failed');
 });

--- a/tests/Feature/Http/SignUp/HappyPathTest.php
+++ b/tests/Feature/Http/SignUp/HappyPathTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 use App\Models\EmailAddress;
 use App\Models\Session;
+use App\Models\SignUpAttempt;
 use App\Models\User;
 use App\Models\Verification;
 use App\Models\VerificationCode;
 use Tests\Feature\Http\SignUp\SignUpTestSupport;
 
-it('runs create → prepare → attempt → complete with email + password', function (): void {
+it('runs create → challenge → answer → complete with email + password', function (): void {
     $f = SignUpTestSupport::bootEnv();
     $bs = SignUpTestSupport::clientWithCookie($f['env']);
     $cookie = $bs['cookie'];
@@ -29,14 +30,18 @@ it('runs create → prepare → attempt → complete with email + password', fun
         ->assertJsonPath('response.unverified_fields', ['email_address']);
     $sid = $create->json('response.id');
 
-    // 2. POST /prepare-verification strategy=email_code.
-    $this->withCredentials()
+    // 2. POST /challenges strategy=email_code.
+    $issue = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$sid}/prepare-verification", [
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$sid}/challenges", [
             'strategy' => 'email_code',
-        ])
-        ->assertOk();
+        ]);
+    $issue->assertOk()
+        ->assertJsonPath('response.object', 'challenge')
+        ->assertJsonPath('response.strategy', 'email_code')
+        ->assertJsonPath('response.step', 'single');
+    $cid = $issue->json('response.id');
 
     // 3. Stamp a known code on the row.
     $verification = Verification::query()->withoutGlobalScopes()->latest('id')->first();
@@ -44,22 +49,24 @@ it('runs create → prepare → attempt → complete with email + password', fun
     $known = '424242';
     $codeRow->forceFill(['code_hash' => hash('sha256', $known)])->save();
 
-    // 4. POST /attempt-verification → complete.
-    $attempt = $this->withCredentials()
+    // 4. POST /challenges/{cid}/answer → SignUp completes.
+    $answer = $this->withCredentials()
         ->withUnencryptedCookie('__client', $cookie)
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$sid}/attempt-verification", [
-            'strategy' => 'email_code',
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$sid}/challenges/{$cid}/answer", [
             'code' => $known,
         ]);
 
-    $attempt->assertOk()
-        ->assertJsonPath('response.status', 'complete');
-    expect($attempt->json('response.created_session_id'))->toStartWith('sess_');
-    expect($attempt->json('response.created_user_id'))->toStartWith('user_');
+    $answer->assertOk()
+        ->assertJsonPath('response.status', 'verified');
+
+    $signUp = SignUpAttempt::query()->withoutGlobalScopes()->where('id', $sid)->firstOrFail();
+    expect($signUp->status)->toBe('complete');
+    expect($signUp->created_session_id)->toStartWith('sess_');
+    expect($signUp->created_user_id)->toStartWith('user_');
 
     // 5. Verify the User + EmailAddress + Session rows exist with the right state.
-    $userId = $attempt->json('response.created_user_id');
+    $userId = $signUp->created_user_id;
     $user = User::query()->withoutGlobalScopes()->where('id', $userId)->first();
     expect($user)->not->toBeNull();
     expect($user->checkPassword('super-secret-password'))->toBeTrue();
@@ -70,7 +77,7 @@ it('runs create → prepare → attempt → complete with email + password', fun
     expect($email->isVerified())->toBeTrue();
     expect($email->is_primary)->toBeTrue();
 
-    $sessionId = $attempt->json('response.created_session_id');
+    $sessionId = $signUp->created_session_id;
     expect(Session::query()->withoutGlobalScopes()->where('id', $sessionId)->where('status', 'active')->exists())->toBeTrue();
 });
 
@@ -95,6 +102,5 @@ it('returns missing_fields when first_name is required and not provided', functi
         ->assertJsonPath('response.status', 'missing_requirements')
         ->assertJsonPath('response.missing_fields', ['first_name']);
 
-    // No User row written until everything is supplied + verified.
     expect(User::query()->withoutGlobalScopes()->count())->toBe(0);
 });

--- a/tests/Feature/Http/SignUp/TestModeFlowTest.php
+++ b/tests/Feature/Http/SignUp/TestModeFlowTest.php
@@ -29,11 +29,12 @@ it('sign-up against +authn_test in dev uses fixed code 424242, no driver call', 
     $create->assertOk()->assertJsonPath('response.status', 'missing_requirements');
     $sid = $create->json('response.id');
 
-    $this->withCredentials()
+    $issue = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$sid}/prepare-verification", ['strategy' => 'email_code'])
-        ->assertOk();
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$sid}/challenges", ['strategy' => 'email_code']);
+    $issue->assertOk();
+    $cid = $issue->json('response.id');
 
     // The minted code is the fixed 424242 (still hashed in storage).
     $verification = Verification::query()->withoutGlobalScopes()->latest('id')->first();
@@ -44,14 +45,14 @@ it('sign-up against +authn_test in dev uses fixed code 424242, no driver call', 
     $r = $this->withCredentials()
         ->withUnencryptedCookie('__client', $bs['cookie'])
         ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
-        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$sid}/attempt-verification", [
-            'strategy' => 'email_code',
+        ->postJson("https://acme.authn.local/v1/client/sign-ups/{$sid}/challenges/{$cid}/answer", [
             'code' => '424242',
         ]);
-    $r->assertOk()->assertJsonPath('response.status', 'complete');
+    $r->assertOk()->assertJsonPath('response.status', 'verified');
 
-    $userId = $r->json('response.created_user_id');
-    expect($userId)->toStartWith('user_');
+    $signUp = \App\Models\SignUpAttempt::query()->withoutGlobalScopes()->where('id', $sid)->firstOrFail();
+    expect($signUp->status)->toBe('complete');
+    expect($signUp->created_user_id)->toStartWith('user_');
 });
 
 it('sign-up against +authn_test in production returns test_identifier_forbidden', function (): void {

--- a/tests/Feature/Http/SignUp/TestModeFlowTest.php
+++ b/tests/Feature/Http/SignUp/TestModeFlowTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Models\ApiKey;
 use App\Models\Environment;
+use App\Models\SignUpAttempt;
 use App\Models\User;
 use App\Models\Verification;
 use App\Models\VerificationCode;
@@ -50,7 +51,7 @@ it('sign-up against +authn_test in dev uses fixed code 424242, no driver call', 
         ]);
     $r->assertOk()->assertJsonPath('response.status', 'verified');
 
-    $signUp = \App\Models\SignUpAttempt::query()->withoutGlobalScopes()->where('id', $sid)->firstOrFail();
+    $signUp = SignUpAttempt::query()->withoutGlobalScopes()->where('id', $sid)->firstOrFail();
     expect($signUp->status)->toBe('complete');
     expect($signUp->created_user_id)->toStartWith('user_');
 });

--- a/tests/Feature/Models/SignUpAttemptTest.php
+++ b/tests/Feature/Models/SignUpAttemptTest.php
@@ -32,7 +32,6 @@ it('defaults status to missing_requirements on create', function (): void {
     expect($a->status)->toBe('missing_requirements');
     expect($a->missing_fields)->toBe([]);
     expect($a->unverified_fields)->toBe([]);
-    expect($a->verifications)->toBe([]);
 });
 
 it('allows missing_requirements → complete and missing_requirements → transferable', function (): void {
@@ -87,14 +86,12 @@ it('persists jsonb columns as arrays', function (): void {
         'environment_id' => $f['env']->id,
         'client_id' => $f['client']->id,
         'unsafe_metadata' => ['plan' => 'pro'],
-        'verifications' => ['email_address' => 'ver_xyz'],
         'missing_fields' => ['username'],
         'unverified_fields' => ['email_address'],
     ]);
 
     $a = $a->fresh();
     expect($a->unsafe_metadata)->toBe(['plan' => 'pro']);
-    expect($a->verifications)->toBe(['email_address' => 'ver_xyz']);
     expect($a->missing_fields)->toBe(['username']);
     expect($a->unverified_fields)->toBe(['email_address']);
 });


### PR DESCRIPTION
## Summary

- Drops the per-factor prepare/attempt endpoint pairs (and the `/reset-password` POST) in favour of a uniform `Challenge` sub-resource attached to `SignIn` and `SignUp`.
- Each Challenge wraps a `Verification` 1:1 — Verification still owns the cryptographic state, Challenge is the API-facing veneer with a uniform `pending → verified|transferable|failed|expired` lifecycle.
- `SignInResource` / `SignUpResource` now expose `current_challenge_id` and a narrowed `supported_strategies[]` instead of the old factor-shaped fields. Reset-password completes via `PATCH /sign-ins/{sid} { password }` once the SignIn is in `needs_new_password`.

## Routes

Added (FAPI, under `ResolveClientFromCookie`):

```
POST   /v1/client/sign-ins/{sid}/challenges               fapi.sign_in.challenges.store
POST   /v1/client/sign-ins/{sid}/challenges/{cid}/answer  fapi.sign_in.challenges.answer
GET    /v1/client/sign-ins/{sid}/challenges/{cid}         fapi.sign_in.challenges.show
POST   /v1/client/sign-ups/{sid}/challenges               fapi.sign_up.challenges.store
POST   /v1/client/sign-ups/{sid}/challenges/{cid}/answer  fapi.sign_up.challenges.answer
GET    /v1/client/sign-ups/{sid}/challenges/{cid}         fapi.sign_up.challenges.show
PATCH  /v1/client/sign-ins/{sid}                          fapi.sign_in.patch
```

Removed: `prepare-first-factor`, `attempt-first-factor`, `prepare-second-factor`, `attempt-second-factor`, `reset-password`, `prepare-verification`, `attempt-verification` (and their controller methods).

## Migration (in place; alpha — no compat shims)

`0005_…_create_flow_state_models.php` is edited in place:
- adds `current_challenge_id` to `sign_in_attempts` / `sign_up_attempts` (loop FK to `challenges`),
- drops `first_factor_verification_id` / `second_factor_verification_id` from `sign_in_attempts`,
- drops the `verifications` jsonb column from `sign_up_attempts`,
- creates `challenges (id chal_, environment_id, parent_type, parent_id, step, strategy, status, verification_id, attempts, nonce, external_verification_redirect_url, error_code, error_message, expire_at, timestamps)` with a `(parent_type, parent_id, status)` index.

## Contract

The auto-applied OpenAPI contract validator passes against the bundled spec from the openapi v0.2 PR — Challenge envelopes match `ClientResponseEnvelope { response: Challenge, client: Client }`, `GET show` returns the unwrapped `Challenge` per spec.

## Test plan

- [x] `php artisan test --parallel` — 454 passed, 1493 assertions.
- [ ] CI green.