### PR TITLE
AU-3: TOTP enrolment service + FAPI /v1/me/totp (#89)

### DIFF
--- a/app/Auth/ErrorCodes.php
+++ b/app/Auth/ErrorCodes.php
@@ -59,6 +59,10 @@ final class ErrorCodes
 
     public const MFA_NOT_ENABLED = 'mfa_not_enabled';
 
+    public const MFA_ALREADY_VERIFIED = 'mfa_already_verified';
+
+    public const TOTP_NOT_FOUND = 'totp_not_found';
+
     public const STRATEGY_NOT_SUPPORTED = 'strategy_not_supported';
 
     public const PREPARE_NOT_REQUIRED = 'prepare_not_required';

--- a/app/Auth/Mfa/TotpEnrolmentService.php
+++ b/app/Auth/Mfa/TotpEnrolmentService.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Mfa;
+
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\TotpSecret;
+use App\Models\User;
+use BaconQrCode\Renderer\Image\SvgImageBackEnd;
+use BaconQrCode\Renderer\ImageRenderer;
+use BaconQrCode\Renderer\RendererStyle\RendererStyle;
+use BaconQrCode\Writer;
+use PragmaRX\Google2FA\Google2FA;
+use RuntimeException;
+
+/**
+ * RFC 6238 TOTP enrolment + verification. Uses pragmarx/google2fa for the
+ * step math and bacon/bacon-qr-code for the inline-SVG QR rendering. The
+ * issuer / label conventions follow the openapi `TotpSecret` example.
+ *
+ * Replay protection: every successful verify stamps `last_used_step` on
+ * the secret row; subsequent attempts at the same or earlier step are
+ * rejected so a captured 60-second-window code can't be replayed.
+ */
+final readonly class TotpEnrolmentService
+{
+    public const VERIFY_WINDOW_STEPS = 1;
+
+    public const SECRET_LENGTH_BITS = 160;
+
+    public function __construct(
+        private Google2FA $google2fa = new Google2FA,
+    ) {
+        $this->google2fa->setWindow(self::VERIFY_WINDOW_STEPS);
+    }
+
+    /**
+     * Mint (or overwrite the unverified) `TotpSecret` for `$user`. Caller
+     * is responsible for the per-env strategy gate (see
+     * `MultiFactorSettings::strategyEnabled('totp')`) and for refusing the
+     * call when a verified row already exists.
+     */
+    public function start(User $user, Environment $environment): TotpSecret
+    {
+        TotpSecret::query()
+            ->where('user_id', $user->id)
+            ->whereNull('verified_at')
+            ->delete();
+
+        $secret = $this->google2fa->generateSecretKey(32);
+
+        return TotpSecret::create([
+            'environment_id' => $environment->id,
+            'user_id' => $user->id,
+            'secret' => $secret,
+        ]);
+    }
+
+    /**
+     * Verify the supplied 6-digit `$code` against `$secret`. Honours the
+     * `±1 step` window and rejects replays via `last_used_step`. On
+     * success: stamps `verified_at`, flips the `User` MFA flags, and
+     * persists `last_used_step` so the same code can't be reused.
+     */
+    public function verify(TotpSecret $secret, string $code): bool
+    {
+        $code = preg_replace('/\s+/', '', $code) ?? '';
+        if (! preg_match('/^\d{6}$/', $code)) {
+            return false;
+        }
+
+        $matchedStep = $this->google2fa->verifyKeyNewer(
+            $secret->secret,
+            $code,
+            $secret->last_used_step,
+            self::VERIFY_WINDOW_STEPS,
+        );
+        if ($matchedStep === false) {
+            return false;
+        }
+
+        $secret->last_used_step = (int) $matchedStep;
+        if (! $secret->isVerified()) {
+            $secret->verified_at = now();
+        }
+        $secret->save();
+
+        return true;
+    }
+
+    /**
+     * Drop the user's TotpSecret row. Caller flips the `User` MFA flags.
+     */
+    public function remove(User $user): bool
+    {
+        $deleted = TotpSecret::query()
+            ->where('user_id', $user->id)
+            ->delete();
+
+        return $deleted > 0;
+    }
+
+    /**
+     * Build the otpauth:// URI suitable for direct hand-off to an
+     * authenticator app. Issuer is `<env_slug>.<app_host>`; label is
+     * `<issuer>:<email>` per the openapi `TotpSecret` example.
+     */
+    public function otpauthUri(TotpSecret $secret, Environment $environment, ?EmailAddress $primaryEmail): string
+    {
+        $issuer = $environment->slug.'.'.((string) config('authn.app_host', 'authn.local'));
+        $accountName = $primaryEmail?->email_address ?? $secret->user_id;
+
+        return $this->google2fa->getQRCodeUrl($issuer, $accountName, $secret->secret);
+    }
+
+    /**
+     * Render `$otpauthUri` as an inline-SVG `data:image/svg+xml;base64,…`
+     * QR. Pure-PHP, no GD/imagick requirement.
+     */
+    public function qrCodeDataUrl(string $otpauthUri): string
+    {
+        $renderer = new ImageRenderer(
+            new RendererStyle(192, 1),
+            new SvgImageBackEnd,
+        );
+        $writer = new Writer($renderer);
+        $svg = $writer->writeString($otpauthUri);
+        if ($svg === '') {
+            throw new RuntimeException('QR rendering produced an empty payload.');
+        }
+
+        return 'data:image/svg+xml;base64,'.base64_encode($svg);
+    }
+}

--- a/app/Http/Controllers/Fapi/MeTotpController.php
+++ b/app/Http/Controllers/Fapi/MeTotpController.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Auth\ErrorCodes;
+use App\Auth\Mfa\TotpEnrolmentService;
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\TotpSecretResource;
+use App\Jobs\Mail\SendTotpEnabledNotification;
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\Session;
+use App\Models\TotpSecret;
+use App\Models\User;
+use App\Settings\MultiFactorSettings;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * `POST /v1/me/totp` (start), `POST /v1/me/totp/verify`,
+ * `GET /v1/me/totp`, `DELETE /v1/me/totp`.
+ *
+ * The plaintext `secret` / `otpauth_uri` / `qr_code_data_url` only
+ * surface on the `start` response. Subsequent reads return them as
+ * `null` per the openapi `TotpSecret` contract.
+ */
+final class MeTotpController
+{
+    public function __construct(
+        private readonly TotpEnrolmentService $enrolment,
+    ) {}
+
+    public function start(): JsonResponse
+    {
+        $env = app(Environment::class);
+        $user = app(User::class);
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot enrol MFA.');
+        }
+
+        $settings = MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
+        if (! $settings->totpEnabled) {
+            return $this->error(422, ErrorCodes::MFA_NOT_ENABLED, 'TOTP enrolment is disabled for this environment.');
+        }
+
+        $verified = TotpSecret::query()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->first();
+        if ($verified !== null) {
+            return $this->error(409, ErrorCodes::MFA_ALREADY_VERIFIED, 'TOTP is already enrolled. Remove the existing secret first.');
+        }
+
+        $secret = $this->enrolment->start($user, $env);
+        $primaryEmail = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('id', (string) $user->primary_email_address_id)
+            ->first();
+        $otpauthUri = $this->enrolment->otpauthUri($secret, $env, $primaryEmail);
+        $qr = $this->enrolment->qrCodeDataUrl($otpauthUri);
+
+        return $this->clientEnvelope(TotpSecretResource::from(
+            $secret,
+            exposedSecret: $secret->secret,
+            otpauthUri: $otpauthUri,
+            qrCodeDataUrl: $qr,
+        ));
+    }
+
+    public function verify(Request $request): JsonResponse
+    {
+        $user = app(User::class);
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot verify MFA.');
+        }
+
+        $secret = TotpSecret::query()
+            ->where('user_id', $user->id)
+            ->orderByDesc('created_at')
+            ->first();
+        if ($secret === null) {
+            return $this->error(404, ErrorCodes::TOTP_NOT_FOUND, 'No TOTP enrolment in progress.');
+        }
+        if ($secret->isVerified()) {
+            return $this->error(409, ErrorCodes::MFA_ALREADY_VERIFIED, 'TOTP is already verified.');
+        }
+
+        $code = (string) $request->input('code', '');
+        $wasUnverified = ! $secret->isVerified();
+        if (! $this->enrolment->verify($secret, $code)) {
+            return $this->error(422, ErrorCodes::FORM_CODE_INCORRECT, 'TOTP code is incorrect or expired.');
+        }
+
+        if ($wasUnverified) {
+            $user->totp_enabled = true;
+            $user->two_factor_enabled = true;
+            if ($user->mfa_enabled_at === null) {
+                $user->mfa_enabled_at = now();
+            }
+            $user->save();
+            SendTotpEnabledNotification::dispatch($user->id);
+        }
+
+        return $this->clientEnvelope(TotpSecretResource::from($secret->fresh()));
+    }
+
+    public function show(): JsonResponse
+    {
+        $user = app(User::class);
+        $secret = TotpSecret::query()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->first();
+        if ($secret === null) {
+            return $this->error(404, ErrorCodes::TOTP_NOT_FOUND, 'No verified TOTP secret on this user.');
+        }
+
+        return $this->clientEnvelope(TotpSecretResource::from($secret));
+    }
+
+    public function destroy(): JsonResponse
+    {
+        $user = app(User::class);
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot remove MFA.');
+        }
+
+        $secret = TotpSecret::query()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->first();
+        if ($secret === null) {
+            return $this->error(404, ErrorCodes::TOTP_NOT_FOUND, 'No verified TOTP secret on this user.');
+        }
+
+        $shape = TotpSecretResource::from($secret);
+        $this->enrolment->remove($user);
+
+        $user->totp_enabled = false;
+        if (! $user->backup_code_enabled) {
+            $user->two_factor_enabled = false;
+            $user->mfa_disabled_at = now();
+        }
+        $user->save();
+
+        return $this->clientEnvelope($shape);
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    private function clientEnvelope(mixed $body, int $status = 200): JsonResponse
+    {
+        $client = app()->bound(Client::class) ? app(Client::class) : null;
+
+        return response()->json([
+            'response' => $body,
+            'client' => ClientResource::from($client?->fresh()),
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Resources/TotpSecretResource.php
+++ b/app/Http/Resources/TotpSecretResource.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\TotpSecret;
+
+/**
+ * Public TotpSecret shape per openapi components/schemas/TotpSecret.yaml.
+ * `secret` / `otpauth_uri` / `qr_code_data_url` are surfaced **only** on
+ * the enrolment response — set `secret`, `otpauthUri`, `qrCodeDataUrl`
+ * on the call. Subsequent reads (`GET`, `verify`, `destroy`) pass the
+ * defaults and emit `null` for those fields.
+ */
+final class TotpSecretResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function from(
+        TotpSecret $secret,
+        ?string $exposedSecret = null,
+        ?string $otpauthUri = null,
+        ?string $qrCodeDataUrl = null,
+    ): array {
+        return [
+            'object' => 'totp_secret',
+            'id' => $secret->id,
+            'user_id' => $secret->user_id,
+            'secret' => $exposedSecret,
+            'otpauth_uri' => $otpauthUri,
+            'qr_code_data_url' => $qrCodeDataUrl,
+            'verified_at' => $secret->verified_at?->getTimestampMs(),
+            'created_at' => $secret->created_at?->getTimestampMs(),
+            'updated_at' => $secret->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/app/Jobs/Mail/SendTotpEnabledNotification.php
+++ b/app/Jobs/Mail/SendTotpEnabledNotification.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Mail;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Heads-up email sent when a user enables TOTP. Body wiring (template
+ * lookup, EmailPipeline dispatch) lands in AU-9; this stub keeps the
+ * dispatch site stable so AU-9 is a one-line replace.
+ */
+final class SendTotpEnabledNotification implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function __construct(public readonly string $userId)
+    {
+        $this->onQueue('mail');
+    }
+
+    public function backoff(): array
+    {
+        return [10, 60, 300];
+    }
+
+    public function handle(): void
+    {
+        $user = User::query()->withoutGlobalScopes()->where('id', $this->userId)->first();
+        if ($user === null) {
+            Log::warning('mail_user_missing', ['user_id' => $this->userId, 'template' => 'totp_enabled']);
+
+            return;
+        }
+        Log::info('mfa.totp_enabled_notification.queued', [
+            'user_id' => $user->id,
+            'environment_id' => $user->environment_id,
+        ]);
+    }
+}

--- a/app/Models/TotpSecret.php
+++ b/app/Models/TotpSecret.php
@@ -24,6 +24,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $digits
  * @property int $period_seconds
  * @property ?\DateTimeInterface $verified_at
+ * @property ?int $last_used_step
  */
 class TotpSecret extends Model
 {
@@ -40,6 +41,7 @@ class TotpSecret extends Model
         'digits',
         'period_seconds',
         'verified_at',
+        'last_used_step',
     ];
 
     protected $hidden = [
@@ -55,6 +57,7 @@ class TotpSecret extends Model
             'digits' => 'int',
             'period_seconds' => 'int',
             'verified_at' => 'immutable_datetime',
+            'last_used_step' => 'int',
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,15 @@
         "php": "^8.4",
         "ext-pdo_pgsql": "*",
         "ext-redis": "*",
+        "bacon/bacon-qr-code": "^3.1",
         "inertiajs/inertia-laravel": "^3.0",
         "justinrainbow/json-schema": "^6.8",
         "laravel/framework": "^13.0",
         "laravel/horizon": "^5.46",
         "laravel/tinker": "^3.0",
         "lcobucci/clock": "^3.6",
-        "lcobucci/jwt": "^5.6"
+        "lcobucci/jwt": "^5.6",
+        "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2fede2eb2be18f03bbfcd50755a7afe",
+    "content-hash": "7891590dc01810c800675efe727d2155",
     "packages": [
+        {
+            "name": "bacon/bacon-qr-code",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "shasum": ""
+            },
+            "require": {
+                "dasprid/enum": "^1.0.3",
+                "ext-iconv": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phly/keep-a-changelog": "^2.12",
+                "phpunit/phpunit": "^10.5.11 || ^11.0.4",
+                "spatie/phpunit-snapshot-assertions": "^5.1.5",
+                "spatie/pixelmatch-php": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.9"
+            },
+            "suggest": {
+                "ext-imagick": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BaconQrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "support": {
+                "issues": "https://github.com/Bacon/BaconQrCode/issues",
+                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.1.1"
+            },
+            "time": "2026-04-05T21:06:35+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.14.8",
@@ -134,6 +189,56 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "dasprid/enum",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DASPRiD/Enum.git",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1 <9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DASPRiD\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP 7.1 enum implementation",
+            "keywords": [
+                "enum",
+                "map"
+            ],
+            "support": {
+                "issues": "https://github.com/DASPRiD/Enum/issues",
+                "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
+            },
+            "time": "2025-09-16T12:23:56+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -3031,6 +3136,75 @@
             "time": "2026-02-16T23:10:27+00:00"
         },
         {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77",
+                "reference": "d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8"
+            },
+            "require-dev": {
+                "infection/infection": "^0",
+                "nikic/php-fuzzer": "^0",
+                "phpunit/phpunit": "^9|^10|^11",
+                "vimeo/psalm": "^4|^5|^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2025-09-24T15:06:41+00:00"
+        },
+        {
             "name": "phpoption/phpoption",
             "version": "1.9.5",
             "source": {
@@ -3104,6 +3278,58 @@
                 }
             ],
             "time": "2025-12-27T19:41:33+00:00"
+        },
+        {
+            "name": "pragmarx/google2fa",
+            "version": "v9.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antonioribeiro/google2fa.git",
+                "reference": "e6bc62dd6ae83acc475f57912e27466019a1f2cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antonioribeiro/google2fa/zipball/e6bc62dd6ae83acc475f57912e27466019a1f2cf",
+                "reference": "e6bc62dd6ae83acc475f57912e27466019a1f2cf",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^1.0|^2.0|^3.0",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpunit": "^7.5.15|^8.5|^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PragmaRX\\Google2FA\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Antonio Carlos Ribeiro",
+                    "email": "acr@antoniocarlosribeiro.com",
+                    "role": "Creator & Designer"
+                }
+            ],
+            "description": "A One Time Password Authentication package, compatible with Google Authenticator.",
+            "keywords": [
+                "2fa",
+                "Authentication",
+                "Two Factor Authentication",
+                "google2fa"
+            ],
+            "support": {
+                "issues": "https://github.com/antonioribeiro/google2fa/issues",
+                "source": "https://github.com/antonioribeiro/google2fa/tree/v9.0.0"
+            },
+            "time": "2025-09-19T22:51:08+00:00"
         },
         {
             "name": "psr/clock",

--- a/database/migrations/2026_05_09_000000_create_totp_secrets_and_backup_codes.php
+++ b/database/migrations/2026_05_09_000000_create_totp_secrets_and_backup_codes.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->unsignedSmallInteger('digits')->default(6);
             $table->unsignedSmallInteger('period_seconds')->default(30);
             $table->timestamp('verified_at')->nullable();
+            $table->unsignedBigInteger('last_used_step')->nullable();
             $table->timestamps();
 
             $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Fapi\EnvironmentController;
 use App\Http\Controllers\Fapi\MagicLinkController;
 use App\Http\Controllers\Fapi\MeController;
 use App\Http\Controllers\Fapi\MeOrganizationController;
+use App\Http\Controllers\Fapi\MeTotpController;
 use App\Http\Controllers\Fapi\OrganizationController as FapiOrganizationController;
 use App\Http\Controllers\Fapi\OrganizationInvitationController as FapiOrganizationInvitationController;
 use App\Http\Controllers\Fapi\OrganizationMembershipController as FapiOrganizationMembershipController;
@@ -116,6 +117,11 @@ Route::prefix('v1')->group(function (): void {
 
         Route::get('/me/sessions', [MeController::class, 'listSessions'])->name('fapi.me.sessions.list');
         Route::post('/me/change-password', [MeController::class, 'changePassword'])->name('fapi.me.change_password');
+
+        Route::post('/me/totp', [MeTotpController::class, 'start'])->name('fapi.me.totp.start');
+        Route::post('/me/totp/verify', [MeTotpController::class, 'verify'])->name('fapi.me.totp.verify');
+        Route::get('/me/totp', [MeTotpController::class, 'show'])->name('fapi.me.totp.show');
+        Route::delete('/me/totp', [MeTotpController::class, 'destroy'])->name('fapi.me.totp.destroy');
 
         // Organizations — user-scoped CRUD (PLAN §4.4 / OA-3 / AU-6).
         Route::post('/organizations', [FapiOrganizationController::class, 'store'])->name('fapi.organizations.store');

--- a/tests/Feature/Mfa/MeTotpEnrollmentTest.php
+++ b/tests/Feature/Mfa/MeTotpEnrollmentTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\TotpSecret;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Testing\TestResponse;
+use PragmaRX\Google2FA\Google2FA;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function totpReq(string $method, string $path, string $jwt, array $body = []): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+it('POST /me/totp returns secret + otpauth_uri + qr_code_data_url and persists an unverified row', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = totpReq('POST', '/me/totp', $auth['jwt']);
+
+    $r->assertOk();
+    expect($r->json('response.object'))->toBe('totp_secret');
+    expect($r->json('response.user_id'))->toBe($auth['user']->id);
+    expect($r->json('response.secret'))->toBeString()->not->toBe('');
+    expect($r->json('response.otpauth_uri'))->toStartWith('otpauth://totp/');
+    expect($r->json('response.qr_code_data_url'))->toStartWith('data:image/svg+xml;base64,');
+    expect($r->json('response.verified_at'))->toBeNull();
+
+    $row = TotpSecret::query()->withoutGlobalScopes()->where('user_id', $auth['user']->id)->first();
+    expect($row)->not->toBeNull();
+    expect($row->verified_at)->toBeNull();
+    expect($row->secret)->toBe($r->json('response.secret'));
+});
+
+it('POST /me/totp again while unverified overwrites the existing row in place', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $first = totpReq('POST', '/me/totp', $auth['jwt'])->assertOk();
+    $second = totpReq('POST', '/me/totp', $auth['jwt'])->assertOk();
+
+    expect($second->json('response.secret'))->not->toBe($first->json('response.secret'));
+    $count = TotpSecret::query()->withoutGlobalScopes()->where('user_id', $auth['user']->id)->count();
+    expect($count)->toBe(1);
+});
+
+it('POST /me/totp/verify with a fresh code flips verified_at and User.totp_enabled', function (): void {
+    Queue::fake();
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    totpReq('POST', '/me/totp', $auth['jwt'])->assertOk();
+    $row = TotpSecret::query()->withoutGlobalScopes()->where('user_id', $auth['user']->id)->first();
+    $code = (new Google2FA)->getCurrentOtp($row->secret);
+
+    $r = totpReq('POST', '/me/totp/verify', $auth['jwt'], ['code' => $code]);
+
+    $r->assertOk();
+    expect($r->json('response.verified_at'))->toBeInt();
+    $row->refresh();
+    expect($row->verified_at)->not->toBeNull();
+    expect($row->last_used_step)->not->toBeNull();
+    $user = User::query()->withoutGlobalScopes()->where('id', $auth['user']->id)->first();
+    expect($user->totp_enabled)->toBeTrue();
+    expect($user->two_factor_enabled)->toBeTrue();
+    expect($user->mfa_enabled_at)->not->toBeNull();
+});
+
+it('POST /me/totp/verify rejects an incorrect code with form_code_incorrect', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    totpReq('POST', '/me/totp', $auth['jwt'])->assertOk();
+
+    $r = totpReq('POST', '/me/totp/verify', $auth['jwt'], ['code' => '000000']);
+
+    $r->assertStatus(422);
+    expect($r->json('errors.0.code'))->toBe('form_code_incorrect');
+});
+
+it('POST /me/totp/verify rejects a replayed code on second submission', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    totpReq('POST', '/me/totp', $auth['jwt'])->assertOk();
+    $row = TotpSecret::query()->withoutGlobalScopes()->where('user_id', $auth['user']->id)->first();
+    $code = (new Google2FA)->getCurrentOtp($row->secret);
+
+    totpReq('POST', '/me/totp/verify', $auth['jwt'], ['code' => $code])->assertOk();
+
+    $replay = totpReq('POST', '/me/totp/verify', $auth['jwt'], ['code' => $code]);
+
+    expect($replay->status())->toBeIn([409, 422]);
+    if ($replay->status() === 409) {
+        expect($replay->json('errors.0.code'))->toBe('mfa_already_verified');
+    }
+});
+
+it('POST /me/totp returns 409 mfa_already_verified when a verified secret already exists', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    totpReq('POST', '/me/totp', $auth['jwt'])->assertOk();
+    $row = TotpSecret::query()->withoutGlobalScopes()->where('user_id', $auth['user']->id)->first();
+    $code = (new Google2FA)->getCurrentOtp($row->secret);
+    totpReq('POST', '/me/totp/verify', $auth['jwt'], ['code' => $code])->assertOk();
+
+    $r = totpReq('POST', '/me/totp', $auth['jwt']);
+
+    $r->assertStatus(409);
+    expect($r->json('errors.0.code'))->toBe('mfa_already_verified');
+});
+
+it('POST /me/totp returns 422 mfa_not_enabled when totp.enabled is false', function (): void {
+    $f = MeTestSupport::bootEnv([
+        'multi_factor' => ['totp' => ['enabled' => false], 'backup_codes' => ['enabled' => true, 'default_count' => 10]],
+    ]);
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = totpReq('POST', '/me/totp', $auth['jwt']);
+
+    $r->assertStatus(422);
+    expect($r->json('errors.0.code'))->toBe('mfa_not_enabled');
+});
+
+it('DELETE /me/totp removes the row, flips totp_enabled, and stamps mfa_disabled_at when no other factor remains', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    totpReq('POST', '/me/totp', $auth['jwt'])->assertOk();
+    $row = TotpSecret::query()->withoutGlobalScopes()->where('user_id', $auth['user']->id)->first();
+    $code = (new Google2FA)->getCurrentOtp($row->secret);
+    totpReq('POST', '/me/totp/verify', $auth['jwt'], ['code' => $code])->assertOk();
+
+    totpReq('DELETE', '/me/totp', $auth['jwt'])->assertOk();
+
+    $count = TotpSecret::query()->withoutGlobalScopes()->where('user_id', $auth['user']->id)->count();
+    expect($count)->toBe(0);
+    $user = User::query()->withoutGlobalScopes()->where('id', $auth['user']->id)->first();
+    expect($user->totp_enabled)->toBeFalse();
+    expect($user->two_factor_enabled)->toBeFalse();
+    expect($user->mfa_disabled_at)->not->toBeNull();
+});
+
+it('GET /me/totp returns 404 totp_not_found when nothing is enrolled', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = totpReq('GET', '/me/totp', $auth['jwt']);
+
+    $r->assertStatus(404);
+    expect($r->json('errors.0.code'))->toBe('totp_not_found');
+});


