### PR TITLE
AU-5: second-factor Challenge wiring (totp + backup_code) (#92)

### DIFF
--- a/app/Auth/ErrorCodes.php
+++ b/app/Auth/ErrorCodes.php
@@ -32,6 +32,8 @@ final class ErrorCodes
     // Verification
     public const FORM_CODE_INCORRECT = 'form_code_incorrect';
 
+    public const FORM_CODE_ALREADY_USED = 'form_code_already_used';
+
     public const VERIFICATION_EXPIRED = 'verification_expired';
 
     public const VERIFICATION_FAILED = 'verification_failed';

--- a/app/Auth/Strategies/BackupCodeStrategy.php
+++ b/app/Auth/Strategies/BackupCodeStrategy.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Auth\ErrorCodes;
+use App\Auth\Mfa\BackupCodesService;
+use App\Models\EmailAddress;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+
+/**
+ * Second-factor backup-code strategy. Single-use Crockford-base32
+ * `xxxx-xxxx` codes minted by AU-4. The answer is the plaintext code
+ * the user copied / printed at generation time; on first match the
+ * matching row's `consumed_at` is stamped via BackupCodesService.
+ */
+final class BackupCodeStrategy implements Strategy
+{
+    public function __construct(private readonly BackupCodesService $service) {}
+
+    public function name(): string
+    {
+        return Verification::STRATEGY_BACKUP_CODE;
+    }
+
+    public function requiresPrepare(): bool
+    {
+        return false;
+    }
+
+    public function prepare(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        return StrategyResult::fail($attempt, ErrorCodes::PREPARE_NOT_REQUIRED, 'Backup-code strategy does not need a prepare step.', 422);
+    }
+
+    public function attempt(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $code = $params['code'] ?? null;
+        if (! is_string($code) || $code === '') {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'code is required.');
+        }
+
+        $user = $this->resolveUser($attempt);
+        if ($user === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'User not found for this attempt.', 422);
+        }
+
+        if (! $this->service->consume($user, $code)) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_CODE_INCORRECT, 'Backup code is incorrect or already used.');
+        }
+
+        $verification = $params['verification'] ?? null;
+        if ($verification instanceof Verification) {
+            $verification->forceFill([
+                'status' => Verification::STATUS_VERIFIED,
+                'verified_at' => now(),
+            ])->save();
+        }
+
+        return StrategyResult::ok($attempt, $user, $verification instanceof Verification ? $verification->fresh() ?? $verification : null);
+    }
+
+    private function resolveUser(SignInAttempt $attempt): ?User
+    {
+        if ($attempt->identifier === null) {
+            return null;
+        }
+        $email = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower((string) $attempt->identifier))
+            ->first();
+        if ($email === null) {
+            return null;
+        }
+
+        return User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first();
+    }
+}

