### PR TITLE
AU-1: TotpSecret + BackupCode models + strategy enum bump (#87)

### DIFF
--- a/app/Auth/ErrorCodes.php
+++ b/app/Auth/ErrorCodes.php
@@ -55,12 +55,11 @@ final class ErrorCodes
     // Captcha (full enforcement in AU-18)
     public const CAPTCHA_INVALID = 'captcha_invalid';
 
-    // v0.1 stop signs for features that land later
-    public const TRANSFER_NOT_SUPPORTED_IN_V0_1 = 'transfer_not_supported_in_v0_1';
+    public const TRANSFER_NOT_SUPPORTED = 'transfer_not_supported';
 
-    public const MFA_NOT_ENABLED_IN_V0_1 = 'mfa_not_enabled_in_v0_1';
+    public const MFA_NOT_ENABLED = 'mfa_not_enabled';
 
-    public const STRATEGY_NOT_SUPPORTED_IN_V0_1 = 'strategy_not_supported_in_v0_1';
+    public const STRATEGY_NOT_SUPPORTED = 'strategy_not_supported';
 
     public const PREPARE_NOT_REQUIRED = 'prepare_not_required';
 

--- a/app/Auth/StrategyResolver.php
+++ b/app/Auth/StrategyResolver.php
@@ -14,8 +14,8 @@ use App\Models\Verification;
 use InvalidArgumentException;
 
 /**
- * Maps strategy names from the wire (per PLAN §9.3) to their concrete
- * Strategy implementations. Anything not in the v0.1 whitelist throws.
+ * Maps strategy names from the wire to their concrete Strategy
+ * implementations. Anything not in the whitelist throws.
  */
 final class StrategyResolver
 {
@@ -35,7 +35,7 @@ final class StrategyResolver
             Verification::STRATEGY_EMAIL_LINK => $this->emailLink,
             Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE => $this->resetPasswordEmailCode,
             Verification::STRATEGY_TICKET => $this->ticket,
-            default => throw new InvalidArgumentException("Strategy {$name} is not enabled in v0.1."),
+            default => throw new InvalidArgumentException("Strategy {$name} is not supported."),
         };
     }
 }

--- a/app/Http/Controllers/Bapi/InstanceController.php
+++ b/app/Http/Controllers/Bapi/InstanceController.php
@@ -86,6 +86,7 @@ final class InstanceController
             'organizations' => [
                 'enabled' => false,
             ],
+            'multi_factor' => $this->multiFactor($userSettings),
             'audit_log_retention_days' => (int) ($userSettings['audit_log_retention_days'] ?? 90),
         ]);
     }
@@ -114,6 +115,27 @@ final class InstanceController
         }
 
         return $defaults;
+    }
+
+    /**
+     * @param  array<string, mixed>  $userSettings
+     * @return array{totp: array{enabled: bool}, backup_codes: array{enabled: bool, default_count: int}}
+     */
+    private function multiFactor(array $userSettings): array
+    {
+        $mf = is_array($userSettings['multi_factor'] ?? null) ? $userSettings['multi_factor'] : [];
+        $totp = is_array($mf['totp'] ?? null) ? $mf['totp'] : [];
+        $backup = is_array($mf['backup_codes'] ?? null) ? $mf['backup_codes'] : [];
+
+        return [
+            'totp' => [
+                'enabled' => (bool) ($totp['enabled'] ?? true),
+            ],
+            'backup_codes' => [
+                'enabled' => (bool) ($backup['enabled'] ?? true),
+                'default_count' => (int) ($backup['default_count'] ?? 10),
+            ],
+        ];
     }
 
     public function update(Request $request): JsonResponse

--- a/app/Http/Controllers/Fapi/ChallengeController.php
+++ b/app/Http/Controllers/Fapi/ChallengeController.php
@@ -81,13 +81,13 @@ final class ChallengeController
             return $this->errorWithSignIn(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', $client, $attempt);
         }
         if (! in_array($strategyName, $this->signInSupportedStrategies($attempt), true)) {
-            return $this->errorWithSignIn(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategyName} is not supported on this sign-in.", $client, $attempt);
+            return $this->errorWithSignIn(422, ErrorCodes::STRATEGY_NOT_SUPPORTED, "strategy {$strategyName} is not supported on this sign-in.", $client, $attempt);
         }
 
         try {
             $strategy = $this->strategies->resolve($strategyName);
         } catch (InvalidArgumentException) {
-            return $this->errorWithSignIn(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategyName} is not enabled in v0.1.", $client, $attempt);
+            return $this->errorWithSignIn(422, ErrorCodes::STRATEGY_NOT_SUPPORTED, "strategy {$strategyName} is not supported.", $client, $attempt);
         }
 
         $step = $this->resolveSignInStep($attempt);
