### PR TITLE
Bump @authn-sh/* to 0.2.0-alpha.3 (email/domain Challenge generalization)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,10 @@
     "packages": {
         "": {
             "dependencies": {
-                "@authn-sh/sdk-js": "0.2.0-alpha.1",
-                "@authn-sh/sdk-react": "1.0.0-alpha.1",
-                "@authn-sh/types": "0.2.0-alpha.1",
-                "@authn-sh/ui": "0.2.0-alpha.0"
+                "@authn-sh/sdk-js": "0.2.0-alpha.3",
+                "@authn-sh/sdk-react": "0.2.0-alpha.3",
+                "@authn-sh/types": "0.2.0-alpha.3",
+                "@authn-sh/ui": "0.2.0-alpha.3"
             },
             "devDependencies": {
                 "@inertiajs/react": "^3.0.3",
@@ -28,33 +28,33 @@
             }
         },
         "node_modules/@authn-sh/sdk-js": {
-            "version": "0.2.0-alpha.1",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.2.0-alpha.1.tgz",
-            "integrity": "sha512-F6ENqAUZrejWNsCQuN4y3fSFWaQbtQx3RD+OTzv5yyrbm2I0TfRn4rqjHo0+0JjMTgJr3HqELYCtmv/Bb3f/rA==",
+            "version": "0.2.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.2.0-alpha.3.tgz",
+            "integrity": "sha512-v9+QHSxqS6YhOTKI8+kNVKpAHz1YW5d2clYIawgCiF4N+RS3MJCxa01YmnA0LBX65mjCcA4i4M7r/gfChjzcKg==",
             "license": "AGPL-3.0-only"
         },
         "node_modules/@authn-sh/sdk-react": {
-            "version": "1.0.0-alpha.1",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-1.0.0-alpha.1.tgz",
-            "integrity": "sha512-kxrvHS35MC4hZWxq1jaDGn7uQ3QGy7BQJMZv6tGeUCgiZhwupgE0i6VnGfwthJG9PRi7R9BoVltBgK2A8kD/Rg==",
+            "version": "0.2.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-0.2.0-alpha.3.tgz",
+            "integrity": "sha512-4UBQ3dLCoNOOVWAUW+m45H76BjOCB5LmJ8uX+NLyPUt5aH13o6GONCYz/XuEEvceZ0ae0+5qx2ADRX67z91gLA==",
             "license": "AGPL-3.0-only",
             "peerDependencies": {
-                "@authn-sh/sdk-js": "0.2.0-alpha.1",
-                "@authn-sh/ui": "0.2.0-alpha.0",
+                "@authn-sh/sdk-js": "0.2.0-alpha.3",
+                "@authn-sh/ui": "0.2.0-alpha.3",
                 "react": "^18 || ^19",
                 "react-dom": "^18 || ^19"
             }
         },
         "node_modules/@authn-sh/types": {
-            "version": "0.2.0-alpha.1",
-            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.2.0-alpha.1.tgz",
-            "integrity": "sha512-1vV18Gc2Tc3lWu0WF/C+YIn7joN3P+gf7pBUANZVIAFlZjvrvT9GrNkN6SByXlq3HCorL1G3I4r/RJWMpXt11w==",
+            "version": "0.2.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.2.0-alpha.3.tgz",
+            "integrity": "sha512-qTvJfnbzByld87GeB9aLJD9GfdMmCo4/B4LIXrFlWAWBynw8hzWlIelafTScUx4izNDj5kKpdPVW54TqVcaJIg==",
             "license": "AGPL-3.0-only"
         },
         "node_modules/@authn-sh/ui": {
-            "version": "0.2.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/ui/-/ui-0.2.0-alpha.0.tgz",
-            "integrity": "sha512-vdPndgVs8Mde4OWu5WqJ7Am8Oz+tVuidoby8IfnhQz36dJHy6kIM/AfPnIxPSHZ4Dc3aniO1IQKdGw6KEDGtLA==",
+            "version": "0.2.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@authn-sh/ui/-/ui-0.2.0-alpha.3.tgz",
+            "integrity": "sha512-PEpVMMK9/GSTp5NOAbQ9KM/d3FIMnqMpxj1/IRtYTkTSlFt3gh5B2VewTLrNk7VG6c2bCxljjUGQamyqtmYTFg==",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@radix-ui/react-avatar": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
         "vite": "^8.0.0"
     },
     "dependencies": {
-        "@authn-sh/sdk-js": "0.2.0-alpha.1",
-        "@authn-sh/sdk-react": "1.0.0-alpha.1",
-        "@authn-sh/types": "0.2.0-alpha.1",
-        "@authn-sh/ui": "0.2.0-alpha.0"
+        "@authn-sh/sdk-js": "0.2.0-alpha.3",
+        "@authn-sh/sdk-react": "0.2.0-alpha.3",
+        "@authn-sh/types": "0.2.0-alpha.3",
+        "@authn-sh/ui": "0.2.0-alpha.3"
     }
 }


### PR DESCRIPTION
Picks up the email-address + organization-domain Challenge generalization (authn-sh/javascript#32) plus the sdk-react version realignment (authn-sh/javascript#34). All four packages now pin to `0.2.0-alpha.3`, matching the linked-package config now in the JS monorepo.

The dashboard + Account Portal will hit the new `/me/email-addresses/{id}/challenges` and `/organizations/{org}/domains/{did}/challenges` endpoints instead of the deleted `/prepare-verification` / `/attempt-verification` / `/verify` ones.