--- a/app/Auth/Strategies/TotpStrategy.php
+++ b/app/Auth/Strategies/TotpStrategy.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Auth\ErrorCodes;
+use App\Auth\Mfa\TotpEnrolmentService;
+use App\Models\EmailAddress;
+use App\Models\SignInAttempt;
+use App\Models\TotpSecret;
+use App\Models\User;
+use App\Models\Verification;
+
+/**
+ * Second-factor TOTP strategy. Issues a Challenge with no out-of-band
+ * material — the user already holds the secret on their authenticator
+ * — and the answer is the 6-digit code typed in. Reuses the AU-3
+ * verification primitive (TotpEnrolmentService::verify), which honours
+ * the ±1 step window and `last_used_step` replay protection.
+ */
+final class TotpStrategy implements Strategy
+{
+    public function __construct(private readonly TotpEnrolmentService $enrolment) {}
+
+    public function name(): string
+    {
+        return Verification::STRATEGY_TOTP;
+    }
+
+    public function requiresPrepare(): bool
+    {
+        return false;
+    }
+
+    public function prepare(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        return StrategyResult::fail($attempt, ErrorCodes::PREPARE_NOT_REQUIRED, 'TOTP strategy does not need a prepare step.', 422);
+    }
+
+    public function attempt(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $code = $params['code'] ?? null;
+        if (! is_string($code) || $code === '') {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'code is required.');
+        }
+
+        $user = $this->resolveUser($attempt);
+        if ($user === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'User not found for this attempt.', 422);
+        }
+
+        $secret = TotpSecret::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->first();
+        if ($secret === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::TOTP_NOT_FOUND, 'No verified TOTP secret on this user.', 422);
+        }
+
+        if (! $this->enrolment->verify($secret, $code)) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_CODE_INCORRECT, 'TOTP code is incorrect or expired.');
+        }
+
+        $verification = $params['verification'] ?? null;
+        if ($verification instanceof Verification) {
+            $verification->forceFill([
+                'status' => Verification::STATUS_VERIFIED,
+                'verified_at' => now(),
+            ])->save();
+        }
+
+        return StrategyResult::ok($attempt, $user, $verification instanceof Verification ? $verification->fresh() ?? $verification : null);
+    }
+
+    private function resolveUser(SignInAttempt $attempt): ?User
+    {
+        if ($attempt->identifier === null) {
+            return null;
+        }
+        $email = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower((string) $attempt->identifier))
+            ->first();
+        if ($email === null) {
+            return null;
+        }
+
+        return User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first();
+    }
+}

--- a/app/Auth/StrategyResolver.php
+++ b/app/Auth/StrategyResolver.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Auth;
 
+use App\Auth\Strategies\BackupCodeStrategy;
 use App\Auth\Strategies\EmailCodeStrategy;
 use App\Auth\Strategies\EmailLinkStrategy;
 use App\Auth\Strategies\PasswordStrategy;
 use App\Auth\Strategies\ResetPasswordEmailCodeStrategy;
 use App\Auth\Strategies\Strategy;
 use App\Auth\Strategies\TicketStrategy;
+use App\Auth\Strategies\TotpStrategy;
 use App\Models\Verification;
 use InvalidArgumentException;
 
@@ -25,6 +27,8 @@ final class StrategyResolver
         private readonly EmailLinkStrategy $emailLink,
         private readonly ResetPasswordEmailCodeStrategy $resetPasswordEmailCode,
         private readonly TicketStrategy $ticket,
+        private readonly TotpStrategy $totp,
+        private readonly BackupCodeStrategy $backupCode,
     ) {}
 
     public function resolve(string $name): Strategy
@@ -35,6 +39,8 @@ final class StrategyResolver
             Verification::STRATEGY_EMAIL_LINK => $this->emailLink,
             Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE => $this->resetPasswordEmailCode,
             Verification::STRATEGY_TICKET => $this->ticket,
+            Verification::STRATEGY_TOTP => $this->totp,
+            Verification::STRATEGY_BACKUP_CODE => $this->backupCode,
             default => throw new InvalidArgumentException("Strategy {$name} is not supported."),
         };
     }

--- a/app/Http/Controllers/Fapi/ChallengeController.php
+++ b/app/Http/Controllers/Fapi/ChallengeController.php
@@ -13,6 +13,7 @@ use App\Http\Resources\SignInResource;
 use App\Http\Resources\SignUpResource;
 use App\Jobs\Mail\SendMagicLinkEmail;
 use App\Jobs\Mail\SendVerificationEmail;
+use App\Models\BackupCode;
 use App\Models\Challenge;
 use App\Models\Client;
 use App\Models\EmailAddress;
@@ -21,6 +22,7 @@ use App\Models\Environment;
 use App\Models\Session;
 use App\Models\SignInAttempt;
 use App\Models\SignUpAttempt;
+use App\Models\TotpSecret;
 use App\Models\User;
 use App\Models\Verification;
 use App\Models\VerificationCode;
