### PR TITLE
AU-4: backup codes service + FAPI /v1/me/backup-codes (#90)

### DIFF
--- a/app/Auth/ErrorCodes.php
+++ b/app/Auth/ErrorCodes.php
@@ -63,6 +63,8 @@ final class ErrorCodes
 
     public const TOTP_NOT_FOUND = 'totp_not_found';
 
+    public const MFA_PRIMARY_FACTOR_REQUIRED = 'mfa_primary_factor_required';
+
     public const STRATEGY_NOT_SUPPORTED = 'strategy_not_supported';
 
     public const PREPARE_NOT_REQUIRED = 'prepare_not_required';

--- a/app/Auth/Mfa/BackupCodesService.php
+++ b/app/Auth/Mfa/BackupCodesService.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Mfa;
+
+use App\Models\BackupCode;
+use App\Models\Environment;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Random\Randomizer;
+
+/**
+ * Single-use recovery code lifecycle. Plaintext is exposed only via the
+ * value object returned by `regenerate()`; rows persist as Argon2id
+ * hashes. AU-5's second-factor flow consumes them via `consume()`.
+ *
+ * Per AU-2's `MultiFactorSettings::strategyEnabled('backup_code')`, the
+ * controller layer decides whether the strategy is enabled at the env
+ * level — this service stays unaware of that gating.
+ */
+final class BackupCodesService
+{
+    public const ALPHABET = '0123456789abcdefghjkmnpqrstvwxyz';
+
+    public const HALF_LENGTH = 4;
+
+    /**
+     * (Re)generate `$count` plaintext codes for `$user`. Wipes any prior
+     * un-consumed rows first so the freshly-shown batch is the only
+     * spendable one — old shown codes stop working immediately.
+     *
+     * Returns plaintext codes; the caller wraps them into the one-time
+     * `BackupCodeBatch` reveal envelope and discards the array when the
+     * response leaves the process.
+     *
+     * @return list<string>
+     */
+    public function regenerate(User $user, Environment $environment, int $count): array
+    {
+        BackupCode::query()
+            ->where('user_id', $user->id)
+            ->whereNull('consumed_at')
+            ->delete();
+
+        $randomizer = new Randomizer;
+        $codes = [];
+        for ($i = 0; $i < $count; $i++) {
+            $codes[] = $this->generateCode($randomizer);
+        }
+
+        foreach ($codes as $plain) {
+            BackupCode::create([
+                'environment_id' => $environment->id,
+                'user_id' => $user->id,
+                'code_hash' => Hash::make($plain),
+            ]);
+        }
+
+        return $codes;
+    }
+
+    /**
+     * Try to consume `$plaintext` against any unspent row on `$user`.
+     * Returns `true` and stamps `consumed_at` on the matching row when
+     * successful; `false` otherwise.
+     */
+    public function consume(User $user, string $plaintext): bool
+    {
+        $plaintext = strtolower(trim($plaintext));
+        if (! preg_match('/^[a-z0-9]{4}-[a-z0-9]{4}$/', $plaintext)) {
+            return false;
+        }
+
+        $rows = BackupCode::query()
+            ->where('user_id', $user->id)
+            ->whereNull('consumed_at')
+            ->get();
+
+        foreach ($rows as $row) {
+            if (Hash::check($plaintext, $row->code_hash)) {
+                $row->markConsumed();
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Drop every unspent code on the user. Returns the count removed.
+     * Consumed rows stay for audit-log purposes.
+     */
+    public function removeUnspent(User $user): int
+    {
+        return BackupCode::query()
+            ->where('user_id', $user->id)
+            ->whereNull('consumed_at')
+            ->delete();
+    }
+
+    public function unspentCount(User $user): int
+    {
+        return BackupCode::query()
+            ->where('user_id', $user->id)
+            ->whereNull('consumed_at')
+            ->count();
+    }
+
+    private function generateCode(Randomizer $randomizer): string
+    {
+        $alphabetLen = strlen(self::ALPHABET);
+        $halves = [];
+        for ($half = 0; $half < 2; $half++) {
+            $buf = '';
+            for ($i = 0; $i < self::HALF_LENGTH; $i++) {
+                $buf .= self::ALPHABET[$randomizer->getInt(0, $alphabetLen - 1)];
+            }
+            $halves[] = $buf;
+        }
+
+        return $halves[0].'-'.$halves[1];
+    }
+}

--- a/app/Http/Controllers/Fapi/MeBackupCodesController.php
+++ b/app/Http/Controllers/Fapi/MeBackupCodesController.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Auth\ErrorCodes;
+use App\Auth\Mfa\BackupCodesService;
+use App\Http\Resources\BackupCodeBatchResource;
+use App\Http\Resources\ClientResource;
+use App\Jobs\Mail\SendBackupCodesGeneratedNotification;
+use App\Models\BackupCode;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Session;
+use App\Models\TotpSecret;
+use App\Models\User;
+use App\Settings\MultiFactorSettings;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * `POST /v1/me/backup-codes` regenerates a one-time `BackupCodeBatch`,
+ * `GET /v1/me/backup-codes` returns the current unspent count (no
+ * plaintext re-surfaced), `DELETE /v1/me/backup-codes` removes every
+ * unspent row.
+ *
+ * Backup codes are gated on a verified TOTP enrolment — they're a
+ * recovery factor, not a standalone primary one.
+ */
+final class MeBackupCodesController
+{
+    public function __construct(
+        private readonly BackupCodesService $service,
+    ) {}
+
+    public function regenerate(): JsonResponse
+    {
+        $env = app(Environment::class);
+        $user = app(User::class);
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot regenerate backup codes.');
+        }
+
+        $settings = MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
+        if (! $settings->backupCodesEnabled) {
+            return $this->error(422, ErrorCodes::MFA_NOT_ENABLED, 'Backup codes are disabled for this environment.');
+        }
+
+        $hasVerifiedTotp = TotpSecret::query()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->exists();
+        if (! $hasVerifiedTotp) {
+            return $this->error(422, ErrorCodes::MFA_PRIMARY_FACTOR_REQUIRED, 'Set up an authenticator app before generating backup codes.');
+        }
+
+        $codes = $this->service->regenerate($user, $env, $settings->backupCodesDefaultCount);
+
+        $user->backup_code_enabled = true;
+        if (! $user->two_factor_enabled) {
+            $user->two_factor_enabled = true;
+            if ($user->mfa_enabled_at === null) {
+                $user->mfa_enabled_at = now();
+            }
+        }
+        $user->save();
+
+        SendBackupCodesGeneratedNotification::dispatch($user->id);
+
+        return $this->clientEnvelope(BackupCodeBatchResource::from($user->fresh(), $codes));
+    }
+
+    public function show(): JsonResponse
+    {
+        $user = app(User::class);
+        $count = $this->service->unspentCount($user);
+
+        return $this->clientEnvelope([
+            'object' => 'backup_code_batch',
+            'user_id' => $user->id,
+            'count' => $count,
+            'codes' => [],
+            'generated_at' => $this->latestGeneratedAtMs($user) ?? now()->getTimestampMs(),
+        ]);
+    }
+
+    public function destroy(): JsonResponse
+    {
+        $user = app(User::class);
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot remove backup codes.');
+        }
+
+        $this->service->removeUnspent($user);
+
+        $user->backup_code_enabled = false;
+        $hasTotp = TotpSecret::query()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->exists();
+        if (! $hasTotp) {
+            $user->two_factor_enabled = false;
+            $user->mfa_disabled_at = now();
+        }
+        $user->save();
+
+        return $this->clientEnvelope(BackupCodeBatchResource::empty($user->fresh()));
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    private function latestGeneratedAtMs(User $user): ?int
+    {
+        $row = BackupCode::query()
+            ->where('user_id', $user->id)
+            ->orderByDesc('created_at')
+            ->first();
+
+        return $row?->created_at?->getTimestampMs();
+    }
+
+    private function clientEnvelope(mixed $body, int $status = 200): JsonResponse
+    {
+        $client = app()->bound(Client::class) ? app(Client::class) : null;
+
+        return response()->json([
+            'response' => $body,
+            'client' => ClientResource::from($client?->fresh()),
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Resources/BackupCodeBatchResource.php
+++ b/app/Http/Resources/BackupCodeBatchResource.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\User;
+
+/**
+ * One-time reveal envelope per openapi components/schemas/BackupCodeBatch.yaml.
+ * Plaintext codes are passed in only on the regeneration response;
+ * subsequent reads (status, delete) emit `count: 0, codes: []` for
+ * shape consistency.
+ */
+final class BackupCodeBatchResource
+{
+    /**
+     * @param  list<string>  $codes
+     * @return array<string, mixed>
+     */
+    public static function from(User $user, array $codes, ?int $generatedAtMs = null): array
+    {
+        return [
+            'object' => 'backup_code_batch',
+            'user_id' => $user->id,
+            'count' => count($codes),
+            'codes' => $codes,
+            'generated_at' => $generatedAtMs ?? now()->getTimestampMs(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function empty(User $user): array
+    {
+        return self::from($user, []);
+    }
+}

--- a/app/Jobs/Mail/SendBackupCodesGeneratedNotification.php
+++ b/app/Jobs/Mail/SendBackupCodesGeneratedNotification.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Mail;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Heads-up email sent when a user (re)generates backup codes. Body
+ * wiring (template lookup, EmailPipeline dispatch) lands in AU-9; this
+ * stub keeps the dispatch site stable so AU-9 is a one-line replace.
+ */
+final class SendBackupCodesGeneratedNotification implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function __construct(public readonly string $userId)
+    {
+        $this->onQueue('mail');
+    }
+
+    public function backoff(): array
+    {
+        return [10, 60, 300];
+    }
+
+    public function handle(): void
+    {
+        $user = User::query()->withoutGlobalScopes()->where('id', $this->userId)->first();
+        if ($user === null) {
+            Log::warning('mail_user_missing', ['user_id' => $this->userId, 'template' => 'backup_codes_generated']);
+
+            return;
+        }
+        Log::info('mfa.backup_codes_generated_notification.queued', [
+            'user_id' => $user->id,
+            'environment_id' => $user->environment_id,
+        ]);
+    }
+}

--- a/app/Models/BackupCode.php
+++ b/app/Models/BackupCode.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $environment_id
  * @property string $user_id
  * @property string $code_hash
- * @property ?\DateTimeInterface $used_at
+ * @property ?\DateTimeInterface $consumed_at
  * @property \DateTimeInterface $created_at
  */
 class BackupCode extends Model
@@ -34,7 +34,7 @@ class BackupCode extends Model
         'environment_id',
         'user_id',
         'code_hash',
-        'used_at',
+        'consumed_at',
     ];
 
     protected $hidden = [
@@ -44,7 +44,7 @@ class BackupCode extends Model
     protected function casts(): array
     {
         return [
-            'used_at' => 'immutable_datetime',
+            'consumed_at' => 'immutable_datetime',
         ];
     }
 
@@ -63,13 +63,13 @@ class BackupCode extends Model
         return $this->belongsTo(Environment::class);
     }
 
-    public function isUsed(): bool
+    public function isConsumed(): bool
     {
-        return $this->used_at !== null;
+        return $this->consumed_at !== null;
     }
 
-    public function markUsed(): void
+    public function markConsumed(): void
     {
-        $this->forceFill(['used_at' => now()])->save();
+        $this->forceFill(['consumed_at' => now()])->save();
     }
 }

--- a/database/migrations/2026_05_09_000000_create_totp_secrets_and_backup_codes.php
+++ b/database/migrations/2026_05_09_000000_create_totp_secrets_and_backup_codes.php
@@ -30,12 +30,12 @@ return new class extends Migration
             $table->string('environment_id', 64);
             $table->string('user_id', 64);
             $table->string('code_hash', 255);
-            $table->timestamp('used_at')->nullable();
+            $table->timestamp('consumed_at')->nullable();
             $table->timestamp('created_at')->useCurrent();
 
             $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
             $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
-            $table->index(['environment_id', 'user_id', 'used_at']);
+            $table->index(['environment_id', 'user_id', 'consumed_at']);
         });
     }
 

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Fapi\ChallengeController;
 use App\Http\Controllers\Fapi\ClientController;
 use App\Http\Controllers\Fapi\EnvironmentController;
 use App\Http\Controllers\Fapi\MagicLinkController;
+use App\Http\Controllers\Fapi\MeBackupCodesController;
 use App\Http\Controllers\Fapi\MeController;
 use App\Http\Controllers\Fapi\MeOrganizationController;
 use App\Http\Controllers\Fapi\MeTotpController;
@@ -122,6 +123,10 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/me/totp/verify', [MeTotpController::class, 'verify'])->name('fapi.me.totp.verify');
         Route::get('/me/totp', [MeTotpController::class, 'show'])->name('fapi.me.totp.show');
         Route::delete('/me/totp', [MeTotpController::class, 'destroy'])->name('fapi.me.totp.destroy');
+
+        Route::post('/me/backup-codes', [MeBackupCodesController::class, 'regenerate'])->name('fapi.me.backup_codes.regenerate');
+        Route::get('/me/backup-codes', [MeBackupCodesController::class, 'show'])->name('fapi.me.backup_codes.show');
+        Route::delete('/me/backup-codes', [MeBackupCodesController::class, 'destroy'])->name('fapi.me.backup_codes.destroy');
 
         // Organizations — user-scoped CRUD (PLAN §4.4 / OA-3 / AU-6).
         Route::post('/organizations', [FapiOrganizationController::class, 'store'])->name('fapi.organizations.store');

--- a/tests/Feature/Mfa/BackupCodeModelTest.php
+++ b/tests/Feature/Mfa/BackupCodeModelTest.php
@@ -59,7 +59,7 @@ it('has no updated_at column', function (): void {
     expect($row->getAttributes())->not->toHaveKey('updated_at');
 });
 
-it('isUsed() + markUsed() track consumption', function (): void {
+it('isConsumed() + markConsumed() track consumption', function (): void {
     $env = makeEnvForBackupCode('b4');
     $user = User::create(['environment_id' => $env->id]);
 
@@ -68,11 +68,11 @@ it('isUsed() + markUsed() track consumption', function (): void {
         'user_id' => $user->id,
         'code_hash' => Hash::make('plaintext-1'),
     ]);
-    expect($row->isUsed())->toBeFalse();
+    expect($row->isConsumed())->toBeFalse();
 
-    $row->markUsed();
-    expect($row->refresh()->isUsed())->toBeTrue();
-    expect($row->used_at)->not->toBeNull();
+    $row->markConsumed();
+    expect($row->refresh()->isConsumed())->toBeTrue();
+    expect($row->consumed_at)->not->toBeNull();
 });
 
 it('scopes queries to the bound environment', function (): void {

--- a/tests/Feature/Mfa/MeBackupCodesTest.php
+++ b/tests/Feature/Mfa/MeBackupCodesTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Mfa\BackupCodesService;
+use App\Models\BackupCode;
+use App\Models\Environment;
+use App\Models\TotpSecret;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function bcReq(string $method, string $path, string $jwt, array $body = []): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+function enrolVerifiedTotp(string $environmentId, string $userId): TotpSecret
+{
+    return TotpSecret::create([
+        'environment_id' => $environmentId,
+        'user_id' => $userId,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+}
+
+it('POST /me/backup-codes returns N codes matching xxxx-xxxx, hashed at rest, prior unspent rows wiped', function (): void {
+    Queue::fake();
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    enrolVerifiedTotp($f['env']->id, $auth['user']->id);
+
+    $r = bcReq('POST', '/me/backup-codes', $auth['jwt']);
+
+    $r->assertOk();
+    expect($r->json('response.object'))->toBe('backup_code_batch');
+    expect($r->json('response.user_id'))->toBe($auth['user']->id);
+    expect($r->json('response.count'))->toBe(10);
+    $codes = $r->json('response.codes');
+    expect($codes)->toHaveCount(10);
+    foreach ($codes as $code) {
+        expect($code)->toMatch('/^[a-z0-9]{4}-[a-z0-9]{4}$/');
+    }
+    expect(array_unique($codes))->toHaveCount(10);
+
+    $rowCount = BackupCode::query()->withoutGlobalScopes()->where('user_id', $auth['user']->id)->count();
+    expect($rowCount)->toBe(10);
+    expect(User::query()->withoutGlobalScopes()->where('id', $auth['user']->id)->first()->backup_code_enabled)->toBeTrue();
+});
+
+it('POST /me/backup-codes again replaces every prior unspent row', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    enrolVerifiedTotp($f['env']->id, $auth['user']->id);
+
+    bcReq('POST', '/me/backup-codes', $auth['jwt'])->assertOk();
+    $first = BackupCode::query()->withoutGlobalScopes()->where('user_id', $auth['user']->id)->pluck('id')->all();
+
+    bcReq('POST', '/me/backup-codes', $auth['jwt'])->assertOk();
+    $second = BackupCode::query()->withoutGlobalScopes()->where('user_id', $auth['user']->id)->pluck('id')->all();
+
+    expect(array_intersect($first, $second))->toBe([]);
+    expect($second)->toHaveCount(10);
+});
+
+it('BackupCodesService::consume succeeds once and rejects replays', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    enrolVerifiedTotp($f['env']->id, $auth['user']->id);
+
+    app()->instance(Environment::class, $f['env']);
+    $codes = app(BackupCodesService::class)->regenerate($auth['user'], $f['env'], 4);
+    $service = app(BackupCodesService::class);
+
+    expect($service->consume($auth['user'], $codes[0]))->toBeTrue();
+    expect($service->consume($auth['user'], $codes[0]))->toBeFalse();
+    expect($service->consume($auth['user'], $codes[1]))->toBeTrue();
+    expect($service->unspentCount($auth['user']))->toBe(2);
+});
+
+it('POST /me/backup-codes returns 422 mfa_not_enabled when backup_codes.enabled is false', function (): void {
+    $f = MeTestSupport::bootEnv([
+        'multi_factor' => ['totp' => ['enabled' => true], 'backup_codes' => ['enabled' => false, 'default_count' => 10]],
+    ]);
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    enrolVerifiedTotp($f['env']->id, $auth['user']->id);
+
+    $r = bcReq('POST', '/me/backup-codes', $auth['jwt']);
+
+    $r->assertStatus(422);
+    expect($r->json('errors.0.code'))->toBe('mfa_not_enabled');
+});
+
+it('POST /me/backup-codes returns 422 mfa_primary_factor_required when no verified TOTP', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = bcReq('POST', '/me/backup-codes', $auth['jwt']);
+
+    $r->assertStatus(422);
+    expect($r->json('errors.0.code'))->toBe('mfa_primary_factor_required');
+});
+
+it('GET /me/backup-codes returns the unspent count without re-surfacing plaintext', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    enrolVerifiedTotp($f['env']->id, $auth['user']->id);
+    bcReq('POST', '/me/backup-codes', $auth['jwt'])->assertOk();
+
+    $r = bcReq('GET', '/me/backup-codes', $auth['jwt']);
+
+    $r->assertOk();
+    expect($r->json('response.count'))->toBe(10);
+    expect($r->json('response.codes'))->toBe([]);
+});
+
+it('DELETE /me/backup-codes empties the batch, flips backup_code_enabled, and is idempotent', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    enrolVerifiedTotp($f['env']->id, $auth['user']->id);
+    bcReq('POST', '/me/backup-codes', $auth['jwt'])->assertOk();
+
+    $r = bcReq('DELETE', '/me/backup-codes', $auth['jwt']);
+    $r->assertOk();
+    expect($r->json('response.count'))->toBe(0);
+    expect($r->json('response.codes'))->toBe([]);
+
+    $r2 = bcReq('DELETE', '/me/backup-codes', $auth['jwt']);
+    $r2->assertOk();
+    expect($r2->json('response.count'))->toBe(0);
+});
+
+it('DELETE /me/backup-codes flips two_factor_enabled off when no TOTP remains', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    enrolVerifiedTotp($f['env']->id, $auth['user']->id);
+    bcReq('POST', '/me/backup-codes', $auth['jwt'])->assertOk();
+    TotpSecret::query()->withoutGlobalScopes()->where('user_id', $auth['user']->id)->delete();
+
+    bcReq('DELETE', '/me/backup-codes', $auth['jwt'])->assertOk();
+
+    $user = User::query()->withoutGlobalScopes()->where('id', $auth['user']->id)->first();
+    expect($user->backup_code_enabled)->toBeFalse();
+    expect($user->two_factor_enabled)->toBeFalse();
+    expect($user->mfa_disabled_at)->not->toBeNull();
+});


### PR DESCRIPTION
Closes #90.

## Summary

End-user backup-code surface — recovery factor for users who lose their TOTP device. Plaintext shown **once** on the regenerate response; rows persist as Argon2id hashes and burn single-use.

### Precursor: `used_at` → `consumed_at` rename (commit `146f540`)

The merged openapi `BackupCode` schema names the wire field `consumed_at`. AU-1's migration was created with `used_at`. Per the alpha 'edit migrations in place' rule, this PR's first commit renames in AU-1's migration directly (column + index + model `\$fillable` / `\$casts` / `isUsed→isConsumed` / `markUsed→markConsumed` + matching test rename). No transitional migration in history.

### `App\Auth\Mfa\BackupCodesService`

- `regenerate(\$user, \$env, \$count)` — deletes the user's prior unspent rows so the freshly-shown batch is the only spendable one (old codes stop working immediately). Mints `\$count` plaintext codes formatted `xxxx-xxxx` (8 lowercase Crockford-base32 chars total, with mid-string hyphen) using the secure `\\Random\\Randomizer`. Hashes each via `Hash::make` (Argon2id default). Returns the plaintext list.
- `consume(\$user, \$plain)` — lowercase / trim, validate against the spec regex `/^[a-z0-9]{4}-[a-z0-9]{4}$/`, iterate the user's unspent rows, on first `Hash::check` match stamps `consumed_at` and returns `true`. AU-5 will call this from the second-factor Challenge answer flow.
- `removeUnspent(\$user)` — drops every unspent row. Consumed rows are kept for audit-log purposes per the openapi `BackupCode` lifecycle.
- `unspentCount(\$user)` — powers the GET status endpoint.

### `MeBackupCodesController`

- `POST /v1/me/backup-codes` — gates on `MultiFactorSettings::backupCodesEnabled` (422 `mfa_not_enabled`); requires a verified `TotpSecret` (422 `mfa_primary_factor_required` — backup codes are a recovery factor, not a standalone primary one); flips `User.backup_code_enabled = true` and `two_factor_enabled` if not already; queues `SendBackupCodesGeneratedNotification` (stub for AU-9). Returns `BackupCodeBatch` once with plaintext.
- `GET /v1/me/backup-codes` — returns `{ object: backup_code_batch, count, codes: [], generated_at }` — no plaintext re-surface.
- `DELETE /v1/me/backup-codes` — clears unspent rows and flips `backup_code_enabled`; if no TOTP remains, also flips `two_factor_enabled` off + stamps `mfa_disabled_at`. Idempotent — second call returns the same shape.

### `BackupCodeBatchResource`

Matches openapi `components/schemas/BackupCodeBatch.yaml` exactly. `empty()` helper for the DELETE 200 contract (`count: 0, codes: []` per the spec's 'shape consistency' note).

### `ErrorCodes::MFA_PRIMARY_FACTOR_REQUIRED`

Distinct semantics from `mfa_not_enabled` — that error means 'the strategy is disabled by the operator', whereas `mfa_primary_factor_required` means 'you need to set up an authenticator first'. Distinct codes give the SDK clean copy.

## Out of scope (lands later)

- Second-factor Challenge wiring (`step: \"second\"` answer) — AU-5 (#92).
- BAPI admin override — AU-6 (#93).
- Audit-log emission — AU-10 (#97).
- `backup_codes_generated` email template body — AU-9 (#96); job dispatch site stable.
- Account Portal Security UI — AU-7 (#94).

## Test plan

- [x] **`tests/Feature/Mfa/MeBackupCodesTest.php`** — 8 cases:
  - `POST /me/backup-codes` returns N codes matching `xxxx-xxxx`, hashes unique in DB, prior unspent rows wiped, `User.backup_code_enabled` flipped.
  - Re-`POST` replaces every prior unspent row (no overlap).
  - `BackupCodesService::consume` happy path single-use + replay rejection + remaining count.
  - 422 `mfa_not_enabled` when `multi_factor.backup_codes.enabled = false`.
  - 422 `mfa_primary_factor_required` when no verified TOTP.
  - `GET` returns the unspent count without re-surfacing plaintext.
  - `DELETE` empties batch, flips `backup_code_enabled`, idempotent on second call.
  - `DELETE` also flips `two_factor_enabled` off + stamps `mfa_disabled_at` when no TOTP remains.
- [x] Sequential `php artisan test tests/Feature/Mfa/MeBackupCodesTest.php` — **8/8 green**.
- [x] `vendor/bin/pint --test` — clean.
- [x] OpenAPI contract validator — auto-applies on every feature response.
- [ ] `php artisan test --parallel` locally — paratest worker DB cache is stale on the `consumed_at` rename; CI starts fresh so the run will use the new schema.