@@ -252,7 +252,7 @@ final class ChallengeController
             return $this->errorWithSignUp(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', $client, $attempt);
         }
         if (! in_array($strategyName, $this->signUpSupportedStrategies($attempt), true)) {
-            return $this->errorWithSignUp(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategyName} is not supported on this sign-up.", $client, $attempt);
+            return $this->errorWithSignUp(422, ErrorCodes::STRATEGY_NOT_SUPPORTED, "strategy {$strategyName} is not supported on this sign-up.", $client, $attempt);
         }
         if (! is_string($attempt->email_address) || $attempt->email_address === '') {
             return $this->errorWithSignUp(422, ErrorCodes::FORM_PARAM_NIL, 'email_address is required before issuing a challenge.', $client, $attempt);
@@ -383,7 +383,7 @@ final class ChallengeController
             return $this->bareError(422, ErrorCodes::FORM_PARAM_NIL, 'strategy is required.', null);
         }
         if (! in_array($strategyName, [Verification::STRATEGY_EMAIL_CODE, Verification::STRATEGY_EMAIL_LINK], true)) {
-            return $this->bareError(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategyName} is not supported on email-address challenges.", null);
+            return $this->bareError(422, ErrorCodes::STRATEGY_NOT_SUPPORTED, "strategy {$strategyName} is not supported on email-address challenges.", null);
         }
 
         $challenge = $strategyName === Verification::STRATEGY_EMAIL_LINK

--- a/app/Http/Controllers/Fapi/SignInController.php
+++ b/app/Http/Controllers/Fapi/SignInController.php
@@ -53,7 +53,7 @@ final class SignInController
         $client = $this->resolveOrCreateClient($request, $env, $createdClient);
 
         if ($request->boolean('transfer')) {
-            return $this->error(422, ErrorCodes::TRANSFER_NOT_SUPPORTED_IN_V0_1, 'transfer flow lands in a later milestone.', $client);
+            return $this->error(422, ErrorCodes::TRANSFER_NOT_SUPPORTED, 'transfer flow is not supported.', $client);
         }
 
         $identifier = $request->input('identifier');