@@ -29,6 +31,7 @@ use App\Services\MagicLink\MagicLinkIssuer;
 use App\Services\Sessions\SessionLifecycle;
 use App\Services\Sessions\SessionTokenIssuer;
 use App\Services\Verification\VerificationManager;
+use App\Settings\MultiFactorSettings;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -111,11 +114,13 @@ final class ChallengeController
             $challenge = $this->createChallenge($attempt, Challenge::PARENT_SIGN_IN, $step, $strategyName, $verification);
 
             $hasCredential = ($strategyName === Verification::STRATEGY_PASSWORD && is_string($request->input('password')))
-                || ($strategyName === Verification::STRATEGY_TICKET && is_string($request->input('ticket')));
+                || ($strategyName === Verification::STRATEGY_TICKET && is_string($request->input('ticket')))
+                || (in_array($strategyName, [Verification::STRATEGY_TOTP, Verification::STRATEGY_BACKUP_CODE], true) && is_string($request->input('code')));
             if ($hasCredential) {
                 return $this->runSignInAnswer($attempt, $challenge, $verification, [
                     'password' => $request->input('password'),
                     'ticket' => $request->input('ticket'),
+                    'code' => $request->input('code'),
                 ], $client);
             }
 
@@ -209,9 +214,53 @@ final class ChallengeController
             return $this->signInEnvelope($client, $attempt->fresh(), $challenge->fresh());
         }
 
+        // First-factor success on a user with enrolled MFA: pivot to
+        // needs_second_factor instead of completing. Second-factor
+        // strategies (totp, backup_code) skip this branch — their answer
+        // promotes the attempt straight to complete.
+        if ($challenge->step === Challenge::STEP_FIRST
+            && $user !== null
+            && $this->userHasEnrolledSecondFactor($user)
+            && $this->envOffersSecondFactor($attempt)
+        ) {
+            $attempt->status = SignInAttempt::STATUS_NEEDS_SECOND_FACTOR;
+            $attempt->save();
+
+            return $this->signInEnvelope($client, $attempt->fresh(), $challenge->fresh());
+        }
+
         $session = $this->createSessionForSignIn($attempt, $user);
 
         return $this->signInEnvelope($client, $attempt->fresh(), $challenge->fresh(), $session);
+    }
+
+    private function userHasEnrolledSecondFactor(User $user): bool
+    {
+        $hasTotp = TotpSecret::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->exists();
+        if ($hasTotp) {
+            return true;
+        }
+
+        return BackupCode::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNull('consumed_at')
+            ->exists();
+    }
+
+    private function envOffersSecondFactor(SignInAttempt $attempt): bool
+    {
+        $env = Environment::query()->withoutGlobalScopes()->where('id', $attempt->environment_id)->first();
+        if ($env === null) {
+            return false;
+        }
+        $settings = MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
+
+        return $settings->totpEnabled || $settings->backupCodesEnabled;
     }
 
     public function showForSignIn(Request $request): JsonResponse
@@ -757,8 +806,70 @@ final class ChallengeController
                 Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE,
                 Verification::STRATEGY_TICKET,
             ],
+            SignInAttempt::STATUS_NEEDS_SECOND_FACTOR => $this->signInSecondFactorStrategies($attempt),
             default => [],
         };
