### PR TITLE
AU-2: per-env multi_factor settings + Environment second_factors mirror (#88)

### DIFF
--- a/app/Http/Controllers/Bapi/InstanceController.php
+++ b/app/Http/Controllers/Bapi/InstanceController.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Bapi;
 
 use App\Models\Environment;
+use App\Settings\MultiFactorSettings;
 use App\Webhooks\Emitter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 
 /**
  * BAPI instance settings surface.
@@ -86,7 +89,7 @@ final class InstanceController
             'organizations' => [
                 'enabled' => false,
             ],
-            'multi_factor' => $this->multiFactor($userSettings),
+            'multi_factor' => MultiFactorSettings::fromUserSettings($userSettings)->toArray(),
             'audit_log_retention_days' => (int) ($userSettings['audit_log_retention_days'] ?? 90),
         ]);
     }
@@ -117,33 +120,13 @@ final class InstanceController
         return $defaults;
     }
 
-    /**
-     * @param  array<string, mixed>  $userSettings
-     * @return array{totp: array{enabled: bool}, backup_codes: array{enabled: bool, default_count: int}}
-     */
-    private function multiFactor(array $userSettings): array
-    {
-        $mf = is_array($userSettings['multi_factor'] ?? null) ? $userSettings['multi_factor'] : [];
-        $totp = is_array($mf['totp'] ?? null) ? $mf['totp'] : [];
-        $backup = is_array($mf['backup_codes'] ?? null) ? $mf['backup_codes'] : [];
-
-        return [
-            'totp' => [
-                'enabled' => (bool) ($totp['enabled'] ?? true),
-            ],
-            'backup_codes' => [
-                'enabled' => (bool) ($backup['enabled'] ?? true),
-                'default_count' => (int) ($backup['default_count'] ?? 10),
-            ],
-        ];
-    }
-
     public function update(Request $request): JsonResponse
     {
         $env = app(Environment::class);
         $appearance = is_array($env->appearance) ? $env->appearance : [];
         $userSettings = is_array($env->user_settings) ? $env->user_settings : [];
         $previousTestMode = $userSettings['test_mode'] ?? null;
+        $previousMultiFactor = MultiFactorSettings::fromUserSettings($userSettings);
 
         if ($request->has('support_email')) {
             $appearance['support_email'] = $request->input('support_email');
@@ -157,6 +140,30 @@ final class InstanceController
         if ($request->has('user_settings') && is_array($request->input('user_settings'))) {
             $userSettings = array_replace_recursive($userSettings, $request->input('user_settings'));
         }
+
+        $multiFactorChanged = false;
+        if ($request->has('multi_factor')) {
+            $patch = $request->input('multi_factor');
+            if (! is_array($patch)) {
+                throw ValidationException::withMessages(['multi_factor' => 'multi_factor must be an object.']);
+            }
+            Validator::make($patch, [
+                'totp' => 'sometimes|array',
+                'totp.enabled' => 'sometimes|boolean',
+                'backup_codes' => 'sometimes|array',
+                'backup_codes.enabled' => 'sometimes|boolean',
+                'backup_codes.default_count' => [
+                    'sometimes',
+                    'integer',
+                    'between:'.MultiFactorSettings::MIN_BACKUP_CODE_COUNT.','.MultiFactorSettings::MAX_BACKUP_CODE_COUNT,
+                ],
+            ])->validate();
+
+            $next = $previousMultiFactor->withPatch($patch);
+            $userSettings['multi_factor'] = $next->toArray();
+            $multiFactorChanged = $next != $previousMultiFactor;
+        }
+
         $env->forceFill([
             'appearance' => $appearance,
             'user_settings' => $userSettings,
@@ -176,6 +183,24 @@ final class InstanceController
             app(Emitter::class)->emit(
                 'system.testmode_enabled_in_production',
                 ['environment_id' => $env->id, 'severity' => 'warning'],
+                $env,
+            );
+        }
+
+        if ($multiFactorChanged) {
+            $next = MultiFactorSettings::fromUserSettings($userSettings);
+            Log::info('instance.config.multi_factor_updated', [
+                'environment_id' => $env->id,
+                'before' => $previousMultiFactor->toArray(),
+                'after' => $next->toArray(),
+            ]);
+            app(Emitter::class)->emit(
+                'instance.config.multi_factor_updated',
+                [
+                    'environment_id' => $env->id,
+                    'before' => $previousMultiFactor->toArray(),
+                    'after' => $next->toArray(),
+                ],
                 $env,
             );
         }

--- a/app/Http/Resources/EnvironmentResource.php
+++ b/app/Http/Resources/EnvironmentResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Resources;
 
 use App\Models\Environment;
+use App\Settings\MultiFactorSettings;
 
 /**
  * The public-facing shape returned by `GET /v1/environment`. The SDK
@@ -22,8 +23,10 @@ final class EnvironmentResource
     public static function from(Environment $environment): array
     {
         $appearance = is_array($environment->appearance) ? $environment->appearance : [];
+        $userSettings = is_array($environment->user_settings) ? $environment->user_settings : [];
         $sessions = is_array($appearance['sessions'] ?? null) ? $appearance['sessions'] : [];
         $localization = is_array($environment->localization) ? $environment->localization : [];
+        $multiFactor = MultiFactorSettings::fromUserSettings($userSettings);
 
         return [
             'object' => 'environment',
@@ -36,7 +39,7 @@ final class EnvironmentResource
                     'username' => 'off',
                 ],
                 'first_factors' => ['password', 'email_code', 'reset_password_email_code', 'ticket'],
-                'second_factors' => [],
+                'second_factors' => $multiFactor->enabledStrategies(),
                 'sign_up_modes' => ['public'],
             ],
 

--- a/app/Settings/MultiFactorSettings.php
+++ b/app/Settings/MultiFactorSettings.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Settings;
+
+use App\Models\Verification;
+
+/**
+ * Per-environment second-factor toggles (PLAN §12.1) read by the FAPI
+ * Challenge controller, the Account Portal Security panel, and the
+ * BAPI instance settings surface. The dashboard / SDK can mutate these
+ * via `PATCH /v1/instance` with a `multi_factor` patch.
+ */
+final readonly class MultiFactorSettings
+{
+    public const DEFAULT_BACKUP_CODE_COUNT = 10;
+
+    public const MIN_BACKUP_CODE_COUNT = 4;
+
+    public const MAX_BACKUP_CODE_COUNT = 24;
+
+    public function __construct(
+        public bool $totpEnabled = true,
+        public bool $backupCodesEnabled = true,
+        public int $backupCodesDefaultCount = self::DEFAULT_BACKUP_CODE_COUNT,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>|null  $userSettings
+     */
+    public static function fromUserSettings(?array $userSettings): self
+    {
+        $mf = is_array($userSettings['multi_factor'] ?? null) ? $userSettings['multi_factor'] : [];
+
+        return self::fromArray($mf);
+    }
+
+    /**
+     * @param  array<string, mixed>  $multiFactor
+     */
+    public static function fromArray(array $multiFactor): self
+    {
+        $totp = is_array($multiFactor['totp'] ?? null) ? $multiFactor['totp'] : [];
+        $backup = is_array($multiFactor['backup_codes'] ?? null) ? $multiFactor['backup_codes'] : [];
+
+        return new self(
+            totpEnabled: (bool) ($totp['enabled'] ?? true),
+            backupCodesEnabled: (bool) ($backup['enabled'] ?? true),
+            backupCodesDefaultCount: (int) ($backup['default_count'] ?? self::DEFAULT_BACKUP_CODE_COUNT),
+        );
+    }
+
+    /**
+     * @return array{totp: array{enabled: bool}, backup_codes: array{enabled: bool, default_count: int}}
+     */
+    public function toArray(): array
+    {
+        return [
+            'totp' => [
+                'enabled' => $this->totpEnabled,
+            ],
+            'backup_codes' => [
+                'enabled' => $this->backupCodesEnabled,
+                'default_count' => $this->backupCodesDefaultCount,
+            ],
+        ];
+    }
+
+    /**
+     * Apply a partial patch — omitted blocks / fields are left untouched.
+     *
+     * @param  array<string, mixed>  $patch
+     */
+    public function withPatch(array $patch): self
+    {
+        $totpEnabled = $this->totpEnabled;
+        $backupCodesEnabled = $this->backupCodesEnabled;
+        $backupCodesDefaultCount = $this->backupCodesDefaultCount;
+
+        if (is_array($patch['totp'] ?? null) && array_key_exists('enabled', $patch['totp'])) {
+            $totpEnabled = (bool) $patch['totp']['enabled'];
+        }
+        if (is_array($patch['backup_codes'] ?? null)) {
+            if (array_key_exists('enabled', $patch['backup_codes'])) {
+                $backupCodesEnabled = (bool) $patch['backup_codes']['enabled'];
+            }
+            if (array_key_exists('default_count', $patch['backup_codes'])) {
+                $backupCodesDefaultCount = (int) $patch['backup_codes']['default_count'];
+            }
+        }
+
+        return new self($totpEnabled, $backupCodesEnabled, $backupCodesDefaultCount);
+    }
+
+    /**
+     * Whether a strategy name (`totp` / `backup_code`) is enabled at the
+     * environment level. Unknown strategy names return false so callers
+     * (notably AU-5's `supportedStrategies` narrowing) can pass any spec
+     * strategy without first checking the type.
+     */
+    public function strategyEnabled(string $strategy): bool
+    {
+        return match ($strategy) {
+            Verification::STRATEGY_TOTP => $this->totpEnabled,
+            Verification::STRATEGY_BACKUP_CODE => $this->backupCodesEnabled,
+            default => false,
+        };
+    }
+
+    /**
+     * Strategy names enabled at the environment level. Used by the public
+     * `Environment.auth_config.second_factors` mirror and by AU-5 to
+     * narrow `SignInResource::supportedStrategies` for `needs_second_factor`.
+     *
+     * @return list<string>
+     */
+    public function enabledStrategies(): array
+    {
+        $out = [];
+        if ($this->totpEnabled) {
+            $out[] = Verification::STRATEGY_TOTP;
+        }
+        if ($this->backupCodesEnabled) {
+            $out[] = Verification::STRATEGY_BACKUP_CODE;
+        }
+
+        return $out;
+    }
+}

--- a/tests/Feature/Http/Bapi/InstanceTest.php
+++ b/tests/Feature/Http/Bapi/InstanceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\Environment;
+use App\Models\WebhookEvent;
 use Tests\Feature\Http\Bapi\BapiTestSupport;
 
 it('reads + patches the env-level instance settings', function (): void {
@@ -43,4 +44,101 @@ it('PATCH /instance/organization-settings is a v0.1 placeholder', function (): v
     $this->withHeaders(BapiTestSupport::headers($f['token']))
         ->patchJson(BapiTestSupport::url('/instance/organization-settings'), ['enabled' => true])
         ->assertOk()->assertJsonPath('enabled', false);
+});
+
+it('GET /instance emits multi_factor spec defaults when unset', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/instance'))
+        ->assertOk()
+        ->assertJsonPath('multi_factor.totp.enabled', true)
+        ->assertJsonPath('multi_factor.backup_codes.enabled', true)
+        ->assertJsonPath('multi_factor.backup_codes.default_count', 10);
+});
+
+it('GET /instance emits persisted multi_factor values when set', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $f['env']->forceFill([
+        'user_settings' => array_merge((array) $f['env']->user_settings, [
+            'multi_factor' => [
+                'totp' => ['enabled' => false],
+                'backup_codes' => ['enabled' => true, 'default_count' => 16],
+            ],
+        ]),
+    ])->save();
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/instance'))
+        ->assertOk()
+        ->assertJsonPath('multi_factor.totp.enabled', false)
+        ->assertJsonPath('multi_factor.backup_codes.enabled', true)
+        ->assertJsonPath('multi_factor.backup_codes.default_count', 16);
+});
+
+it('PATCH /instance writes through multi_factor with partial-patch semantics', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/instance'), [
+            'multi_factor' => [
+                'backup_codes' => ['default_count' => 8],
+            ],
+        ])
+        ->assertOk()
+        ->assertJsonPath('multi_factor.totp.enabled', true)
+        ->assertJsonPath('multi_factor.backup_codes.enabled', true)
+        ->assertJsonPath('multi_factor.backup_codes.default_count', 8);
+
+    expect($f['env']->fresh()->user_settings['multi_factor']['backup_codes']['default_count'])->toBe(8);
+});
+
+it('PATCH /instance rejects multi_factor.backup_codes.default_count outside 4..24', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/instance'), [
+            'multi_factor' => ['backup_codes' => ['default_count' => 3]],
+        ])
+        ->assertStatus(422);
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/instance'), [
+            'multi_factor' => ['backup_codes' => ['default_count' => 25]],
+        ])
+        ->assertStatus(422);
+});
+
+it('PATCH /instance emits an instance.config.multi_factor_updated webhook event when multi_factor changes', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/instance'), [
+            'multi_factor' => ['totp' => ['enabled' => false]],
+        ])
+        ->assertOk();
+
+    $event = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('type', 'instance.config.multi_factor_updated')
+        ->first();
+    expect($event)->not->toBeNull();
+    expect($event->data['before']['totp']['enabled'])->toBeTrue();
+    expect($event->data['after']['totp']['enabled'])->toBeFalse();
+});
+
+it('PATCH /instance does not emit the multi_factor webhook event when nothing changed', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/instance'), [
+            'multi_factor' => ['totp' => ['enabled' => true]],
+        ])
+        ->assertOk();
+
+    $count = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('type', 'instance.config.multi_factor_updated')
+        ->count();
+    expect($count)->toBe(0);
 });