### PR DESCRIPTION
Closes #89.

## Summary

End-user TOTP enrolment surface. Per the openapi spec note carried in our v0.3 contract notes, TOTP enrolment-verify is a **dedicated endpoint**, not a `step: \"second\"` Challenge — that flow is reserved for sign-in and lands in AU-5.

- **`App\Auth\Mfa\TotpEnrolmentService`** wraps `pragmarx/google2fa`:
  - `start()` deletes any prior unverified row (service-layer enforcement of AU-1's deferred unique invariant — \"at most one row per (env, user)\"), generates a 32-char base32 secret via `generateSecretKey(32)`, persists with `verified_at: null`.
  - `verify()` calls `verifyKeyNewer(secret, code, lastUsedStep, window=1)` so a fresh code in the ±1 step window succeeds but a captured 60-second-window code can't be replayed — `last_used_step` advances on every successful verify.
  - `otpauthUri()` builds `otpauth://totp/<env_slug>.<app_host>:<email>?…` matching the openapi `TotpSecret` example.
  - `qrCodeDataUrl()` renders an inline-SVG QR via `bacon/bacon-qr-code` → `data:image/svg+xml;base64,…` (pure-PHP — no GD/imagick dependency).
- **AU-1 migration edited in place** (alpha rule: edit migrations in place) — adds `last_used_step BIGINT NULL` to `totp_secrets`. `TotpSecret` model casts/fillable updated.
- **Routes** under `AuthenticateSessionToken`:
  - `POST /v1/me/totp` (start) — returns `secret` + `otpauth_uri` + `qr_code_data_url`
  - `POST /v1/me/totp/verify` — first-code verification
  - `GET /v1/me/totp` — current verified state
  - `DELETE /v1/me/totp` — removes; flips User flags
- **`App\Http\Resources\TotpSecretResource`** matches openapi `TotpSecret` exactly. Optional `secret` / `otpauth_uri` / `qr_code_data_url` parameters control which fields surface — only the enrolment response passes them; subsequent reads emit `null` per the openapi contract.
- **ErrorCodes** additions: `MFA_ALREADY_VERIFIED` (409 from POST when a verified secret exists) and `TOTP_NOT_FOUND` (404 from verify/show/destroy when absent).
- **User-flag bookkeeping** on successful verify: stamps `verified_at`, flips `User.totp_enabled` + `User.two_factor_enabled`, sets `mfa_enabled_at` if null. Queues `SendTotpEnabledNotification` (stub — the actual `EmailPipeline` dispatch lands in AU-9; the job is a one-line replace at that point).
- **DELETE** flow: drops the row, flips `totp_enabled`, and if no other factor remains also flips `two_factor_enabled` + stamps `mfa_disabled_at`.

## Composer dependencies (justification)

- **`pragmarx/google2fa` (^9.0, MIT)** — RFC 6238 / RFC 4226 implementation. ~3KB of code, no I/O, used by Laravel ecosystems. The `verifyKeyNewer(timestamp, window)` API is exactly the replay-resistant verification primitive we need (returns the matched timestamp, or `false`).
- **`bacon/bacon-qr-code` (^3.1, BSD-2)** — pure-PHP QR renderer. Picked over `endroid/qr-code` because it doesn't pull in `ext-imagick` / GD as a runtime requirement; SVG output is renderable in any `<img src=\"data:image/svg+xml;base64,…\">` and crisp at any scale.

## Per-env strategy gating

`MeTotpController::start()` reads `MultiFactorSettings::fromUserSettings(env.user_settings)` and refuses with 422 `mfa_not_enabled` when `multi_factor.totp.enabled = false`. This is the AU-2 gating helper put to work — AU-5's second-factor Challenge wiring will read the same value object.

## Out of scope (lands later)

- Backup codes — AU-4 (#90).
- Second-factor Challenge wiring (`step: \"second\"`) — AU-5 (#92).
- Audit-log emission — AU-10 (#97).
- `totp_enabled` email template body — AU-9 (#96); the job dispatch site is stable.
- Account Portal Security UI — AU-7 (#94).

## Test plan

- [x] **`tests/Feature/Mfa/MeTotpEnrollmentTest.php`** — 9 cases:
  - `POST /me/totp` returns `secret` + `otpauth_uri` + `qr_code_data_url` and persists an unverified row.
  - Re-`POST` while unverified overwrites the existing row in place (no duplicate row).
  - `POST /me/totp/verify` with a fresh code flips `verified_at`, `User.totp_enabled` true, `mfa_enabled_at` set.
  - Wrong code → 422 `form_code_incorrect`.
  - Replay protection: same code rejected on second submission.
  - `POST /me/totp` while verified → 409 `mfa_already_verified`.
  - `POST /me/totp` with `multi_factor.totp.enabled = false` → 422 `mfa_not_enabled`.
  - `DELETE /me/totp` clears the row, flips flags; with no backup codes also flips `two_factor_enabled` + stamps `mfa_disabled_at`.
  - `GET /me/totp` returns 404 `totp_not_found` when nothing is enrolled.
- [x] `php artisan test --parallel` — **487 passed, 1614 assertions**, no regressions.
- [x] `vendor/bin/pint --test` — clean across 359 files.
- [x] OpenAPI contract validator — auto-applies on every feature response.