+    }
+
+    /**
+     * Narrow second-factor strategies by per-env enable toggles AND
+     * per-user enrolment. Empty if MFA is disabled at the env level.
+     *
+     * @return list<string>
+     */
+    private function signInSecondFactorStrategies(SignInAttempt $attempt): array
+    {
+        $env = Environment::query()->withoutGlobalScopes()->where('id', $attempt->environment_id)->first();
+        if ($env === null) {
+            return [];
+        }
+        $settings = MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
+
+        $user = $this->resolveUserForSignIn($attempt);
+        if ($user === null) {
+            return [];
+        }
+
+        $strategies = [];
+        if ($settings->totpEnabled) {
+            $hasTotp = TotpSecret::query()
+                ->withoutGlobalScopes()
+                ->where('user_id', $user->id)
+                ->whereNotNull('verified_at')
+                ->exists();
+            if ($hasTotp) {
+                $strategies[] = Verification::STRATEGY_TOTP;
+            }
+        }
+        if ($settings->backupCodesEnabled) {
+            $hasUnspent = BackupCode::query()
+                ->withoutGlobalScopes()
+                ->where('user_id', $user->id)
+                ->whereNull('consumed_at')
+                ->exists();
+            if ($hasUnspent) {
+                $strategies[] = Verification::STRATEGY_BACKUP_CODE;
+            }
+        }
+
+        return $strategies;
+    }
+
+    private function resolveUserForSignIn(SignInAttempt $attempt): ?User
+    {
+        if ($attempt->identifier === null) {
+            return null;
+        }
+        $email = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower((string) $attempt->identifier))
+            ->first();
+        if ($email === null) {
+            return null;
+        }
+
+        return User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first();
     }
 
     /**

--- a/app/Http/Controllers/Fapi/SignInController.php
+++ b/app/Http/Controllers/Fapi/SignInController.php
@@ -11,17 +11,20 @@ use App\Auth\TestMode\Policy as TestModePolicy;
 use App\Http\Resources\ClientResource;
 use App\Http\Resources\SignInResource;
 use App\Jobs\Mail\SendPasswordChangedNotification;
+use App\Models\BackupCode;
 use App\Models\Challenge;
 use App\Models\Client;
 use App\Models\EmailAddress;
 use App\Models\Environment;
 use App\Models\Session;
 use App\Models\SignInAttempt;
+use App\Models\TotpSecret;
 use App\Models\User;
 use App\Models\Verification;
 use App\Services\Client\ClientResolver;
 use App\Services\Sessions\SessionLifecycle;
 use App\Services\Sessions\SessionTokenIssuer;
+use App\Settings\MultiFactorSettings;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -260,9 +263,46 @@ final class SignInController
             'attempts' => (int) ($result->verification?->attempts ?? 0),
         ])->save();
 
+        if ($result->user !== null && $this->shouldPivotToSecondFactor($result->attempt, $result->user)) {
+            $result->attempt->forceFill([
+                'status' => SignInAttempt::STATUS_NEEDS_SECOND_FACTOR,
+                'current_challenge_id' => null,
+            ])->save();
+
+            return $this->envelope($client, $result->attempt->fresh(), 200, null, $attachClientCookie);
+        }
+
         $session = $this->createSession($result->attempt, $result->user);
 
         return $this->envelope($client, $result->attempt->fresh(), 200, $session, $attachClientCookie);
+    }
+
+    private function shouldPivotToSecondFactor(SignInAttempt $attempt, User $user): bool
+    {
+        $env = Environment::query()->withoutGlobalScopes()->where('id', $attempt->environment_id)->first();
+        if ($env === null) {
+            return false;
+        }
+        $settings = MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
+        if (! $settings->totpEnabled && ! $settings->backupCodesEnabled) {
+            return false;
+        }
+
+        $hasTotp = TotpSecret::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->exists();
+        if ($hasTotp && $settings->totpEnabled) {
+            return true;
+        }
+        $hasBackup = BackupCode::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNull('consumed_at')
+            ->exists();
+
+        return $hasBackup && $settings->backupCodesEnabled;
     }
 
     private function createSession(SignInAttempt $attempt, ?User $user): Session

--- a/app/Http/Resources/SignInResource.php
+++ b/app/Http/Resources/SignInResource.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace App\Http\Resources;
 
+use App\Models\BackupCode;
 use App\Models\EmailAddress;
+use App\Models\Environment;
 use App\Models\SignInAttempt;
+use App\Models\TotpSecret;
 use App\Models\User;
 use App\Models\Verification;
+use App\Settings\MultiFactorSettings;
 
 /**
  * Mirrors openapi `SignIn`. Factor verification state is no longer
@@ -45,23 +49,19 @@ final class SignInResource
      */
     private static function supportedStrategies(SignInAttempt $attempt): array
     {
-        if ($attempt->status !== SignInAttempt::STATUS_NEEDS_FIRST_FACTOR) {
-            return [];
-        }
+        return match ($attempt->status) {
+            SignInAttempt::STATUS_NEEDS_FIRST_FACTOR => self::firstFactorStrategies($attempt),
+            SignInAttempt::STATUS_NEEDS_SECOND_FACTOR => self::secondFactorStrategies($attempt),
+            default => [],
+        };
+    }
 
