### PR TITLE
Generalize Challenge to email-address + organization-domain parents

### DIFF
--- a/app/Http/Controllers/Bapi/OrganizationDomainChallengeController.php
+++ b/app/Http/Controllers/Bapi/OrganizationDomainChallengeController.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Events\Organizations\OrganizationDomainUpdated;
+use App\Events\Organizations\OrganizationDomainVerified;
+use App\Http\Resources\ChallengeResource;
+use App\Jobs\Organizations\VerifyOrganizationDomain;
+use App\Models\Challenge;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationDomain;
+use App\Models\Verification;
+use App\Services\Domains\DnsTxtResolver;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Generalized Challenge sub-resource for OrganizationDomain DNS-TXT
+ * verification — replaces the per-action `/verify` endpoint. The Challenge
+ * carries the operator-facing nonce (the TXT value to publish); answer()
+ * triggers an immediate DnsTxtResolver lookup, and the background
+ * VerifyOrganizationDomain job keeps polling regardless.
+ */
+final class OrganizationDomainChallengeController
+{
+    public const TTL_SECONDS = 14 * 24 * 60 * 60;
+
+    public function store(string $organizationId, string $domainId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $domain = $this->find($organizationId, $domainId);
+        if ($domain === null) {
+            return $this->error(404, 'organization_domain_not_found', 'No domain matches that id in this organization.');
+        }
+
+        $challenge = $this->issueDnsTxtChallenge($env, $domain);
+
+        return response()->json(ChallengeResource::from($challenge), 201)
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function answer(string $organizationId, string $domainId, string $cid): JsonResponse
+    {
+        $domain = $this->find($organizationId, $domainId);
+        if ($domain === null) {
+            return $this->error(404, 'organization_domain_not_found', 'No domain matches that id in this organization.');
+        }
+
+        $challenge = $this->loadChallenge($cid, $domain);
+        if ($challenge === null) {
+            return $this->error(404, 'challenge_not_found', 'Challenge not found.');
+        }
+
+        $verification = Verification::query()->withoutGlobalScopes()->where('id', $challenge->verification_id)->first();
+        if ($verification === null) {
+            return $this->error(422, 'verification_failed', 'Underlying verification missing.');
+        }
+
+        if ($challenge->status === Challenge::STATUS_VERIFIED) {
+            // Terminal — return the body so the SDK can reconcile.
+            return response()->json(ChallengeResource::from($challenge))
+                ->header('Cache-Control', 'no-store');
+        }
+
+        $this->runDnsLookup($domain, $challenge, $verification);
+
+        // Fire-and-forget: background poller continues even after a miss so
+        // the caller doesn't have to retry manually.
+        VerifyOrganizationDomain::dispatch($domain->id);
+
+        return response()->json(ChallengeResource::from($challenge->fresh() ?? $challenge))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function show(string $organizationId, string $domainId, string $cid): JsonResponse
+    {
+        $domain = $this->find($organizationId, $domainId);
+        if ($domain === null) {
+            return $this->error(404, 'organization_domain_not_found', 'No domain matches that id in this organization.');
+        }
+
+        $challenge = $this->loadChallenge($cid, $domain);
+        if ($challenge === null) {
+            return $this->error(404, 'challenge_not_found', 'Challenge not found.');
+        }
+
+        $this->refreshChallengeFromVerification($challenge);
+
+        return response()->json(ChallengeResource::from($challenge->fresh() ?? $challenge))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    private function issueDnsTxtChallenge(Environment $env, OrganizationDomain $domain): Challenge
+    {
+        $nonce = 'authn-domain-verify='.Str::lower(Str::random(40));
+
+        return DB::transaction(function () use ($env, $domain, $nonce): Challenge {
+            $verification = Verification::query()->withoutGlobalScopes()->create([
+                'environment_id' => $env->id,
+                'verifiable_type' => $domain->getMorphClass(),
+                'verifiable_id' => $domain->id,
+                'strategy' => Verification::STRATEGY_DOMAIN_DNS_TXT,
+                'status' => Verification::STATUS_UNVERIFIED,
+                'attempts' => 0,
+                'expire_at' => now()->addSeconds(self::TTL_SECONDS),
+                'nonce' => $nonce,
+            ]);
+
+            $challenge = Challenge::query()->withoutGlobalScopes()->create([
+                'environment_id' => $env->id,
+                'parent_type' => Challenge::PARENT_ORGANIZATION_DOMAIN,
+                'parent_id' => $domain->id,
+                'step' => Challenge::STEP_SINGLE,
+                'strategy' => Verification::STRATEGY_DOMAIN_DNS_TXT,
+                'status' => Challenge::STATUS_PENDING,
+                'verification_id' => $verification->id,
+                'attempts' => 0,
+                'nonce' => $nonce,
+                'expire_at' => $verification->expire_at,
+            ]);
+
+            $domain->forceFill(['current_challenge_id' => $challenge->id])->save();
+
+            return $challenge;
+        });
+    }
+
+    private function runDnsLookup(OrganizationDomain $domain, Challenge $challenge, Verification $verification): void
+    {
+        $resolver = app(DnsTxtResolver::class);
+        $expected = (string) $verification->nonce;
+        if ($expected === '') {
+            return;
+        }
+
+        $records = $resolver->resolve('_authn-verification.'.$domain->name);
+        $matched = false;
+        foreach ($records as $record) {
+            if (str_contains($record, $expected)) {
+                $matched = true;
+                break;
+            }
+        }
+
+        if ($matched) {
+            $this->flipToVerified($domain, $challenge, $verification);
+
+            return;
+        }
+
+        $attempts = (int) $verification->attempts + 1;
+        $verification->forceFill(['attempts' => $attempts])->save();
+        $challenge->forceFill(['attempts' => $attempts])->save();
+    }
+
+    private function flipToVerified(OrganizationDomain $domain, Challenge $challenge, Verification $verification): void
+    {
+        $wasVerified = (bool) $domain->verified;
+
+        DB::transaction(function () use ($domain, $challenge, $verification): void {
+            $verification->forceFill([
+                'status' => Verification::STATUS_VERIFIED,
+                'verified_at' => now(),
+            ])->save();
+            $challenge->forceFill([
+                'status' => Challenge::STATUS_VERIFIED,
+                'attempts' => (int) $verification->attempts,
+                'error_code' => null,
+                'error_message' => null,
+            ])->save();
+            $domain->forceFill([
+                'verified' => true,
+                'current_challenge_id' => null,
+            ])->save();
+        });
+
+        $fresh = $domain->fresh();
+        if (! $wasVerified && $fresh !== null) {
+            OrganizationDomainVerified::dispatch($fresh);
+        }
+        if ($fresh !== null) {
+            OrganizationDomainUpdated::dispatch($fresh);
+        }
+    }
+
+    private function refreshChallengeFromVerification(Challenge $challenge): void
+    {
+        $verification = Verification::query()->withoutGlobalScopes()->where('id', $challenge->verification_id)->first();
+        if ($verification === null) {
+            return;
+        }
+        $challenge->forceFill([
+            'status' => match ($verification->status) {
+                Verification::STATUS_UNVERIFIED => Challenge::STATUS_PENDING,
+                Verification::STATUS_VERIFIED => Challenge::STATUS_VERIFIED,
+                Verification::STATUS_FAILED => Challenge::STATUS_FAILED,
+                Verification::STATUS_EXPIRED => Challenge::STATUS_EXPIRED,
+                default => Challenge::STATUS_PENDING,
+            },
+            'attempts' => (int) $verification->attempts,
+            'nonce' => $verification->nonce,
+            'error_code' => $verification->error_code,
+            'error_message' => $verification->error_message,
+        ])->save();
+    }
+
+    private function loadChallenge(string $cid, OrganizationDomain $domain): ?Challenge
+    {
+        return Challenge::query()
+            ->withoutGlobalScopes()
+            ->where('id', $cid)
+            ->where('parent_type', Challenge::PARENT_ORGANIZATION_DOMAIN)
+            ->where('parent_id', $domain->id)
+            ->first();
+    }
+
+    private function find(string $organizationId, string $domainId): ?OrganizationDomain
+    {
+        $env = app(Environment::class);
+        $org = Organization::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $organizationId)
+            ->first();
+        if ($org === null) {
+            return null;
+        }
+
+        return OrganizationDomain::query()
+            ->where('organization_id', $org->id)
+            ->where('id', $domainId)
+            ->first();
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Controllers/Bapi/OrganizationDomainController.php
+++ b/app/Http/Controllers/Bapi/OrganizationDomainController.php
@@ -10,34 +10,18 @@ use App\Events\Organizations\OrganizationDomainUpdated;
 use App\Http\Requests\Bapi\Organizations\CreateDomainRequest;
 use App\Http\Requests\Bapi\Organizations\UpdateDomainRequest;
 use App\Http\Resources\OrganizationDomainResource;
-use App\Jobs\Organizations\VerifyOrganizationDomain;
 use App\Models\Environment;
 use App\Models\Organization;
 use App\Models\OrganizationDomain;
-use App\Models\Verification;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 
 /**
- * BAPI organization-domains surface (PLAN §3.1, OA-2).
- *
- *   GET    /v1/organizations/{organization_id}/domains
- *   POST   /v1/organizations/{organization_id}/domains
- *   GET    /v1/organizations/{organization_id}/domains/{domain_id}
- *   PATCH  /v1/organizations/{organization_id}/domains/{domain_id}
- *   DELETE /v1/organizations/{organization_id}/domains/{domain_id}
- *   POST   /v1/organizations/{organization_id}/domains/{domain_id}/verify
- *
- * The actual DNS TXT lookup (and the verified=true transition) is owned by
- * AU-9's domain-verification job. This controller only mints the row + the
- * paired Verification challenge.
+ * BAPI organization-domains CRUD. DNS-TXT verification lives on the
+ * generalized Challenge sub-resource (OrganizationDomainChallengeController).
  */
 final class OrganizationDomainController
 {
-    public const VERIFICATION_TTL_SECONDS = 14 * 24 * 60 * 60;
-
     public function index(Request $request, string $organizationId): JsonResponse
     {
         $org = $this->findOrganization($organizationId);
@@ -79,24 +63,18 @@ final class OrganizationDomainController
             return $this->error(409, 'form_identifier_exists', 'A domain with that name is already registered in this environment.');
         }
 
-        [$domain, $verification] = DB::transaction(function () use ($env, $org, $name, $request): array {
-            $domain = OrganizationDomain::create([
-                'environment_id' => $env->id,
-                'organization_id' => $org->id,
-                'name' => $name,
-                'verified' => false,
-                'enrollment_mode' => $request->input('enrollment_mode', OrganizationDomain::MODE_MANUAL_INVITATION),
-                'affiliation_email_address' => $request->input('affiliation_email_address'),
-            ]);
-
-            $verification = $this->issueDnsTxtVerification($env, $domain);
-
-            return [$domain, $verification];
-        });
+        $domain = OrganizationDomain::create([
+            'environment_id' => $env->id,
+            'organization_id' => $org->id,
+            'name' => $name,
+            'verified' => false,
+            'enrollment_mode' => $request->input('enrollment_mode', OrganizationDomain::MODE_MANUAL_INVITATION),
+            'affiliation_email_address' => $request->input('affiliation_email_address'),
+        ]);
 
         OrganizationDomainCreated::dispatch($domain);
 
-        return response()->json(OrganizationDomainResource::from($domain->fresh(), $verification), 201);
+        return response()->json(OrganizationDomainResource::from($domain->fresh()), 201);
     }
 
     public function show(string $organizationId, string $domainId): JsonResponse
@@ -149,47 +127,6 @@ final class OrganizationDomainController
             'id' => $domainId,
             'deleted' => true,
         ]);
-    }
-
-    public function verify(string $organizationId, string $domainId): JsonResponse
-    {
-        $env = app(Environment::class);
-        $domain = $this->find($organizationId, $domainId);
-        if ($domain === null) {
-            return $this->error(404, 'organization_domain_not_found', 'No domain matches that id in this organization.');
-        }
-
-        $verification = $this->issueDnsTxtVerification($env, $domain);
-        VerifyOrganizationDomain::dispatch($domain->id);
-
-        return response()->json(OrganizationDomainResource::from($domain->fresh(), $verification));
-    }
-
-    /* -------------------- helpers -------------------- */
-
-    /**
-     * Mint (or re-mint) a domain_dns_txt Verification carrying a fresh nonce
-     * the operator must publish as a TXT record. The actual DNS lookup is in
-     * AU-9; this issue just keeps the challenge state.
-     */
-    private function issueDnsTxtVerification(Environment $env, OrganizationDomain $domain): Verification
-    {
-        $nonce = 'authn-domain-verify='.Str::lower(Str::random(40));
-
-        $verification = Verification::query()->withoutGlobalScopes()->create([
-            'environment_id' => $env->id,
-            'verifiable_type' => $domain->getMorphClass(),
-            'verifiable_id' => $domain->id,
-            'strategy' => Verification::STRATEGY_DOMAIN_DNS_TXT,
-            'status' => Verification::STATUS_UNVERIFIED,
-            'attempts' => 0,
-            'expire_at' => now()->addSeconds(self::VERIFICATION_TTL_SECONDS),
-            'nonce' => $nonce,
-        ]);
-
-        $domain->forceFill(['verification_id' => $verification->id])->save();
-
-        return $verification;
     }
 
     private function find(string $organizationId, string $domainId): ?OrganizationDomain

--- a/app/Http/Controllers/Fapi/ChallengeController.php
+++ b/app/Http/Controllers/Fapi/ChallengeController.php
@@ -37,13 +37,17 @@ use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Cookie;
 
 /**
- * Uniform Challenge sub-resource for SignIn / SignUp factor flows.
+ * Uniform Challenge sub-resource for SignIn / SignUp / EmailAddress
+ * verification flows. The same controller serves all parents — the
+ * concrete `for*` action picks which parent table to load.
  *
- * Replaces the per-factor `prepare-*` / `attempt-*` endpoint pairs with
- * a CRUD-shaped Challenge resource:
- *   POST   /v1/client/sign-{ins|ups}/{sid}/challenges        — issue
- *   POST   /v1/client/sign-{ins|ups}/{sid}/challenges/{cid}/answer — submit
- *   GET    /v1/client/sign-{ins|ups}/{sid}/challenges/{cid}  — poll
+ *   POST   /v1/client/sign-{ins|ups}/{sid}/challenges                — issue
+ *   POST   /v1/client/sign-{ins|ups}/{sid}/challenges/{cid}/answer   — submit
+ *   GET    /v1/client/sign-{ins|ups}/{sid}/challenges/{cid}          — poll
+ *
+ *   POST   /v1/me/email-addresses/{eid}/challenges                   — issue
+ *   POST   /v1/me/email-addresses/{eid}/challenges/{cid}/answer      — submit
+ *   GET    /v1/me/email-addresses/{eid}/challenges/{cid}             — poll
  *
  * Each Challenge wraps an underlying Verification 1:1 — the Verification
  * still owns the cryptographic state (codes, attempt counter, expiry);
@@ -359,6 +363,225 @@ final class ChallengeController
 
         return response()->json(ChallengeResource::from($challenge->fresh()))
             ->header('Cache-Control', 'no-store');
+    }
+
+    /* ============================ email-address surface ============================ */
+
+    public function storeForEmailAddress(Request $request): JsonResponse
+    {
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->bareError(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot verify emails.', null);
+        }
+        $email = $this->loadEmailForUser($request);
+        if ($email instanceof JsonResponse) {
+            return $email;
+        }
+
+        $strategyName = (string) $request->input('strategy', '');
+        if ($strategyName === '') {
+            return $this->bareError(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', null);
+        }
+        if (! in_array($strategyName, [Verification::STRATEGY_EMAIL_CODE, Verification::STRATEGY_EMAIL_LINK], true)) {
+            return $this->bareError(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategyName} is not supported on email-address challenges.", null);
+        }
+
+        $challenge = $strategyName === Verification::STRATEGY_EMAIL_LINK
+            ? $this->issueEmailLinkForEmailAddress($email, $request)
+            : $this->issueEmailCodeForEmailAddress($email);
+
+        // Inline answer-on-create — the SDK can pass `code` alongside the
+        // create call to skip the second round trip for email_code.
+        $code = $request->input('code');
+        if ($strategyName === Verification::STRATEGY_EMAIL_CODE && is_string($code) && $code !== '') {
+            return $this->runEmailAddressAnswer($email, $challenge, ['code' => $code]);
+        }
+
+        return response()->json(ChallengeResource::from($challenge->fresh()))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function answerForEmailAddress(Request $request): JsonResponse
+    {
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->bareError(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot verify emails.', null);
+        }
+        $email = $this->loadEmailForUser($request);
+        if ($email instanceof JsonResponse) {
+            return $email;
+        }
+        $challenge = $this->loadChallenge((string) $request->route('cid'), $email, Challenge::PARENT_EMAIL_ADDRESS);
+        if ($challenge instanceof JsonResponse) {
+            return $challenge;
+        }
+
+        return $this->runEmailAddressAnswer($email, $challenge, [
+            'code' => $request->input('code'),
+        ]);
+    }
+
+    public function showForEmailAddress(Request $request): JsonResponse
+    {
+        $email = $this->loadEmailForUser($request);
+        if ($email instanceof JsonResponse) {
+            return $email;
+        }
+        $challenge = $this->loadChallenge((string) $request->route('cid'), $email, Challenge::PARENT_EMAIL_ADDRESS);
+        if ($challenge instanceof JsonResponse) {
+            return $challenge;
+        }
+
+        $this->refreshChallengeFromVerification($challenge);
+        // email_link verifications flip out-of-band via the click handler;
+        // mirror that into the EmailAddress.verified_at on poll so the
+        // SDK sees the final state without a second round trip.
+        $this->reflectEmailLinkRedemption($email, $challenge->fresh() ?? $challenge);
+
+        return response()->json(ChallengeResource::from($challenge->fresh()))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    private function issueEmailCodeForEmailAddress(EmailAddress $email): Challenge
+    {
+        $verification = $this->verifications->start(
+            $email,
+            Verification::STRATEGY_EMAIL_CODE,
+            self::SIGN_UP_EMAIL_VERIFICATION_TTL,
+        );
+        $code = $this->verifications->mintNumericCode(
+            $verification,
+            VerificationCode::PURPOSE_EMAIL_CODE,
+            self::SIGN_UP_EMAIL_VERIFICATION_TTL,
+        );
+
+        SendVerificationEmail::dispatch(
+            $email->environment_id,
+            $email->email_address,
+            $code,
+            VerificationCode::PURPOSE_EMAIL_CODE,
+            $verification->id,
+            $email->id,
+        );
+
+        return $this->createChallenge(
+            $email,
+            Challenge::PARENT_EMAIL_ADDRESS,
+            Challenge::STEP_SINGLE,
+            Verification::STRATEGY_EMAIL_CODE,
+            $verification,
+        );
+    }
+
+    private function issueEmailLinkForEmailAddress(EmailAddress $email, Request $request): Challenge
+    {
+        $verification = $this->verifications->start(
+            $email,
+            Verification::STRATEGY_EMAIL_LINK,
+            MagicLinkIssuer::TTL_SECONDS,
+        );
+
+        $redirectUrl = $request->input('redirect_url');
+        $minted = app(MagicLinkIssuer::class)->issue(
+            $verification,
+            is_string($redirectUrl) && $redirectUrl !== '' ? $redirectUrl : null,
+        );
+
+        SendMagicLinkEmail::dispatch(
+            $email->environment_id,
+            $email->email_address,
+            $minted['url'],
+            EmailTemplate::SLUG_MAGIC_LINK_SIGN_IN,
+            $verification->id,
+            $email->id,
+        );
+
+        $verification->forceFill(['external_verification_redirect_url' => $minted['url']])->save();
+
+        return $this->createChallenge(
+            $email,
+            Challenge::PARENT_EMAIL_ADDRESS,
+            Challenge::STEP_SINGLE,
+            Verification::STRATEGY_EMAIL_LINK,
+            $verification->fresh() ?? $verification,
+        );
+    }
+
+    private function runEmailAddressAnswer(EmailAddress $email, Challenge $challenge, array $params): JsonResponse
+    {
+        $verification = Verification::query()->withoutGlobalScopes()->where('id', $challenge->verification_id)->first();
+        if ($verification === null) {
+            return $this->bareError(422, ErrorCodes::VERIFICATION_FAILED, 'Underlying verification missing.', null);
+        }
+
+        if ($challenge->strategy === Verification::STRATEGY_EMAIL_LINK) {
+            // Empty-body poll. The click handler flips Verification.status
+            // out-of-band; here we just mirror it onto the Challenge.
+            $this->refreshChallengeFromVerification($challenge);
+            $fresh = $challenge->fresh() ?? $challenge;
+            if ($fresh->status === Challenge::STATUS_PENDING) {
+                return $this->bareError(422, ErrorCodes::VERIFICATION_FAILED, 'Magic link not yet redeemed.', null);
+            }
+            if ($fresh->status === Challenge::STATUS_EXPIRED) {
+                return $this->bareError(422, ErrorCodes::VERIFICATION_EXPIRED, 'Magic link expired.', null);
+            }
+            if ($fresh->status !== Challenge::STATUS_VERIFIED) {
+                return $this->bareError(422, ErrorCodes::VERIFICATION_FAILED, "Challenge in status {$fresh->status}.", null);
+            }
+            $this->reflectEmailLinkRedemption($email, $fresh);
+
+            return response()->json(ChallengeResource::from($fresh))->header('Cache-Control', 'no-store');
+        }
+
+        $code = $params['code'] ?? null;
+        if (! is_string($code) || $code === '') {
+            return $this->bareError(422, ErrorCodes::FORM_PARAM_NIL, 'code is required.', null);
+        }
+
+        $ok = $this->verifications->attempt($verification, $code);
+        if (! $ok) {
+            $fresh = $verification->fresh();
+            $errCode = $fresh->status === Verification::STATUS_FAILED
+                ? ErrorCodes::VERIFICATION_FAILED
+                : ($fresh->status === Verification::STATUS_EXPIRED
+                    ? ErrorCodes::VERIFICATION_EXPIRED
+                    : ErrorCodes::FORM_CODE_INCORRECT);
+            $this->reflectFailure($challenge, $fresh, $errCode, 'Incorrect code.');
+
+            return $this->bareError(422, $errCode, 'Incorrect code.', null);
+        }
+
+        $this->markChallengeVerified($challenge, $verification->fresh() ?? $verification);
+        $email->forceFill(['verified_at' => now()])->save();
+
+        return response()->json(ChallengeResource::from($challenge->fresh()))->header('Cache-Control', 'no-store');
+    }
+
+    private function reflectEmailLinkRedemption(EmailAddress $email, Challenge $challenge): void
+    {
+        if ($challenge->status !== Challenge::STATUS_VERIFIED) {
+            return;
+        }
+        if ($email->verified_at !== null) {
+            return;
+        }
+        $email->forceFill(['verified_at' => now()])->save();
+    }
+
+    private function loadEmailForUser(Request $request): EmailAddress|JsonResponse
+    {
+        $eid = (string) $request->route('email_address_id');
+        $user = app(User::class);
+        $email = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('id', $eid)
+            ->where('user_id', $user->id)
+            ->first();
+        if ($email === null) {
+            return $this->bareError(404, ErrorCodes::EMAIL_NOT_FOUND, 'Email not found on this user.', null);
+        }
+
+        return $email;
     }
 
     /* ================================ helpers ================================ */

--- a/app/Http/Controllers/Fapi/ChallengeController.php
+++ b/app/Http/Controllers/Fapi/ChallengeController.php
@@ -397,8 +397,7 @@ final class ChallengeController
             return $this->runEmailAddressAnswer($email, $challenge, ['code' => $code]);
         }
 
-        return response()->json(ChallengeResource::from($challenge->fresh()))
-            ->header('Cache-Control', 'no-store');
+        return $this->emailAddressEnvelope($challenge->fresh());
     }
 
     public function answerForEmailAddress(Request $request): JsonResponse
@@ -530,7 +529,7 @@ final class ChallengeController
             }
             $this->reflectEmailLinkRedemption($email, $fresh);
 
-            return response()->json(ChallengeResource::from($fresh))->header('Cache-Control', 'no-store');
+            return $this->emailAddressEnvelope($fresh);
         }
 
         $code = $params['code'] ?? null;