--- a/tests/Feature/Http/Fapi/EnvironmentSecondFactorTest.php
+++ b/tests/Feature/Http/Fapi/EnvironmentSecondFactorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Project;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
+
+function reloadFapiRoutesForSecondFactorTest(): void
+{
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+    $appHost = (string) config('authn.app_host');
+    $fapi = Route::middleware('fapi');
+    if ((string) config('authn.routing_mode') === 'subdomain') {
+        $fapi->domain('{env_slug}.'.$appHost);
+    } else {
+        $fapi->prefix('{env_slug}');
+    }
+    $fapi->group(base_path('routes/fapi.php'));
+}
+
+function bootEnvForSecondFactorTest(string $slug, ?array $multiFactor): Environment
+{
+    config([
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.bapi_host' => 'api.authn.local',
+    ]);
+    reloadFapiRoutesForSecondFactorTest();
+    Cache::flush();
+
+    $project = Project::create(['name' => 'P-'.$slug, 'slug' => 'p-'.$slug]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+
+    if ($multiFactor !== null) {
+        $env->forceFill([
+            'user_settings' => array_merge((array) $env->user_settings, ['multi_factor' => $multiFactor]),
+        ])->save();
+    }
+
+    return $env;
+}
+
+it('returns auth_config.second_factors as [totp, backup_code] under spec defaults', function (): void {
+    bootEnvForSecondFactorTest('mfa-defaults', null);
+
+    $this->withHeader('Host', 'mfa-defaults.authn.local')
+        ->getJson('https://mfa-defaults.authn.local/v1/environment')
+        ->assertOk()
+        ->assertJsonPath('auth_config.second_factors', ['totp', 'backup_code']);
+});
+
+it('omits totp from second_factors when multi_factor.totp.enabled is false', function (): void {
+    bootEnvForSecondFactorTest('mfa-no-totp', [
+        'totp' => ['enabled' => false],
+        'backup_codes' => ['enabled' => true, 'default_count' => 10],
+    ]);
+
+    $this->withHeader('Host', 'mfa-no-totp.authn.local')
+        ->getJson('https://mfa-no-totp.authn.local/v1/environment')
+        ->assertOk()
+        ->assertJsonPath('auth_config.second_factors', ['backup_code']);
+});
+
+it('omits backup_code from second_factors when multi_factor.backup_codes.enabled is false', function (): void {
+    bootEnvForSecondFactorTest('mfa-no-bc', [
+        'totp' => ['enabled' => true],
+        'backup_codes' => ['enabled' => false, 'default_count' => 10],
+    ]);
+
+    $this->withHeader('Host', 'mfa-no-bc.authn.local')
+        ->getJson('https://mfa-no-bc.authn.local/v1/environment')
+        ->assertOk()
+        ->assertJsonPath('auth_config.second_factors', ['totp']);
+});
+
+it('returns auth_config.second_factors as [] when both strategies are disabled', function (): void {
+    bootEnvForSecondFactorTest('mfa-off', [
+        'totp' => ['enabled' => false],
+        'backup_codes' => ['enabled' => false, 'default_count' => 10],
+    ]);
+
+    $this->withHeader('Host', 'mfa-off.authn.local')
+        ->getJson('https://mfa-off.authn.local/v1/environment')
+        ->assertOk()
+        ->assertJsonPath('auth_config.second_factors', []);
+});


### PR DESCRIPTION
Closes #88.

## Summary

- **`MultiFactorSettings` value object** (`app/Settings/MultiFactorSettings.php`) — readonly `{totpEnabled, backupCodesEnabled, backupCodesDefaultCount}` with `fromUserSettings` / `fromArray` / `toArray` / `withPatch` plus `strategyEnabled(string)` and `enabledStrategies()` helpers. AU-3/4/5 will read these for per-env strategy gating and `SignInResource::supportedStrategies` narrowing.
- **`PATCH /v1/instance` honours `multi_factor`** — the dedicated `PATCH /v1/instance/multi-factor` route from the AU-2 issue body isn't in the openapi spec (canonical patch surface is `InstanceUpdateRequest.multi_factor`), so the multi_factor patch lands inside the existing `PATCH /v1/instance` with Laravel validation (`default_count` integer between 4 and 24) and `array_replace_recursive` partial-patch semantics. Dashboard sends `{multi_factor: {…}}`. A focused sub-route can land in v0.3.x as a small spec follow-up if dashboard authz wants one.
- **Audit emission on change** — `Log::info('instance.config.multi_factor_updated', …)` plus `Emitter::emit('instance.config.multi_factor_updated', …)` with `{environment_id, before, after}` diff payload, fired only when the resolved settings actually change (`MultiFactorSettings` value comparison via `!=`).
- **Public mirror** — `EnvironmentResource.auth_config.second_factors` is now sourced from `MultiFactorSettings::enabledStrategies()`. Maps `totp.enabled` → `'totp'` and `backup_codes.enabled` → `'backup_code'`. Admin-only `default_count` stays out of the public `/v1/environment` payload (matches the issue's intent).
- **`InstanceController::show()` simplification** — drops the inline `multiFactor()` private method in favour of the shared value object.

## Spec defaults vs issue defaults

The issue body proposed `enabled: false` defaults; the merged openapi spec defaults to `enabled: true`. Going with the spec — contract validator enforces it, and shipping MFA on by default is the safer security posture.

## Out of scope (lands later)

- Dashboard UI — AU-8.
- TOTP enrolment + FAPI `/v1/me/totp` — AU-3.
- Backup codes + FAPI `/v1/me/backup-codes` — AU-4.
- Strategy gating in `ChallengeController` + `SignInResource::supportedStrategies` narrowing — AU-5 (consumes `MultiFactorSettings::strategyEnabled`).

## Test plan

- [x] **`tests/Feature/Http/Bapi/InstanceTest.php`** — 6 new cases:
  - GET emits multi_factor spec defaults when `user_settings.multi_factor` is unset.
  - GET emits the persisted values when set.
  - PATCH applies partial-patch semantics (omitted blocks/fields untouched).
  - PATCH rejects `default_count: 3` and `default_count: 25` with 422.
  - PATCH emits the `instance.config.multi_factor_updated` webhook event with before/after diff on real change.
  - PATCH does NOT emit the event when the patch is a no-op.
- [x] **`tests/Feature/Http/Fapi/EnvironmentSecondFactorTest.php`** — 4 new cases covering all enable-combinations of the public `auth_config.second_factors` mirror.
- [x] `php artisan test --parallel` — **478 passed, 1569 assertions**, no regressions.
- [x] `vendor/bin/pint --test` — clean across 354 files.
- [x] Existing `EnvironmentEndpointTest` still green (regression check on the public `/v1/environment` shape).