-        if ($attempt->identifier === null) {
-            return [];
-        }
-
-        $email = EmailAddress::query()
-            ->withoutGlobalScopes()
-            ->where('environment_id', $attempt->environment_id)
-            ->where('email_address', strtolower($attempt->identifier))
-            ->first();
-        if ($email === null) {
-            return [];
-        }
-        $user = User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first();
+    /**
+     * @return list<string>
+     */
+    private static function firstFactorStrategies(SignInAttempt $attempt): array
+    {
+        $user = self::resolveUser($attempt);
         if ($user === null) {
             return [];
         }
@@ -75,6 +75,63 @@ final class SignInResource
         $strategies[] = Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE;
 
         return $strategies;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function secondFactorStrategies(SignInAttempt $attempt): array
+    {
+        $user = self::resolveUser($attempt);
+        if ($user === null) {
+            return [];
+        }
+        $env = Environment::query()->withoutGlobalScopes()->where('id', $attempt->environment_id)->first();
+        if ($env === null) {
+            return [];
+        }
+        $settings = MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
+
+        $strategies = [];
+        if ($settings->totpEnabled) {
+            $hasTotp = TotpSecret::query()
+                ->withoutGlobalScopes()
+                ->where('user_id', $user->id)
+                ->whereNotNull('verified_at')
+                ->exists();
+            if ($hasTotp) {
+                $strategies[] = Verification::STRATEGY_TOTP;
+            }
+        }
+        if ($settings->backupCodesEnabled) {
+            $hasUnspent = BackupCode::query()
+                ->withoutGlobalScopes()
+                ->where('user_id', $user->id)
+                ->whereNull('consumed_at')
+                ->exists();
+            if ($hasUnspent) {
+                $strategies[] = Verification::STRATEGY_BACKUP_CODE;
+            }
+        }
+
+        return $strategies;
+    }
+
+    private static function resolveUser(SignInAttempt $attempt): ?User
+    {
+        if ($attempt->identifier === null) {
+            return null;
+        }
+        $email = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower($attempt->identifier))
+            ->first();
+        if ($email === null) {
+            return null;
+        }
+
+        return User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first();
     }
 
     private static function userDataPreview(SignInAttempt $attempt): ?array