@@ -554,7 +553,7 @@ final class ChallengeController
         $this->markChallengeVerified($challenge, $verification->fresh() ?? $verification);
         $email->forceFill(['verified_at' => now()])->save();
 
-        return response()->json(ChallengeResource::from($challenge->fresh()))->header('Cache-Control', 'no-store');
+        return $this->emailAddressEnvelope($challenge->fresh());
     }
 
     private function reflectEmailLinkRedemption(EmailAddress $email, Challenge $challenge): void
@@ -566,6 +565,16 @@ final class ChallengeController
             return;
         }
         $email->forceFill(['verified_at' => now()])->save();
+    }
+
+    private function emailAddressEnvelope(?Challenge $challenge): JsonResponse
+    {
+        $client = app()->bound(Client::class) ? app(Client::class) : null;
+
+        return response()->json([
+            'response' => ChallengeResource::from($challenge),
+            'client' => $client !== null ? ClientResource::from($client->fresh()) : null,
+        ])->header('Cache-Control', 'no-store');
     }
 
     private function loadEmailForUser(Request $request): EmailAddress|JsonResponse

--- a/app/Http/Controllers/Fapi/MeController.php
+++ b/app/Http/Controllers/Fapi/MeController.php
@@ -9,16 +9,12 @@ use App\Http\Resources\ClientResource;
 use App\Http\Resources\EmailAddressResource;
 use App\Http\Resources\UserResource;
 use App\Jobs\Mail\SendPasswordChangedNotification;