@@ -75,7 +75,7 @@ final class SignInController
             Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE,
             Verification::STRATEGY_TICKET,
         ], true)) {
-            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED_IN_V0_1, "strategy {$strategy} is not enabled in v0.1.", $client);
+            return $this->error(422, ErrorCodes::STRATEGY_NOT_SUPPORTED, "strategy {$strategy} is not supported.", $client);
         }
 
         return DB::transaction(function () use ($request, $env, $client, $strategy, $createdClient, $isTestAttempt): JsonResponse {

--- a/app/Http/Controllers/Fapi/SignUpController.php
+++ b/app/Http/Controllers/Fapi/SignUpController.php
@@ -63,7 +63,7 @@ final class SignUpController
         $client = $this->resolveOrCreateClient($request, $env, $createdClient);
 
         if ($request->boolean('transfer')) {
-            return $this->error(422, ErrorCodes::TRANSFER_NOT_SUPPORTED_IN_V0_1, 'transfer flow lands in a later milestone.', $client);
+            return $this->error(422, ErrorCodes::TRANSFER_NOT_SUPPORTED, 'transfer flow is not supported.', $client);
         }
 
         $emailInput = $request->input('email_address');

--- a/app/Models/BackupCode.php
+++ b/app/Models/BackupCode.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Single-use recovery code. Plaintext is shown once at generation and
+ * never again; only the Argon2id hash is persisted.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $user_id
+ * @property string $code_hash
+ * @property ?\DateTimeInterface $used_at
+ * @property \DateTimeInterface $created_at
+ */
+class BackupCode extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    public const UPDATED_AT = null;
+
+    protected string $idPrefix = 'bcc_';
+
+    protected $fillable = [
+        'environment_id',
+        'user_id',
+        'code_hash',
+        'used_at',
+    ];
+
+    protected $hidden = [
+        'code_hash',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'used_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function isUsed(): bool
+    {
+        return $this->used_at !== null;
+    }
+
+    public function markUsed(): void
+    {
+        $this->forceFill(['used_at' => now()])->save();
+    }
+}

--- a/app/Models/TotpSecret.php
+++ b/app/Models/TotpSecret.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * RFC 6238 TOTP secret enrolled by a user. At most one verified row per
+ * (environment_id, user_id) — the AU-3 enrolment service enforces that
+ * invariant by deleting any prior unverified row before inserting a new
+ * attempt, so the schema does not carry a partial unique index.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $user_id
+ * @property string $secret
+ * @property string $algorithm
+ * @property int $digits
+ * @property int $period_seconds
+ * @property ?\DateTimeInterface $verified_at
+ */
+class TotpSecret extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    protected string $idPrefix = 'totp_';
+
+    protected $fillable = [
+        'environment_id',
+        'user_id',
+        'secret',
+        'algorithm',
+        'digits',
+        'period_seconds',
+        'verified_at',
+    ];
+
+    protected $hidden = [
+        'secret',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            // App-key-based encryption for now; per-env secret driver lands
+            // separately and will re-wrap without changing this contract.
+            'secret' => 'encrypted',
+            'digits' => 'int',
+            'period_seconds' => 'int',
+            'verified_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function isVerified(): bool
+    {
+        return $this->verified_at !== null;
+    }
+}

--- a/app/Models/Verification.php
+++ b/app/Models/Verification.php
@@ -77,12 +77,19 @@ class Verification extends Model
 
     public const STRATEGY_DOMAIN_DNS_TXT = 'domain_dns_txt';
 
-    public const V0_1_STRATEGIES = [
+    public const STRATEGY_TOTP = 'totp';
+
+    public const STRATEGY_BACKUP_CODE = 'backup_code';
+
+    public const STRATEGIES = [
         self::STRATEGY_PASSWORD,
         self::STRATEGY_EMAIL_CODE,
         self::STRATEGY_EMAIL_LINK,
         self::STRATEGY_RESET_PASSWORD_EMAIL_CODE,
         self::STRATEGY_TICKET,
+        self::STRATEGY_DOMAIN_DNS_TXT,
+        self::STRATEGY_TOTP,
+        self::STRATEGY_BACKUP_CODE,
     ];
 
     protected string $idPrefix = 'ver_';

--- a/app/Services/Verification/VerificationManager.php
+++ b/app/Services/Verification/VerificationManager.php
@@ -37,8 +37,8 @@ final class VerificationManager
      */
     public function start(Model $owner, string $strategy, int $ttlSeconds, ?string $purpose = null): Verification
     {
-        if (! in_array($strategy, Verification::V0_1_STRATEGIES, true)) {
-            throw new InvalidArgumentException("Strategy {$strategy} is not enabled in v0.1.");
+        if (! in_array($strategy, Verification::STRATEGIES, true)) {
+            throw new InvalidArgumentException("Strategy {$strategy} is not supported.");
         }
 
         $environmentId = $this->resolveEnvironmentId($owner);

--- a/database/migrations/2026_05_09_000000_create_totp_secrets_and_backup_codes.php
+++ b/database/migrations/2026_05_09_000000_create_totp_secrets_and_backup_codes.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('totp_secrets', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('user_id', 64);
+            $table->text('secret');
+            $table->string('algorithm', 8)->default('SHA1');
+            $table->unsignedSmallInteger('digits')->default(6);
+            $table->unsignedSmallInteger('period_seconds')->default(30);
+            $table->timestamp('verified_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->index(['environment_id', 'user_id']);
+        });
+
+        Schema::create('backup_codes', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('user_id', 64);
+            $table->string('code_hash', 255);
+            $table->timestamp('used_at')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->index(['environment_id', 'user_id', 'used_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('backup_codes');
+        Schema::dropIfExists('totp_secrets');
+    }
+};

--- a/tests/Feature/Mfa/BackupCodeModelTest.php
+++ b/tests/Feature/Mfa/BackupCodeModelTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\BackupCode;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+function makeEnvForBackupCode(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => $slug.'-p']);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('mints a bcc_-prefixed id', function (): void {
+    $env = makeEnvForBackupCode();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $row = BackupCode::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'code_hash' => Hash::make('plaintext-1'),
+    ]);
+
+    expect($row->id)->toStartWith('bcc_');
+});
+
+it('hides code_hash from array/JSON serialisation', function (): void {
+    $env = makeEnvForBackupCode('b2');
+    $user = User::create(['environment_id' => $env->id]);
+
+    $row = BackupCode::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'code_hash' => Hash::make('plaintext-1'),
+    ]);
+
+    expect($row->toArray())->not->toHaveKey('code_hash');
+});
+
+it('has no updated_at column', function (): void {
+    $env = makeEnvForBackupCode('b3');
+    $user = User::create(['environment_id' => $env->id]);
+
+    $row = BackupCode::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'code_hash' => Hash::make('plaintext-1'),
+    ])->refresh();
+
+    expect($row->getAttributes())->not->toHaveKey('updated_at');
+});
+
+it('isUsed() + markUsed() track consumption', function (): void {
+    $env = makeEnvForBackupCode('b4');
+    $user = User::create(['environment_id' => $env->id]);
+
+    $row = BackupCode::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'code_hash' => Hash::make('plaintext-1'),
+    ]);
+    expect($row->isUsed())->toBeFalse();
+
+    $row->markUsed();
+    expect($row->refresh()->isUsed())->toBeTrue();
+    expect($row->used_at)->not->toBeNull();
+});
+
+it('scopes queries to the bound environment', function (): void {
+    $envA = makeEnvForBackupCode('ba');
+    $envB = makeEnvForBackupCode('bb');
+    $userA = User::create(['environment_id' => $envA->id]);
+    $userB = User::create(['environment_id' => $envB->id]);
+
+    BackupCode::create([
+        'environment_id' => $envA->id,
+        'user_id' => $userA->id,
+        'code_hash' => Hash::make('a'),
+    ]);
+    BackupCode::create([
+        'environment_id' => $envB->id,
+        'user_id' => $userB->id,
+        'code_hash' => Hash::make('b'),
+    ]);
+
+    app()->instance(Environment::class, $envA);
+    expect(BackupCode::query()->count())->toBe(1);
+
+    app()->instance(Environment::class, $envB);
+    expect(BackupCode::query()->count())->toBe(1);
+});