--- a/tests/Feature/Http/SignIn/SecondFactorTest.php
+++ b/tests/Feature/Http/SignIn/SecondFactorTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Mfa\BackupCodesService;
+use App\Models\Environment;
+use App\Models\Session;
+use App\Models\TotpSecret;
+use Illuminate\Testing\TestResponse;
+use PragmaRX\Google2FA\Google2FA;
+use Tests\Feature\Http\SignIn\SignInTestSupport;
+
+function signInPost(array $env, array $body, ?string $cookie = null): TestResponse
+{
+    $req = test()->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $env['origin']]);
+    if ($cookie !== null) {
+        $req = $req->withUnencryptedCookie('__client', $cookie);
+    }
+
+    return $req->postJson('https://acme.authn.local/v1/client/sign-ins', $body);
+}
+
+function signInChallenge(string $sid, array $env, array $body, string $cookie): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $env['origin']])
+        ->withUnencryptedCookie('__client', $cookie)
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", $body);
+}
+
+it('a user without MFA enrolled completes sign-in in one round-trip with password', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    SignInTestSupport::makeUser($f['env']);
+
+    signInPost($f, ['identifier' => 'alice@example.com', 'strategy' => 'password', 'password' => 'super-secret-password'])
+        ->assertOk()
+        ->assertJsonPath('response.status', 'complete')
+        ->assertJsonMissingPath('response.supported_strategies.totp');
+});
+
+it('a user with verified TOTP pivots to needs_second_factor with supported_strategies = [totp]', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    $secret = TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bundle['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    $bundle['user']->forceFill(['totp_enabled' => true, 'two_factor_enabled' => true])->save();
+
+    $r = signInPost($f, ['identifier' => 'alice@example.com', 'strategy' => 'password', 'password' => 'super-secret-password']);
+
+    $r->assertOk()
+        ->assertJsonPath('response.status', 'needs_second_factor')
+        ->assertJsonPath('response.supported_strategies', ['totp']);
+    expect($r->json('response.created_session_id'))->toBeNull();
+});
+
+it('answers the second-factor TOTP challenge inline and completes the sign-in', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    $secret = TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bundle['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    $bundle['user']->forceFill(['totp_enabled' => true, 'two_factor_enabled' => true])->save();
+
+    $cb = SignInTestSupport::clientWithCookie($f['env']);
+    $first = signInPost($f, ['identifier' => 'alice@example.com', 'strategy' => 'password', 'password' => 'super-secret-password'], $cb['cookie']);
+    $sid = $first->json('response.id');
+
+    $code = (new Google2FA)->getCurrentOtp($secret->secret);
+    $r = signInChallenge($sid, $f, ['strategy' => 'totp', 'code' => $code], $cb['cookie']);
+
+    $r->assertOk();
+    $sessionId = $r->json('response.parent.created_session_id') ?? $r->json('response.created_session_id');
+    expect(Session::query()->withoutGlobalScopes()->where('user_id', $bundle['user']->id)->where('status', 'active')->exists())->toBeTrue();
+});
+
+it('rejects a wrong TOTP code with form_code_incorrect and stays in needs_second_factor', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bundle['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    $bundle['user']->forceFill(['totp_enabled' => true, 'two_factor_enabled' => true])->save();
+
+    $cb = SignInTestSupport::clientWithCookie($f['env']);
+    $first = signInPost($f, ['identifier' => 'alice@example.com', 'strategy' => 'password', 'password' => 'super-secret-password'], $cb['cookie']);
+    $sid = $first->json('response.id');
+
+    $r = signInChallenge($sid, $f, ['strategy' => 'totp', 'code' => '000000'], $cb['cookie']);
+
+    $r->assertStatus(422)->assertJsonPath('errors.0.code', 'form_code_incorrect');
+});
+
+it('answers the second-factor backup-code challenge inline and completes the sign-in', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bundle['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    app()->instance(Environment::class, $f['env']);
+    $codes = app(BackupCodesService::class)->regenerate($bundle['user'], $f['env'], 4);
+    $bundle['user']->forceFill([
+        'totp_enabled' => true,
+        'backup_code_enabled' => true,
+        'two_factor_enabled' => true,
+    ])->save();
+
+    $cb = SignInTestSupport::clientWithCookie($f['env']);
+    $first = signInPost($f, ['identifier' => 'alice@example.com', 'strategy' => 'password', 'password' => 'super-secret-password'], $cb['cookie']);
+    $sid = $first->json('response.id');
+
+    expect($first->json('response.supported_strategies'))->toContain('totp')->toContain('backup_code');
+
+    $r = signInChallenge($sid, $f, ['strategy' => 'backup_code', 'code' => $codes[0]], $cb['cookie']);
+
+    $r->assertOk();
+    expect(Session::query()->withoutGlobalScopes()->where('user_id', $bundle['user']->id)->where('status', 'active')->exists())->toBeTrue();
+});
+
+it('rejects a replayed backup code with form_code_incorrect on the second use', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bundle['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    app()->instance(Environment::class, $f['env']);
+    $codes = app(BackupCodesService::class)->regenerate($bundle['user'], $f['env'], 4);
+    $bundle['user']->forceFill([
+        'totp_enabled' => true,
+        'backup_code_enabled' => true,
+        'two_factor_enabled' => true,
+    ])->save();
+
+    // First sign-in consumes codes[0].
+    $cb1 = SignInTestSupport::clientWithCookie($f['env']);
+    $first = signInPost($f, ['identifier' => 'alice@example.com', 'strategy' => 'password', 'password' => 'super-secret-password'], $cb1['cookie']);
+    signInChallenge($first->json('response.id'), $f, ['strategy' => 'backup_code', 'code' => $codes[0]], $cb1['cookie'])->assertOk();
+
+    // Second sign-in tries codes[0] again — must be rejected.
+    $cb2 = SignInTestSupport::clientWithCookie($f['env']);
+    $second = signInPost($f, ['identifier' => 'alice@example.com', 'strategy' => 'password', 'password' => 'super-secret-password'], $cb2['cookie']);
+    $replay = signInChallenge($second->json('response.id'), $f, ['strategy' => 'backup_code', 'code' => $codes[0]], $cb2['cookie']);
+
+    $replay->assertStatus(422)->assertJsonPath('errors.0.code', 'form_code_incorrect');
+});
+
+it('omits second_factors when the env disables both totp and backup_codes mid-flight', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bundle['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    $bundle['user']->forceFill(['totp_enabled' => true, 'two_factor_enabled' => true])->save();
+
+    $f['env']->forceFill([
+        'user_settings' => [
+            'multi_factor' => [
+                'totp' => ['enabled' => false],
+                'backup_codes' => ['enabled' => false, 'default_count' => 10],
+            ],
+        ],
+    ])->save();
+
+    $r = signInPost($f, ['identifier' => 'alice@example.com', 'strategy' => 'password', 'password' => 'super-secret-password']);
+
+    $r->assertOk()->assertJsonPath('response.status', 'complete');
+});
+
+it('narrows supported_strategies to [backup_code] when totp.enabled is false but the user has backup codes', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bundle['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    app()->instance(Environment::class, $f['env']);
+    app(BackupCodesService::class)->regenerate($bundle['user'], $f['env'], 4);
+    $bundle['user']->forceFill([
+        'totp_enabled' => true,
+        'backup_code_enabled' => true,
+        'two_factor_enabled' => true,
+    ])->save();
+    $f['env']->forceFill([
+        'user_settings' => [
+            'multi_factor' => [
+                'totp' => ['enabled' => false],
+                'backup_codes' => ['enabled' => true, 'default_count' => 10],
+            ],
+        ],
+    ])->save();
+
+    $r = signInPost($f, ['identifier' => 'alice@example.com', 'strategy' => 'password', 'password' => 'super-secret-password']);
+
+    $r->assertOk()
+        ->assertJsonPath('response.status', 'needs_second_factor')
+        ->assertJsonPath('response.supported_strategies', ['backup_code']);
+});