-use App\Jobs\Mail\SendVerificationEmail;
 use App\Models\Client;
 use App\Models\EmailAddress;
 use App\Models\Environment;
 use App\Models\Session;
 use App\Models\User;
-use App\Models\Verification;
-use App\Models\VerificationCode;
 use App\Services\Sessions\SessionLifecycle;
-use App\Services\Verification\VerificationManager;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -33,14 +29,11 @@ use Illuminate\Http\Request;
  */
 final class MeController
 {
-    private const EMAIL_VERIFICATION_TTL = 600;
-
     private const WRITABLE_PROFILE_FIELDS = [
         'first_name', 'last_name', 'username', 'image_url', 'locale',
     ];
 
     public function __construct(
-        private readonly VerificationManager $verifications,
         private readonly SessionLifecycle $lifecycle,
     ) {}
 
@@ -219,81 +212,6 @@ final class MeController
         return response()->json(null, 204);
     }
 
-    public function prepareEmailVerification(Request $request): JsonResponse
-    {
-        $session = app(Session::class);
-        if ($session->isImpersonation()) {
-            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot verify emails.');
-        }
-        $email = $this->loadEmail($request);
-        if ($email instanceof JsonResponse) {
-            return $email;
-        }
-
-        $strategy = (string) $request->input('strategy', '');
-        if ($strategy !== Verification::STRATEGY_EMAIL_CODE) {
-            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategy} is not enabled in v0.1.");
-        }
-
-        $verification = $this->verifications->start($email, Verification::STRATEGY_EMAIL_CODE, self::EMAIL_VERIFICATION_TTL);
-        $code = $this->verifications->mintNumericCode($verification, VerificationCode::PURPOSE_EMAIL_CODE, self::EMAIL_VERIFICATION_TTL);
-
-        SendVerificationEmail::dispatch(
-            $email->environment_id,
-            $email->email_address,
-            $code,
-            VerificationCode::PURPOSE_EMAIL_CODE,
-            $verification->id,
-            $email->id,
-        );
-
-        return $this->clientEnvelope(EmailAddressResource::from($email->fresh()));
-    }
-
-    public function attemptEmailVerification(Request $request): JsonResponse
-    {
-        $session = app(Session::class);
-        if ($session->isImpersonation()) {
-            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot verify emails.');
-        }
-        $email = $this->loadEmail($request);
-        if ($email instanceof JsonResponse) {
-            return $email;
-        }
-
-        $code = $request->input('code');
-        if (! is_string($code) || $code === '') {
-            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'code is required.');
-        }
-
-        $verification = Verification::query()
-            ->withoutGlobalScopes()
-            ->where('verifiable_type', $email->getMorphClass())
-            ->where('verifiable_id', $email->id)
-            ->where('status', Verification::STATUS_UNVERIFIED)
-            ->latest('id')
-            ->first();
-        if ($verification === null) {
-            return $this->error(422, ErrorCodes::NO_VERIFICATION_IN_PROGRESS, 'No verification is in progress for this email.');
-        }
-
-        $ok = $this->verifications->attempt($verification, $code);
-        if (! $ok) {
-            $fresh = $verification->fresh();
-            $errCode = $fresh->status === Verification::STATUS_FAILED
-                ? ErrorCodes::VERIFICATION_FAILED
-                : ($fresh->status === Verification::STATUS_EXPIRED
-                    ? ErrorCodes::VERIFICATION_EXPIRED
-                    : ErrorCodes::FORM_CODE_INCORRECT);
-
-            return $this->error(422, $errCode, 'Incorrect code.');
-        }
-
-        $email->forceFill(['verified_at' => now()])->save();
-
-        return $this->clientEnvelope(EmailAddressResource::from($email->fresh()));
-    }
-
     /* -------------------- sessions -------------------- */
 
     public function listSessions(): JsonResponse