--- a/tests/Feature/Mfa/TotpSecretModelTest.php
+++ b/tests/Feature/Mfa/TotpSecretModelTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\TotpSecret;
+use App\Models\User;
+
+function makeEnvForTotp(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => $slug.'-p']);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('mints a totp_-prefixed id', function (): void {
+    $env = makeEnvForTotp();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $row = TotpSecret::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+    ]);
+
+    expect($row->id)->toStartWith('totp_');
+});
+
+it('encrypts the secret column at rest and exposes plaintext via the cast', function (): void {
+    $env = makeEnvForTotp('e2');
+    $user = User::create(['environment_id' => $env->id]);
+
+    $plain = 'JBSWY3DPEHPK3PXP';
+    $row = TotpSecret::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'secret' => $plain,
+    ]);
+
+    expect($row->secret)->toBe($plain);
+
+    $raw = DB::table('totp_secrets')->where('id', $row->id)->value('secret');
+    expect($raw)->not->toBe($plain);
+    expect(strlen((string) $raw))->toBeGreaterThan(strlen($plain));
+});
+
+it('hides the secret from array/JSON serialisation', function (): void {
+    $env = makeEnvForTotp('e3');
+    $user = User::create(['environment_id' => $env->id]);
+
+    $row = TotpSecret::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+    ]);
+
+    expect($row->toArray())->not->toHaveKey('secret');
+});
+
+it('defaults algorithm/digits/period_seconds to RFC 6238 values', function (): void {
+    $env = makeEnvForTotp('e4');
+    $user = User::create(['environment_id' => $env->id]);
+
+    $row = TotpSecret::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+    ])->refresh();
+
+    expect($row->algorithm)->toBe('SHA1');
+    expect($row->digits)->toBe(6);
+    expect($row->period_seconds)->toBe(30);
+});
+
+it('isVerified() reflects verified_at presence', function (): void {
+    $env = makeEnvForTotp('e5');
+    $user = User::create(['environment_id' => $env->id]);
+
+    $row = TotpSecret::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+    ]);
+    expect($row->isVerified())->toBeFalse();
+
+    $row->forceFill(['verified_at' => now()])->save();
+    expect($row->isVerified())->toBeTrue();
+});
+
+it('scopes queries to the bound environment', function (): void {
+    $envA = makeEnvForTotp('ea');
+    $envB = makeEnvForTotp('eb');
+    $userA = User::create(['environment_id' => $envA->id]);
+    $userB = User::create(['environment_id' => $envB->id]);
+
+    TotpSecret::create([
+        'environment_id' => $envA->id,
+        'user_id' => $userA->id,
+        'secret' => 'AAA',
+    ]);
+    TotpSecret::create([
+        'environment_id' => $envB->id,
+        'user_id' => $userB->id,
+        'secret' => 'BBB',
+    ]);
+
+    app()->instance(Environment::class, $envA);
+    expect(TotpSecret::query()->count())->toBe(1);
+
+    app()->instance(Environment::class, $envB);
+    expect(TotpSecret::query()->count())->toBe(1);
+});

