### PR TITLE
Bump SDK packages to 0.2.0-alpha.2 / 1.0.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
     "packages": {
         "": {
             "dependencies": {
-                "@authn-sh/sdk-js": "0.2.0-alpha.1",
-                "@authn-sh/sdk-react": "1.0.0-alpha.1",
-                "@authn-sh/types": "0.2.0-alpha.1",
+                "@authn-sh/sdk-js": "0.2.0-alpha.2",
+                "@authn-sh/sdk-react": "1.0.0-alpha.2",
+                "@authn-sh/types": "0.2.0-alpha.2",
                 "@authn-sh/ui": "0.2.0-alpha.0"
             },
             "devDependencies": {
@@ -28,27 +28,27 @@
             }
         },
         "node_modules/@authn-sh/sdk-js": {
-            "version": "0.2.0-alpha.1",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.2.0-alpha.1.tgz",
-            "integrity": "sha512-F6ENqAUZrejWNsCQuN4y3fSFWaQbtQx3RD+OTzv5yyrbm2I0TfRn4rqjHo0+0JjMTgJr3HqELYCtmv/Bb3f/rA==",
+            "version": "0.2.0-alpha.2",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.2.0-alpha.2.tgz",
+            "integrity": "sha512-W9qhotnYOXTxd4EeCh9h9saK47qnokYcH0Me9mQxvItf6F/GE0iulrGFMQTt7vVrUK2i6aHtIJcNHE9KNR06zQ==",
             "license": "AGPL-3.0-only"
         },
         "node_modules/@authn-sh/sdk-react": {
-            "version": "1.0.0-alpha.1",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-1.0.0-alpha.1.tgz",
-            "integrity": "sha512-kxrvHS35MC4hZWxq1jaDGn7uQ3QGy7BQJMZv6tGeUCgiZhwupgE0i6VnGfwthJG9PRi7R9BoVltBgK2A8kD/Rg==",
+            "version": "1.0.0-alpha.2",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-1.0.0-alpha.2.tgz",
+            "integrity": "sha512-V2Mt4YXfNLrt15242DsJOfekU0hNroh0eEPc2skufIfxapQmVfwfCJuXrtW5w/zeinfb/MJVMRGaXWl7lbg7Jw==",
             "license": "AGPL-3.0-only",
             "peerDependencies": {
-                "@authn-sh/sdk-js": "0.2.0-alpha.1",
+                "@authn-sh/sdk-js": "0.2.0-alpha.2",
                 "@authn-sh/ui": "0.2.0-alpha.0",
                 "react": "^18 || ^19",
                 "react-dom": "^18 || ^19"
             }
         },
         "node_modules/@authn-sh/types": {
-            "version": "0.2.0-alpha.1",
-            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.2.0-alpha.1.tgz",
-            "integrity": "sha512-1vV18Gc2Tc3lWu0WF/C+YIn7joN3P+gf7pBUANZVIAFlZjvrvT9GrNkN6SByXlq3HCorL1G3I4r/RJWMpXt11w==",
+            "version": "0.2.0-alpha.2",
+            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.2.0-alpha.2.tgz",
+            "integrity": "sha512-HuWPhTMfdaQ+0B9ai6S8HRynovXxTIc9EeeKEdj7vNPSRvI75UUMlgBZrxbgv2powHZ+VcGyQMKqft+IzHLMZw==",
             "license": "AGPL-3.0-only"
         },
         "node_modules/@authn-sh/ui": {

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
         "vite": "^8.0.0"
     },
     "dependencies": {
-        "@authn-sh/sdk-js": "0.2.0-alpha.1",
-        "@authn-sh/sdk-react": "1.0.0-alpha.1",
-        "@authn-sh/types": "0.2.0-alpha.1",
+        "@authn-sh/sdk-js": "0.2.0-alpha.2",
+        "@authn-sh/sdk-react": "1.0.0-alpha.2",
+        "@authn-sh/types": "0.2.0-alpha.2",
         "@authn-sh/ui": "0.2.0-alpha.0"
     }
 }


### PR DESCRIPTION
Picks up the email-address + organization-domain Challenge generalization from authn-sh/javascript#32. Required so the bundled Account Portal + Dashboard hit the new `/me/email-addresses/{id}/challenges` and `/organizations/{org}/domains/{did}/challenges` endpoints instead of the deleted `/prepare-verification` / `/attempt-verification` / `/verify` ones.