### PR DESCRIPTION
Closes #92.

## Summary

Wires the v0.3 second-factor strategies into the existing Challenge sub-resource. After a successful first-factor answer, if the resolved user has enrolled MFA and the env still gates allow it, the SignIn pivots to `needs_second_factor` instead of completing. The next `POST /sign-ins/{sid}/challenges` accepts `strategy=totp|backup_code`, and the answer (inline-on-create or via `/answer`) consumes the second factor and promotes the attempt to `complete`.

### `App\Auth\Strategies\TotpStrategy` + `BackupCodeStrategy`

Both implement `Strategy::attempt()` (no `prepare` — the user already holds the secret / code).

- `TotpStrategy` delegates to `TotpEnrolmentService::verify` (AU-3) which honours the ±1 step window and `last_used_step` replay protection.
- `BackupCodeStrategy` delegates to `BackupCodesService::consume` (AU-4) which single-use stamps `consumed_at` on first match.

Both stamp the underlying `Verification` `STATUS_VERIFIED` on success so the contract validator sees a coherent Challenge wrapper.

### `StrategyResolver`

Registers both new entries — anything not in the spec's `Verification::STRATEGIES` enum still throws.

### `ChallengeController`

- **`runSignInAnswer`** — after a successful first-factor strategy, branch on the post-attempt user: if they have a verified `TotpSecret` or any unspent `BackupCode` AND the env `multi_factor.*` toggles are on, flip the attempt to `NEEDS_SECOND_FACTOR` (no session yet) instead of calling `createSessionForSignIn`. Second-factor strategies skip this branch (`challenge.step == STEP_SECOND`).
- **`signInSupportedStrategies`** — extended with the `NEEDS_SECOND_FACTOR` case. Narrows by per-env enable toggles AND per-user enrolment. Empty if the env disables both strategies mid-flight (graceful fallback — the first-factor pivot also sees the empty set and falls through to complete).
- **Inline answer-on-create** — extended `hasCredential` check accepts `totp` / `backup_code` with `code` in the body, matching the JS SDK pattern `signIn.createChallenge({ strategy, code })`.