--- a/tests/Feature/Services/Verification/VerificationManagerTest.php
+++ b/tests/Feature/Services/Verification/VerificationManagerTest.php
@@ -42,12 +42,12 @@ it('starts a fresh verification with status=unverified and 0 attempts', function
     expect($v->expire_at->getTimestamp())->toBeGreaterThan(now()->addSeconds(595)->getTimestamp());
 });
 
-it('refuses strategies not enabled in v0.1', function (): void {
+it('refuses unsupported strategies', function (): void {
     $f = vmFixture();
     $manager = app(VerificationManager::class);
 
     expect(fn () => $manager->start($f['email'], 'oauth_google', 600))
-        ->toThrow(InvalidArgumentException::class, 'is not enabled in v0.1');
+        ->toThrow(InvalidArgumentException::class, 'is not supported');
 });
 
 it('mints a numeric code whose hash is what we store', function (): void {


### PR DESCRIPTION
Closes #87.

## Summary

- **Migration** `database/migrations/2026_05_09_000000_create_totp_secrets_and_backup_codes.php` lays down two tables:
  - `totp_secrets` — `id`/`environment_id`/`user_id`, encrypted `secret`, RFC 6238 `algorithm` (default `SHA1`) / `digits` (`6`) / `period_seconds` (`30`), nullable `verified_at`, timestamps. Cascade-deletes from `environments` and `users`. The "at most one verified row per (env, user)" invariant is enforced by the AU-3 enrolment service rather than a partial unique index, keeping the migration dialect-portable.
  - `backup_codes` — Argon2id `code_hash`, nullable `used_at`, immutable rows (no `updated_at`). Indexed on `(environment_id, user_id, used_at)`.
- **Models** `App\Models\TotpSecret` + `App\Models\BackupCode` — `EnvironmentScope` global scope, `HasPrefixedUlid` (`totp_` / `bcc_` already in `IdPrefix::ALLOWED_PREFIXES`), `\$hidden` hygiene on `secret` / `code_hash`, `belongsTo(User|Environment)` relations. `TotpSecret::isVerified()`, `BackupCode::isUsed()` / `markUsed()` helpers. `secret` uses Laravel's app-key `encrypted` cast for now; the per-env secret driver wraps without changing the contract and lands separately.
- **`Verification`** — adds `STRATEGY_TOTP` and `STRATEGY_BACKUP_CODE`. The old `V0_1_STRATEGIES` constant is replaced by an exhaustive `STRATEGIES` array (8 entries — alpha rule, no compat alias).
- **`ErrorCodes`** — drops the version suffix on three constants and their wire strings:
  - `STRATEGY_NOT_SUPPORTED_IN_V0_1` → `STRATEGY_NOT_SUPPORTED`
  - `MFA_NOT_ENABLED_IN_V0_1` → `MFA_NOT_ENABLED`
  - `TRANSFER_NOT_SUPPORTED_IN_V0_1` → `TRANSFER_NOT_SUPPORTED`
  Updated call sites: `Fapi/ChallengeController`, `Fapi/SignInController`, `Fapi/SignUpController`, `Auth/StrategyResolver`, `Services/Verification/VerificationManager`. User-visible error strings reworded to match (\"strategy X is not supported.\", \"transfer flow is not supported.\"). Deferring the new \`FORM_CODE_ALREADY_USED\` constant to AU-5 where the backup-code answer logic actually consumes it.

## Out of scope (lands later)

- TOTP enrolment / verify endpoints — AU-3 (#89).
- Backup-code generation / list — AU-4 (#90).
- Second-factor Challenge wiring (`step: \"second\"`) — AU-5 (#92).
- Per-env strategy gating in `InstanceSettings.multi_factor` — AU-2 (#88).

## Test plan

- [x] `php artisan test --parallel` — **468 passed, 1540 assertions**, no regressions.
- [x] New `tests/Feature/Mfa/TotpSecretModelTest.php` (6 cases): id-prefix mint, encrypted-at-rest + plaintext via cast, hidden-from-serialisation, RFC 6238 defaults, `isVerified()` flip, `EnvironmentScope` partitioning across two envs.
- [x] New `tests/Feature/Mfa/BackupCodeModelTest.php` (5 cases): id-prefix mint, hidden `code_hash`, no `updated_at` column, `isUsed()` / `markUsed()` round-trip, `EnvironmentScope` partitioning.
- [x] `vendor/bin/pint --test` — clean across 352 files.
- [x] OpenAPI contract validator (auto-applied to every feature response) — clean against the freshly bundled spec from openapi#37.