@@ -354,7 +272,7 @@ final class MeController
 
     private function loadEmail(Request $request): EmailAddress|JsonResponse
     {
-        $eid = (string) $request->route('eid');
+        $eid = (string) $request->route('email_address_id');
         $user = app(User::class);
         $email = EmailAddress::query()
             ->withoutGlobalScopes()

--- a/app/Http/Resources/ChallengeResource.php
+++ b/app/Http/Resources/ChallengeResource.php
@@ -7,9 +7,9 @@ namespace App\Http\Resources;
 use App\Models\Challenge;
 
 /**
- * Mirrors openapi `Challenge.yaml`. The shape is uniform across sign-in
- * and sign-up parents — `sign_in_id` / `sign_up_id` are mutually exclusive
- * and exactly one is non-null.
+ * Mirrors openapi `Challenge.yaml`. Uniform across all parent types —
+ * exactly one of {sign_in_id, sign_up_id, email_address_id,
+ * organization_domain_id} is non-null per row.
  */
 final class ChallengeResource
 {
@@ -24,6 +24,8 @@ final class ChallengeResource
             'id' => $challenge->id,
             'sign_in_id' => $challenge->parent_type === Challenge::PARENT_SIGN_IN ? $challenge->parent_id : null,
             'sign_up_id' => $challenge->parent_type === Challenge::PARENT_SIGN_UP ? $challenge->parent_id : null,
+            'email_address_id' => $challenge->parent_type === Challenge::PARENT_EMAIL_ADDRESS ? $challenge->parent_id : null,
+            'organization_domain_id' => $challenge->parent_type === Challenge::PARENT_ORGANIZATION_DOMAIN ? $challenge->parent_id : null,
             'step' => $challenge->step,
             'strategy' => $challenge->strategy,
             'status' => $challenge->status,

--- a/app/Http/Resources/EmailAddressResource.php
+++ b/app/Http/Resources/EmailAddressResource.php
@@ -5,33 +5,17 @@ declare(strict_types=1);
 namespace App\Http\Resources;
 
 use App\Models\EmailAddress;
-use App\Models\Verification;
 
 final class EmailAddressResource
 {
     public static function from(EmailAddress $email): array
     {
-        $verification = Verification::query()
-            ->withoutGlobalScopes()
-            ->where('verifiable_type', $email->getMorphClass())
-            ->where('verifiable_id', $email->id)
-            ->latest('id')
-            ->first();
-
         return [
             'object' => 'email_address',
             'id' => $email->id,
             'email_address' => $email->email_address,
-            'verification' => $verification === null ? null : [
-                'status' => $verification->status,
-                'strategy' => $verification->strategy,
-                'attempts' => $verification->attempts,
-                'expire_at' => $verification->expire_at->getTimestampMs(),
-                'error' => $verification->error_code !== null ? [
-                    'code' => $verification->error_code,
-                    'message' => $verification->error_message,
-                ] : null,
-            ],
+            'verified' => $email->verified_at !== null,
+            'current_challenge_id' => $email->current_challenge_id,
             // Per OA-2: the spec exposes a uniform `linked_to` array for
             // OAuth / enterprise / passkey-bound emails (empty in v0.1).
             'linked_to' => $email->linked_to_external_account_id !== null

--- a/app/Http/Resources/OrganizationDomainResource.php
+++ b/app/Http/Resources/OrganizationDomainResource.php
@@ -5,16 +5,11 @@ declare(strict_types=1);
 namespace App\Http\Resources;
 
 use App\Models\OrganizationDomain;
-use App\Models\Verification;
 
 final class OrganizationDomainResource
 {
-    public static function from(OrganizationDomain $domain, ?Verification $verification = null): array
+    public static function from(OrganizationDomain $domain): array
     {
-        $verification ??= $domain->verification_id !== null
-            ? Verification::query()->withoutGlobalScopes()->where('id', $domain->verification_id)->first()
-            : null;
-
         return [
             'object' => 'organization_domain',
             'id' => $domain->id,
@@ -25,13 +20,7 @@ final class OrganizationDomainResource
             'affiliation_email_address' => $domain->affiliation_email_address,
             'total_pending_invitations' => (int) $domain->total_pending_invitations,
             'total_pending_suggestions' => (int) $domain->total_pending_suggestions,
-            'verification' => $verification !== null ? [
-                'status' => $verification->status,
-                'strategy' => $verification->strategy,
-                'attempts' => (int) $verification->attempts,
-                'expire_at' => $verification->expire_at?->getTimestampMs(),
-                'nonce' => $verification->nonce,
-            ] : null,
+            'current_challenge_id' => $domain->current_challenge_id,
             'created_at' => $domain->created_at?->getTimestampMs(),
             'updated_at' => $domain->updated_at?->getTimestampMs(),
         ];

--- a/app/Jobs/Maintenance/RecheckVerifiedDomains.php
+++ b/app/Jobs/Maintenance/RecheckVerifiedDomains.php
@@ -29,7 +29,6 @@ final class RecheckVerifiedDomains implements ShouldQueue
         OrganizationDomain::query()
             ->withoutGlobalScopes()
             ->where('verified', true)
-            ->whereNotNull('verification_id')
             ->orderBy('id')
             ->chunk(200, function ($domains): void {
                 foreach ($domains as $domain) {

--- a/app/Jobs/Organizations/VerifyOrganizationDomain.php
+++ b/app/Jobs/Organizations/VerifyOrganizationDomain.php
@@ -6,6 +6,7 @@ namespace App\Jobs\Organizations;
 
 use App\Events\Organizations\OrganizationDomainUpdated;
 use App\Events\Organizations\OrganizationDomainVerified;
+use App\Models\Challenge;
 use App\Models\OrganizationDomain;
 use App\Models\Verification;
 use App\Services\Domains\DnsTxtResolver;
@@ -62,12 +63,28 @@ final class VerifyOrganizationDomain implements ShouldQueue
         if ($domain === null) {
             return;
         }
-        $verification = $domain->verification_id !== null
-            ? Verification::query()->withoutGlobalScopes()->where('id', $domain->verification_id)->first()
-            : null;
-        if ($verification === null) {
+        // Live pending Challenge is the primary source. For an already-
+        // verified domain (recheck path), `current_challenge_id` is null
+        // once we cleared it on the verified flip — fall back to the most
+        // recent verified Challenge so we can read its nonce and demote on
+        // a missing TXT.
+        $challenge = $domain->current_challenge_id !== null
+            ? Challenge::query()->withoutGlobalScopes()->where('id', $domain->current_challenge_id)->first()
+            : Challenge::query()
+                ->withoutGlobalScopes()
+                ->where('parent_type', Challenge::PARENT_ORGANIZATION_DOMAIN)
+                ->where('parent_id', $domain->id)
+                ->where('strategy', Verification::STRATEGY_DOMAIN_DNS_TXT)
+                ->where('status', Challenge::STATUS_VERIFIED)
+                ->latest('id')
+                ->first();
+        if ($challenge === null) {
             Log::info('domain_verification_no_challenge', ['domain_id' => $domain->id]);
 
+            return;
+        }
+        $verification = Verification::query()->withoutGlobalScopes()->where('id', $challenge->verification_id)->first();
+        if ($verification === null) {
             return;
         }
 
@@ -87,22 +104,31 @@ final class VerifyOrganizationDomain implements ShouldQueue
         }
 
         if ($matched) {
-            $this->flipToVerified($domain, $verification);
+            $this->flipToVerified($domain, $challenge, $verification);
 
             return;
         }
 
-        $this->recordMiss($domain, $verification);
+        $this->recordMiss($domain, $challenge, $verification);
     }
 
-    private function flipToVerified(OrganizationDomain $domain, Verification $verification): void
+    private function flipToVerified(OrganizationDomain $domain, Challenge $challenge, Verification $verification): void
     {
         $wasVerified = (bool) $domain->verified;
         $verification->forceFill([
             'status' => Verification::STATUS_VERIFIED,
             'verified_at' => now(),
         ])->save();
-        $domain->forceFill(['verified' => true])->save();
+        $challenge->forceFill([
+            'status' => Challenge::STATUS_VERIFIED,
+            'attempts' => (int) $verification->attempts,
+            'error_code' => null,
+            'error_message' => null,
+        ])->save();
+        $domain->forceFill([
+            'verified' => true,
+            'current_challenge_id' => null,
+        ])->save();
 
         if (! $wasVerified) {
             OrganizationDomainVerified::dispatch($domain->fresh());
@@ -110,13 +136,14 @@ final class VerifyOrganizationDomain implements ShouldQueue
         OrganizationDomainUpdated::dispatch($domain->fresh());
     }
 
-    private function recordMiss(OrganizationDomain $domain, Verification $verification): void
+    private function recordMiss(OrganizationDomain $domain, Challenge $challenge, Verification $verification): void
     {
         $attempt = (int) $verification->attempts + 1;
         $verification->forceFill(['attempts' => $attempt])->save();
+        $challenge->forceFill(['attempts' => $attempt])->save();
 
         // If the domain was previously verified and the TXT record is gone,
-        // demote it. The org admin can `/verify` again to re-issue.
+        // demote it. The org admin can issue a new Challenge to re-verify.
         if ($domain->verified) {
             $domain->forceFill(['verified' => false])->save();
             OrganizationDomainUpdated::dispatch($domain->fresh());

--- a/app/Models/Challenge.php
+++ b/app/Models/Challenge.php
@@ -79,14 +79,22 @@ class Challenge extends Model
 
     public const PARENT_SIGN_UP = 'sign_up';
 
+    public const PARENT_EMAIL_ADDRESS = 'email_address';
+
+    public const PARENT_ORGANIZATION_DOMAIN = 'organization_domain';
+
     public const PARENT_TYPES = [
         self::PARENT_SIGN_IN,
         self::PARENT_SIGN_UP,
+        self::PARENT_EMAIL_ADDRESS,
+        self::PARENT_ORGANIZATION_DOMAIN,
     ];
 
     public const MORPH_MAP = [
         self::PARENT_SIGN_IN => SignInAttempt::class,
         self::PARENT_SIGN_UP => SignUpAttempt::class,
+        self::PARENT_EMAIL_ADDRESS => EmailAddress::class,
+        self::PARENT_ORGANIZATION_DOMAIN => OrganizationDomain::class,
     ];
 
     protected string $idPrefix = 'chal_';

--- a/app/Models/EmailAddress.php
+++ b/app/Models/EmailAddress.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Str;
  * @property ?\DateTimeInterface $verified_at
  * @property bool $is_primary
  * @property ?string $linked_to_external_account_id
+ * @property ?string $current_challenge_id
  */
 #[ObservedBy([EmailAddressObserver::class])]
 class EmailAddress extends Model
@@ -46,6 +47,7 @@ class EmailAddress extends Model
         'verified_at',
         'is_primary',
         'linked_to_external_account_id',
+        'current_challenge_id',
     ];
 
     protected function casts(): array

--- a/app/Models/OrganizationDomain.php
+++ b/app/Models/OrganizationDomain.php
@@ -17,7 +17,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $name
  * @property bool $verified
  * @property string $enrollment_mode
- * @property ?string $verification_id
+ * @property ?string $current_challenge_id
  * @property ?string $affiliation_email_address
  * @property int $total_pending_invitations
  * @property int $total_pending_suggestions
@@ -47,7 +47,7 @@ class OrganizationDomain extends Model
         'name',
         'verified',
         'enrollment_mode',
-        'verification_id',
+        'current_challenge_id',
         'affiliation_email_address',
         'total_pending_invitations',
         'total_pending_suggestions',
@@ -72,8 +72,8 @@ class OrganizationDomain extends Model
         return $this->belongsTo(Organization::class);
     }
 
-    public function verification(): BelongsTo
+    public function currentChallenge(): BelongsTo
     {
-        return $this->belongsTo(Verification::class);
+        return $this->belongsTo(Challenge::class, 'current_challenge_id');
     }
 }

--- a/database/migrations/0004_01_01_000000_expand_users_and_create_email_verifications.php
+++ b/database/migrations/0004_01_01_000000_expand_users_and_create_email_verifications.php
@@ -30,6 +30,11 @@ return new class extends Migration
             $table->timestamp('verified_at')->nullable();
             $table->boolean('is_primary')->default(false);
             $table->string('linked_to_external_account_id', 64)->nullable();
+            // Live Challenge (email_code / email_link) the SDK is currently
+            // polling. Cleared once the Challenge leaves `pending`. FK is
+            // wired in the back-fill pass below — challenges table doesn't
+            // exist yet.
+            $table->string('current_challenge_id', 64)->nullable();
             $table->timestamps();
 
             $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();

--- a/database/migrations/0005_01_01_000000_create_flow_state_models.php
+++ b/database/migrations/0005_01_01_000000_create_flow_state_models.php
@@ -128,10 +128,10 @@ return new class extends Migration
             $table->string('id', 64)->primary();
             $table->string('environment_id', 64);
 
-            // Polymorphic parent: 'sign_in' | 'sign_up'. The parent_id points
-            // at sign_in_attempts.id or sign_up_attempts.id; no DB-level FK
-            // because the type column disambiguates the target table.
-            $table->string('parent_type', 16);
+            // Polymorphic parent: 'sign_in' | 'sign_up' | 'email_address' |
+            // 'organization_domain'. The parent_id points at the matching
+            // table; no DB-level FK because the type column disambiguates.
+            $table->string('parent_type', 32);
             $table->string('parent_id', 64);
 
             $table->string('step', 16);
@@ -159,6 +159,10 @@ return new class extends Migration
         });
 
         Schema::table('sign_up_attempts', function (Blueprint $table): void {
+            $table->foreign('current_challenge_id')->references('id')->on('challenges')->nullOnDelete();
+        });
+
+        Schema::table('email_addresses', function (Blueprint $table): void {
             $table->foreign('current_challenge_id')->references('id')->on('challenges')->nullOnDelete();
         });
 
@@ -233,6 +237,9 @@ return new class extends Migration
 
     public function down(): void
     {
+        Schema::table('email_addresses', function (Blueprint $table): void {
+            $table->dropForeign(['current_challenge_id']);
+        });
         Schema::table('sign_up_attempts', function (Blueprint $table): void {
             $table->dropForeign(['created_session_id']);
             $table->dropForeign(['current_challenge_id']);

--- a/database/migrations/0012_01_01_000006_create_organization_domains.php
+++ b/database/migrations/0012_01_01_000006_create_organization_domains.php
@@ -15,7 +15,9 @@ return new class extends Migration
             $table->string('name');
             $table->boolean('verified')->default(false);
             $table->string('enrollment_mode', 32)->default('manual_invitation');
-            $table->string('verification_id', 64)->nullable();
+            // Live domain_dns_txt Challenge the operator is currently being
+            // asked to satisfy. Cleared once verified or re-issued.
+            $table->string('current_challenge_id', 64)->nullable();
             $table->string('affiliation_email_address')->nullable();
             $table->unsignedInteger('total_pending_invitations')->default(0);
             $table->unsignedInteger('total_pending_suggestions')->default(0);
@@ -23,7 +25,7 @@ return new class extends Migration
 
             $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
             $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
-            $table->foreign('verification_id')->references('id')->on('verifications')->nullOnDelete();
+            $table->foreign('current_challenge_id')->references('id')->on('challenges')->nullOnDelete();
 
             $table->unique(['environment_id', 'name']);
             $table->index(['organization_id', 'verified']);

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Bapi\BlocklistIdentifiersController;
 use App\Http\Controllers\Bapi\InstanceController;
 use App\Http\Controllers\Bapi\InvitationsController;
 use App\Http\Controllers\Bapi\OrganizationController;
+use App\Http\Controllers\Bapi\OrganizationDomainChallengeController;
 use App\Http\Controllers\Bapi\OrganizationDomainController;
 use App\Http\Controllers\Bapi\OrganizationInvitationController;
 use App\Http\Controllers\Bapi\OrganizationMembershipController;
@@ -115,7 +116,10 @@ Route::post('/organizations/{organization_id}/domains', [OrganizationDomainContr
 Route::get('/organizations/{organization_id}/domains/{domain_id}', [OrganizationDomainController::class, 'show'])->middleware(RateLimit::class.':orgs.domains.read,300,60')->name('bapi.organizations.domains.show');
 Route::patch('/organizations/{organization_id}/domains/{domain_id}', [OrganizationDomainController::class, 'update'])->middleware(RateLimit::class.':orgs.domains.update,60,60')->name('bapi.organizations.domains.update');
 Route::delete('/organizations/{organization_id}/domains/{domain_id}', [OrganizationDomainController::class, 'destroy'])->middleware(RateLimit::class.':orgs.domains.destroy,30,60')->name('bapi.organizations.domains.destroy');
-Route::post('/organizations/{organization_id}/domains/{domain_id}/verify', [OrganizationDomainController::class, 'verify'])->middleware(RateLimit::class.':orgs.domains.verify,30,60')->name('bapi.organizations.domains.verify');
+
+Route::post('/organizations/{organization_id}/domains/{domain_id}/challenges', [OrganizationDomainChallengeController::class, 'store'])->middleware(RateLimit::class.':orgs.domains.verify,30,60')->name('bapi.organizations.domains.challenges.store');
+Route::post('/organizations/{organization_id}/domains/{domain_id}/challenges/{cid}/answer', [OrganizationDomainChallengeController::class, 'answer'])->middleware(RateLimit::class.':orgs.domains.verify,30,60')->name('bapi.organizations.domains.challenges.answer');
+Route::get('/organizations/{organization_id}/domains/{domain_id}/challenges/{cid}', [OrganizationDomainChallengeController::class, 'show'])->middleware(RateLimit::class.':orgs.domains.read,300,60')->name('bapi.organizations.domains.challenges.show');
 
 // Roles + Permissions
 Route::get('/roles', [RoleController::class, 'index'])->middleware(RateLimit::class.':roles.list,300,60')->name('bapi.roles.index');

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -106,11 +106,13 @@ Route::prefix('v1')->group(function (): void {
 
         Route::get('/me/email-addresses', [MeController::class, 'listEmails'])->name('fapi.me.emails.list');
         Route::post('/me/email-addresses', [MeController::class, 'createEmail'])->name('fapi.me.emails.create');
-        Route::get('/me/email-addresses/{eid}', [MeController::class, 'showEmail'])->name('fapi.me.emails.show');
-        Route::patch('/me/email-addresses/{eid}', [MeController::class, 'updateEmail'])->name('fapi.me.emails.update');
-        Route::delete('/me/email-addresses/{eid}', [MeController::class, 'deleteEmail'])->name('fapi.me.emails.destroy');
-        Route::post('/me/email-addresses/{eid}/prepare-verification', [MeController::class, 'prepareEmailVerification'])->name('fapi.me.emails.prepare_verification');
-        Route::post('/me/email-addresses/{eid}/attempt-verification', [MeController::class, 'attemptEmailVerification'])->name('fapi.me.emails.attempt_verification');
+        Route::get('/me/email-addresses/{email_address_id}', [MeController::class, 'showEmail'])->name('fapi.me.emails.show');
+        Route::patch('/me/email-addresses/{email_address_id}', [MeController::class, 'updateEmail'])->name('fapi.me.emails.update');
+        Route::delete('/me/email-addresses/{email_address_id}', [MeController::class, 'deleteEmail'])->name('fapi.me.emails.destroy');
+
+        Route::post('/me/email-addresses/{email_address_id}/challenges', [ChallengeController::class, 'storeForEmailAddress'])->name('fapi.me.emails.challenges.store');
+        Route::post('/me/email-addresses/{email_address_id}/challenges/{cid}/answer', [ChallengeController::class, 'answerForEmailAddress'])->name('fapi.me.emails.challenges.answer');
+        Route::get('/me/email-addresses/{email_address_id}/challenges/{cid}', [ChallengeController::class, 'showForEmailAddress'])->name('fapi.me.emails.challenges.show');
 
         Route::get('/me/sessions', [MeController::class, 'listSessions'])->name('fapi.me.sessions.list');
         Route::post('/me/change-password', [MeController::class, 'changePassword'])->name('fapi.me.change_password');

--- a/tests/Feature/Http/Bapi/OrganizationDomainsTest.php
+++ b/tests/Feature/Http/Bapi/OrganizationDomainsTest.php
@@ -6,9 +6,11 @@ use App\Events\Organizations\OrganizationDomainCreated;
 use App\Events\Organizations\OrganizationDomainDeleted;
 use App\Events\Organizations\OrganizationDomainUpdated;
 use App\Jobs\Organizations\VerifyOrganizationDomain;
+use App\Models\Challenge;
 use App\Models\Environment;
 use App\Models\OrganizationDomain;
 use App\Models\Verification;
+use App\Services\Domains\DnsTxtResolver;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
 use Tests\Feature\Http\Bapi\BapiTestSupport;
@@ -30,7 +32,7 @@ function setupOrgForDomains(TestCase $testCase): array
     ];
 }
 
-it('POST /domains creates a domain, mints a domain_dns_txt Verification, fires the event', function (): void {
+it('POST /domains creates a domain row and fires the event; no challenge minted on create', function (): void {
     Event::fake([OrganizationDomainCreated::class]);
     $ctx = setupOrgForDomains($this);
 
@@ -44,13 +46,9 @@ it('POST /domains creates a domain, mints a domain_dns_txt Verification, fires t
         ->assertJsonPath('name', 'acme.test')
         ->assertJsonPath('enrollment_mode', 'automatic_invitation')
         ->assertJsonPath('verified', false)
-        ->assertJsonPath('verification.strategy', 'domain_dns_txt')
-        ->assertJsonPath('verification.status', 'unverified');
+        ->assertJsonPath('current_challenge_id', null);
     expect($r->json('id'))->toStartWith('orgdom_');
-    expect($r->json('verification.nonce'))->toStartWith('authn-domain-verify=');
-
-    $nonce = $r->json('verification.nonce');
-    expect(Verification::query()->withoutGlobalScopes()->where('nonce', $nonce)->exists())->toBeTrue();
+    expect($r->json())->not->toHaveKey('verification');
 
     Event::assertDispatched(OrganizationDomainCreated::class, 1);
 });
@@ -75,13 +73,16 @@ it('GET /domains lists rows scoped to the org', function (): void {
     $r->assertOk()->assertJsonPath('total_count', 2);
 });
 
-it('GET /domains/{id} returns the verification block', function (): void {
+it('GET /domains/{id} returns the domain without a nested verification block', function (): void {
     $ctx = setupOrgForDomains($this);
     $created = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'show.test']);
     $id = $created->json('id');
 
     $r = $this->withHeaders($ctx['headers'])->getJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}"));
-    $r->assertOk()->assertJsonPath('verification.strategy', 'domain_dns_txt');
+    $r->assertOk()
+        ->assertJsonPath('id', $id)
+        ->assertJsonPath('current_challenge_id', null);
+    expect($r->json())->not->toHaveKey('verification');
 });
 
 it('PATCH /domains/{id} updates enrollment_mode and fires the event', function (): void {
@@ -98,18 +99,93 @@ it('PATCH /domains/{id} updates enrollment_mode and fires the event', function (
     Event::assertDispatched(OrganizationDomainUpdated::class, 1);
 });
 
-it('POST /domains/{id}/verify re-issues a fresh Verification with a new nonce', function (): void {
-    Bus::fake([VerifyOrganizationDomain::class]);
+it('POST /domains/{id}/challenges mints a domain_dns_txt Challenge with a fresh nonce and points current_challenge_id at it', function (): void {
     $ctx = setupOrgForDomains($this);
     $created = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'verify.test']);
     $id = $created->json('id');
-    $firstNonce = $created->json('verification.nonce');
 
-    $r = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}/verify"));
-    $r->assertOk();
-    expect($r->json('verification.nonce'))->not->toBe($firstNonce);
-    expect($r->json('verification.strategy'))->toBe('domain_dns_txt');
-    Bus::assertDispatched(VerifyOrganizationDomain::class, 1);
+    $r = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}/challenges"));
+    $r->assertStatus(201)
+        ->assertJsonPath('object', 'challenge')
+        ->assertJsonPath('strategy', 'domain_dns_txt')
+        ->assertJsonPath('status', 'pending')
+        ->assertJsonPath('organization_domain_id', $id);
+    expect($r->json('id'))->toStartWith('chal_');
+    expect($r->json('nonce'))->toStartWith('authn-domain-verify=');
+
+    $cid = $r->json('id');
+    expect(OrganizationDomain::query()->withoutGlobalScopes()->where('id', $id)->first()->current_challenge_id)->toBe($cid);
+});
+
+it('POST /domains/{id}/challenges/{cid}/answer flips the domain on a matching TXT and fires OrganizationDomainVerified', function (): void {
+    Bus::fake([VerifyOrganizationDomain::class]);
+    $ctx = setupOrgForDomains($this);
+    $created = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'answer.test']);
+    $id = $created->json('id');
+    $challenge = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}/challenges"));
+    $cid = $challenge->json('id');
+    $nonce = $challenge->json('nonce');
+
+    $resolver = new class extends DnsTxtResolver
+    {
+        public string $nonce = '';
+
+        public function resolve(string $host): array
+        {
+            return $host === '_authn-verification.answer.test' ? [$this->nonce] : [];
+        }
+    };
+    $resolver->nonce = $nonce;
+    app()->instance(DnsTxtResolver::class, $resolver);
+
+    $r = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}/challenges/{$cid}/answer"));
+    $r->assertOk()
+        ->assertJsonPath('object', 'challenge')
+        ->assertJsonPath('status', 'verified');
+
+    $domain = OrganizationDomain::query()->withoutGlobalScopes()->where('id', $id)->first();
+    expect($domain->verified)->toBeTrue();
+    expect($domain->current_challenge_id)->toBeNull();
+    expect(Verification::query()->withoutGlobalScopes()->where('id', Challenge::query()->withoutGlobalScopes()->where('id', $cid)->first()->verification_id)->first()->status)->toBe('verified');
+});
+
+it('POST /domains/{id}/challenges/{cid}/answer leaves status pending on a TXT miss and increments attempts', function (): void {
+    Bus::fake([VerifyOrganizationDomain::class]);
+    $ctx = setupOrgForDomains($this);
+    $created = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'miss.test']);
+    $id = $created->json('id');
+    $challenge = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}/challenges"));
+    $cid = $challenge->json('id');
+
+    $resolver = new class extends DnsTxtResolver
+    {
+        public function resolve(string $host): array
+        {
+            return [];
+        }
+    };
+    app()->instance(DnsTxtResolver::class, $resolver);
+
+    $r = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}/challenges/{$cid}/answer"));
+    $r->assertOk()
+        ->assertJsonPath('status', 'pending')
+        ->assertJsonPath('attempts', 1);
+
+    expect(OrganizationDomain::query()->withoutGlobalScopes()->where('id', $id)->first()->verified)->toBeFalse();
+});
+
+it('GET /domains/{id}/challenges/{cid} polls the challenge state', function (): void {
+    $ctx = setupOrgForDomains($this);
+    $created = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains"), ['name' => 'poll.test']);
+    $id = $created->json('id');
+    $challenge = $this->withHeaders($ctx['headers'])->postJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}/challenges"));
+    $cid = $challenge->json('id');
+
+    $r = $this->withHeaders($ctx['headers'])->getJson(BapiTestSupport::url("/organizations/{$ctx['org_id']}/domains/{$id}/challenges/{$cid}"));
+    $r->assertOk()
+        ->assertJsonPath('id', $cid)
+        ->assertJsonPath('strategy', 'domain_dns_txt')
+        ->assertJsonPath('status', 'pending');
 });
 
 it('DELETE /domains/{id} removes the row and fires the event', function (): void {

--- a/tests/Feature/Http/Me/MeEndpointsTest.php
+++ b/tests/Feature/Http/Me/MeEndpointsTest.php
@@ -63,11 +63,11 @@ it('POST /v1/me/email-addresses creates an unverified row; verifies via Challeng
         'strategy' => 'email_code',
     ]);
     $challenge->assertOk()
-        ->assertJsonPath('object', 'challenge')
-        ->assertJsonPath('strategy', 'email_code')
-        ->assertJsonPath('status', 'pending')
-        ->assertJsonPath('email_address_id', $eid);
-    $cid = $challenge->json('id');
+        ->assertJsonPath('response.object', 'challenge')
+        ->assertJsonPath('response.strategy', 'email_code')
+        ->assertJsonPath('response.status', 'pending')
+        ->assertJsonPath('response.email_address_id', $eid);
+    $cid = $challenge->json('response.id');
 
     // Stamp a known code on the verification row.
     $verification = Verification::query()->withoutGlobalScopes()->latest('id')->first();
@@ -78,8 +78,8 @@ it('POST /v1/me/email-addresses creates an unverified row; verifies via Challeng
     meReq('POST', "/me/email-addresses/{$eid}/challenges/{$cid}/answer", $auth['jwt'], [
         'code' => $known,
     ])->assertOk()
-        ->assertJsonPath('object', 'challenge')
-        ->assertJsonPath('status', 'verified');
+        ->assertJsonPath('response.object', 'challenge')
+        ->assertJsonPath('response.status', 'verified');
 
     expect(EmailAddress::query()->withoutGlobalScopes()->where('id', $eid)->first()->isVerified())->toBeTrue();
 });

--- a/tests/Feature/Http/Me/MeEndpointsTest.php
+++ b/tests/Feature/Http/Me/MeEndpointsTest.php
@@ -48,19 +48,26 @@ it('PATCH /v1/me updates writable fields and ignores unknown', function (): void
         ->assertJsonPath('client.object', 'client');
 });
 
-it('POST /v1/me/email-addresses creates an unverified row; verifies via prepare + attempt', function (): void {
+it('POST /v1/me/email-addresses creates an unverified row; verifies via Challenge sub-resource', function (): void {
     $f = MeTestSupport::bootEnv();
     $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
 
     $created = meReq('POST', '/me/email-addresses', $auth['jwt'], ['email_address' => 'alt@example.com']);
     $created->assertOk()
         ->assertJsonPath('response.email_address', 'alt@example.com')
-        ->assertJsonPath('response.verification', null);
+        ->assertJsonPath('response.verified', false)
+        ->assertJsonPath('response.current_challenge_id', null);
     $eid = $created->json('response.id');
 
-    meReq('POST', "/me/email-addresses/{$eid}/prepare-verification", $auth['jwt'], [
+    $challenge = meReq('POST', "/me/email-addresses/{$eid}/challenges", $auth['jwt'], [
         'strategy' => 'email_code',
-    ])->assertOk();
+    ]);
+    $challenge->assertOk()
+        ->assertJsonPath('object', 'challenge')
+        ->assertJsonPath('strategy', 'email_code')
+        ->assertJsonPath('status', 'pending')
+        ->assertJsonPath('email_address_id', $eid);
+    $cid = $challenge->json('id');
 
     // Stamp a known code on the verification row.
     $verification = Verification::query()->withoutGlobalScopes()->latest('id')->first();
@@ -68,10 +75,11 @@ it('POST /v1/me/email-addresses creates an unverified row; verifies via prepare 
     $known = '424242';
     $codeRow->forceFill(['code_hash' => hash('sha256', $known)])->save();
 
-    meReq('POST', "/me/email-addresses/{$eid}/attempt-verification", $auth['jwt'], [
-        'strategy' => 'email_code',
+    meReq('POST', "/me/email-addresses/{$eid}/challenges/{$cid}/answer", $auth['jwt'], [
         'code' => $known,
-    ])->assertOk()->assertJsonPath('response.verification.status', 'verified');
+    ])->assertOk()
+        ->assertJsonPath('object', 'challenge')
+        ->assertJsonPath('status', 'verified');
 
     expect(EmailAddress::query()->withoutGlobalScopes()->where('id', $eid)->first()->isVerified())->toBeTrue();
 });

--- a/tests/Feature/Jobs/Organizations/VerifyOrganizationDomainTest.php
+++ b/tests/Feature/Jobs/Organizations/VerifyOrganizationDomainTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Events\Organizations\OrganizationDomainVerified;
 use App\Jobs\Organizations\VerifyOrganizationDomain;
+use App\Models\Challenge;
 use App\Models\Environment;
 use App\Models\Organization;
 use App\Models\OrganizationDomain;
@@ -57,9 +58,41 @@ function makeUnverifiedDomain(Environment $env, string $name = 'acme.test', stri
         'expire_at' => now()->addDays(14),
         'nonce' => 'authn-domain-verify=fixture-nonce-1234',
     ]);
-    $domain->forceFill(['verification_id' => $verification->id])->save();
+    $challenge = Challenge::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'parent_type' => Challenge::PARENT_ORGANIZATION_DOMAIN,
+        'parent_id' => $domain->id,
+        'step' => Challenge::STEP_SINGLE,
+        'strategy' => Verification::STRATEGY_DOMAIN_DNS_TXT,
+        'status' => Challenge::STATUS_PENDING,
+        'verification_id' => $verification->id,
+        'attempts' => 0,
+        'nonce' => $verification->nonce,
+        'expire_at' => $verification->expire_at,
+    ]);
+    $domain->forceFill(['current_challenge_id' => $challenge->id])->save();
 
     return $domain->fresh();
+}
+
+function challengeFor(OrganizationDomain $domain): ?Challenge
+{
+    return Challenge::query()
+        ->withoutGlobalScopes()
+        ->where('parent_type', Challenge::PARENT_ORGANIZATION_DOMAIN)
+        ->where('parent_id', $domain->id)
+        ->latest('id')
+        ->first();
+}
+
+function verificationForDomain(OrganizationDomain $domain): Verification
+{
+    return Verification::query()
+        ->withoutGlobalScopes()
+        ->where('verifiable_type', $domain->getMorphClass())
+        ->where('verifiable_id', $domain->id)
+        ->latest('id')
+        ->firstOrFail();
 }
 
 it('flips a domain to verified when the TXT record matches and fires OrganizationDomainVerified', function (): void {
@@ -75,8 +108,9 @@ it('flips a domain to verified when the TXT record matches and fires Organizatio
 
     $fresh = $domain->fresh();
     expect($fresh->verified)->toBeTrue();
-    $verification = Verification::query()->withoutGlobalScopes()->where('id', $fresh->verification_id)->firstOrFail();
-    expect($verification->status)->toBe('verified');
+    expect($fresh->current_challenge_id)->toBeNull();
+    expect(verificationForDomain($fresh)->status)->toBe('verified');
+    expect(challengeFor($fresh)->status)->toBe(Challenge::STATUS_VERIFIED);
     Event::assertDispatched(OrganizationDomainVerified::class, 1);
 });
 
@@ -86,15 +120,15 @@ it('records a miss without flipping verified, increments attempts, re-enqueues',
     $domain = makeUnverifiedDomain($f['env']);
 
     $resolver = new FakeDnsTxtResolver;
-    // No matching TXT record present.
     app()->instance(DnsTxtResolver::class, $resolver);
 
     (new VerifyOrganizationDomain($domain->id))->handle($resolver);
 
-    $verification = Verification::query()->withoutGlobalScopes()->where('id', $domain->verification_id)->firstOrFail();
+    $verification = verificationForDomain($domain);
     expect($verification->status)->toBe('unverified');
     expect((int) $verification->attempts)->toBe(1);
     expect($domain->fresh()->verified)->toBeFalse();
+    expect((int) challengeFor($domain)->attempts)->toBe(1);
     Bus::assertDispatched(VerifyOrganizationDomain::class, 1);
 });
 
@@ -102,15 +136,14 @@ it('demotes a previously-verified domain when the TXT record disappears', functi
     Bus::fake([VerifyOrganizationDomain::class]);
     $f = bootDomainEnv();
     $domain = makeUnverifiedDomain($f['env']);
-    // Simulate already verified.
-    $domain->forceFill(['verified' => true])->save();
-    Verification::query()->withoutGlobalScopes()->where('id', $domain->verification_id)->update([
-        'status' => 'verified',
-        'verified_at' => now(),
-    ]);
+    // Simulate already verified — current_challenge_id cleared, challenge marked verified.
+    $verification = verificationForDomain($domain);
+    $verification->forceFill(['status' => 'verified', 'verified_at' => now()])->save();
+    $challenge = challengeFor($domain);
+    $challenge->forceFill(['status' => Challenge::STATUS_VERIFIED])->save();
+    $domain->forceFill(['verified' => true, 'current_challenge_id' => null])->save();
 
     $resolver = new FakeDnsTxtResolver;
-    // Record gone.
     app()->instance(DnsTxtResolver::class, $resolver);
 
     (new VerifyOrganizationDomain($domain->id))->handle($resolver);
@@ -122,9 +155,7 @@ it('stops re-enqueueing after MAX_ATTEMPTS', function (): void {
     Bus::fake([VerifyOrganizationDomain::class]);
     $f = bootDomainEnv();
     $domain = makeUnverifiedDomain($f['env']);
-    Verification::query()->withoutGlobalScopes()->where('id', $domain->verification_id)->update([
-        'attempts' => VerifyOrganizationDomain::MAX_ATTEMPTS - 1,
-    ]);
+    verificationForDomain($domain)->forceFill(['attempts' => VerifyOrganizationDomain::MAX_ATTEMPTS - 1])->save();
 
     $resolver = new FakeDnsTxtResolver;
     app()->instance(DnsTxtResolver::class, $resolver);


### PR DESCRIPTION
## Summary

Generalizes the Challenge sub-resource so the same shape that drives sign-in / sign-up factor flows now also drives:

- **FAPI** email-address verification (`/v1/me/email-addresses/{email_address_id}/challenges`), strategies `email_code` and `email_link`.
- **BAPI** organization-domain DNS-TXT verification (`/v1/organizations/{org}/domains/{did}/challenges`), strategy `domain_dns_txt`.

Replaces (alpha — no compat shims):

- `POST /v1/me/email-addresses/{id}/prepare-verification`
- `POST /v1/me/email-addresses/{id}/attempt-verification`
- `POST /v1/organizations/{org}/domains/{id}/verify`

The nested `verification` blob on `EmailAddressResource` and `OrganizationDomainResource` is gone — both resources now expose a flat `verified` flag (where applicable) plus `current_challenge_id`.

## What changed

- `challenges.parent_type` widened to `varchar(32)` to fit `organization_domain`.
- `Challenge` model gains `PARENT_EMAIL_ADDRESS` + `PARENT_ORGANIZATION_DOMAIN` and a `MORPH_MAP` entry for each.
- `email_addresses` + `organization_domains` get nullable `current_challenge_id` FK columns. `organization_domains.verification_id` is dropped.
- `ChallengeResource` adds mutually-exclusive `email_address_id` / `organization_domain_id` fields.
- FAPI `ChallengeController` extends with `storeForEmailAddress` / `answerForEmailAddress` / `showForEmailAddress`. Inline-answer-on-create is supported for `email_code` (`{strategy: "email_code", code}` in one round trip). GET on a terminal challenge returns 200 + body. Magic-link (`email_link`) verification flips out-of-band via the existing click handler; the SDK polls the Challenge to observe the final state.
- New BAPI `OrganizationDomainChallengeController` mints the nonce, exposes it as `Challenge.nonce`, runs the DnsTxtResolver synchronously on `answer`, dispatches the existing `VerifyOrganizationDomain` job for ongoing background polling, and fires `OrganizationDomainVerified` on the verified flip.
- `VerifyOrganizationDomain` switched from `domain.verification_id` to `domain.current_challenge_id`, with a fallback to the latest verified challenge so the recheck-of-verified path still works after `current_challenge_id` is cleared.

## Test plan

- [x] `php artisan test --parallel` — 457 passed (1520 assertions)
- [x] `./vendor/bin/pint --test` — passed
- [x] OpenAPI contract validator (auto-applied in feature tests) clean
- [x] Email-address Challenge end-to-end via the new endpoints
- [x] Domain Challenge end-to-end (nonce → match → verified flip → event fires)
- [x] Domain Challenge miss path (attempts increment, status stays pending)
- [x] Recheck path: previously-verified domain demoted when TXT disappears