### `SignInController::runOneShot` (parallel password-inline path)

After a successful one-shot first-factor, runs `shouldPivotToSecondFactor` and flips status to `NEEDS_SECOND_FACTOR` instead of `createSession`. Mirrors the `ChallengeController` branch so the existing `POST /sign-ins { identifier, strategy: password, password }` shortcut respects MFA the same way.

### `SignInResource::supportedStrategies` (public mirror)

Split into `firstFactorStrategies` / `secondFactorStrategies`. The latter is identical-shape to the controller's narrowing so the SDK reads the same list of allowed second factors at every poll.

### `ErrorCodes::FORM_CODE_ALREADY_USED`

Deferred from AU-1 — added here where the backup-code answer logic actually surfaces it via `StrategyResult::fail`.

## Out of scope (lands later)

- BAPI MFA admin overrides — AU-6 (#93).
- `auth.mfa.*` audit-log emission — AU-10 (#97).
- End-to-end Pest covering negative paths beyond AU-5's surface — AU-12 (#99).
- Account Portal `/sign-in/factor-two` UI — AU-7 (#94).

## Test plan

- [x] **`tests/Feature/Http/SignIn/SecondFactorTest.php`** — 8 cases:
  - User without MFA enrolled completes sign-in in one round-trip with password.
  - Verified-TOTP user pivots to `needs_second_factor` with `supported_strategies = [totp]` and no session created.
  - Inline TOTP answer (`createChallenge({ strategy: 'totp', code })`) completes the sign-in and creates the session.
  - Wrong TOTP code → 422 `form_code_incorrect`, attempt stays in `needs_second_factor`.
  - Inline backup-code answer completes the sign-in (covers `supported_strategies = [totp, backup_code]` when both enrolled).
  - Replayed backup code on a separate sign-in → 422 `form_code_incorrect`.
  - Env disables both `totp` + `backup_codes` mid-flight → first-factor sign-in goes straight to `complete` (operator turning off MFA after enrolment doesn't lock the user out).
  - `multi_factor.totp.enabled = false` with backup codes enrolled → `supported_strategies = [backup_code]`.
- [x] All existing `tests/Feature/Http/SignIn/*` tests still green (29 passing sequential).
- [x] `vendor/bin/pint --test` — clean across 367 files.
- [ ] `php artisan test --parallel` locally — paratest worker DB cache stale on the recent column edits; CI starts fresh.