### PR TITLE
AU-6: BAPI MFA admin overrides (#93)

### DIFF
--- a/app/Http/Controllers/Bapi/UsersController.php
+++ b/app/Http/Controllers/Bapi/UsersController.php
@@ -4,23 +4,29 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Bapi;
 
+use App\Auth\ErrorCodes;
 use App\Http\Requests\Bapi\Users\CreateUserRequest;
 use App\Http\Requests\Bapi\Users\ProfileImageRequest;
 use App\Http\Requests\Bapi\Users\UpdateMetadataRequest;
 use App\Http\Requests\Bapi\Users\UpdateUserRequest;
 use App\Http\Requests\Bapi\Users\VerifyPasswordRequest;
+use App\Http\Requests\Bapi\Users\VerifyTotpRequest;
 use App\Http\Resources\UserResource;
+use App\Models\BackupCode;
 use App\Models\EmailAddress;
 use App\Models\Environment;
 use App\Models\Session;
+use App\Models\TotpSecret;
 use App\Models\User;
 use App\Services\Sessions\SessionLifecycle;
+use App\Settings\MultiFactorSettings;
 use App\Support\Idempotency;
 use App\Support\IdempotencyMismatch;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
+use PragmaRX\Google2FA\Google2FA;
 
 /**
  * BAPI users surface (PLAN §3.1, OA-2). Server-to-server CRUD plus the
@@ -196,6 +202,82 @@ final class UsersController
         $verified = $user->password_hash !== null && Hash::check((string) $request->input('password'), $user->password_hash);
 
         return response()->json(['object' => 'verify_password', 'verified' => $verified]);
+    }
+
+    /**
+     * Server-side TOTP check against the user's enrolled `TotpSecret`.
+     * Read-only — does not stamp `verified_at` or advance the replay
+     * step counter. Used by support tooling to confirm a user has
+     * access to their authenticator without forcing them through the
+     * FAPI sign-in flow.
+     */
+    public function verifyTotp(VerifyTotpRequest $request, string $id): JsonResponse
+    {
+        $user = $this->find($id);
+        if ($user === null) {
+            return $this->error(404, 'user_not_found', 'No user matches that id in this environment.');
+        }
+
+        $env = app(Environment::class);
+        $settings = MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
+        if (! $settings->totpEnabled) {
+            return $this->error(422, ErrorCodes::MFA_NOT_ENABLED, 'TOTP is disabled for this environment.');
+        }
+
+        $secret = TotpSecret::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->first();
+        if ($secret === null) {
+            return $this->error(404, ErrorCodes::TOTP_NOT_FOUND, 'No verified TOTP secret on this user.');
+        }
+
+        $code = (string) $request->input('code');
+        $google2fa = new Google2FA;
+        $google2fa->setWindow(1);
+        $verified = $google2fa->verifyKey($secret->secret, $code);
+
+        return response()->json(['verified' => (bool) $verified]);
+    }
+
+    /**
+     * Operator MFA reset. Drops the user's `TotpSecret` plus every
+     * unconsumed `BackupCode`, flips the User MFA flags off, and stamps
+     * `mfa_disabled_at`. Idempotent — safe to call on a user who's not
+     * enrolled.
+     */
+    public function deleteMfa(string $id): JsonResponse
+    {
+        $user = $this->find($id);
+        if ($user === null) {
+            return $this->error(404, 'user_not_found', 'No user matches that id in this environment.');
+        }
+
+        $hadTotp = TotpSecret::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->exists();
+        $hadBackup = BackupCode::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNull('consumed_at')
+            ->exists();
+
+        TotpSecret::query()->withoutGlobalScopes()->where('user_id', $user->id)->delete();
+        BackupCode::query()->withoutGlobalScopes()->where('user_id', $user->id)->whereNull('consumed_at')->delete();
+
+        if ($hadTotp || $hadBackup || $user->two_factor_enabled) {
+            $user->forceFill([
+                'totp_enabled' => false,
+                'backup_code_enabled' => false,
+                'two_factor_enabled' => false,
+                'mfa_disabled_at' => now(),
+            ])->save();
+        }
+
+        return response()->json(UserResource::from($user->fresh(), includePrivate: true))
+            ->header('Cache-Control', 'no-store');
     }
 
     public function uploadProfileImage(ProfileImageRequest $request, string $id): JsonResponse

--- a/app/Http/Requests/Bapi/Users/VerifyTotpRequest.php
+++ b/app/Http/Requests/Bapi/Users/VerifyTotpRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\Users;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class VerifyTotpRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'code' => ['required', 'string', 'min:6', 'max:8'],
+        ];
+    }
+}

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -53,6 +53,8 @@ Route::post('/users/{id}/profile-image', [UsersController::class, 'uploadProfile
 Route::delete('/users/{id}/profile-image', [UsersController::class, 'deleteProfileImage'])->middleware(RateLimit::class.':users.image,30,60')->name('bapi.users.profile_image.delete');
 Route::patch('/users/{id}/metadata', [UsersController::class, 'updateMetadata'])->middleware(RateLimit::class.':users.update,60,60')->name('bapi.users.metadata');
 Route::post('/users/{id}/verify-password', [UsersController::class, 'verifyPassword'])->middleware(RateLimit::class.':users.verify,60,60')->name('bapi.users.verify_password');
+Route::post('/users/{id}/verify-totp', [UsersController::class, 'verifyTotp'])->middleware(RateLimit::class.':users.verify,60,60')->name('bapi.users.verify_totp');
+Route::delete('/users/{id}/mfa', [UsersController::class, 'deleteMfa'])->middleware(RateLimit::class.':users.action,60,60')->name('bapi.users.mfa.destroy');
 
 // Sessions
 Route::get('/sessions', [SessionsController::class, 'index'])->middleware(RateLimit::class.':sessions.list,300,60')->name('bapi.sessions.index');

--- a/tests/Feature/Http/Bapi/UserMfaAdminTest.php
+++ b/tests/Feature/Http/Bapi/UserMfaAdminTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\BackupCode;
+use App\Models\TotpSecret;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use PragmaRX\Google2FA\Google2FA;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+
+function makeUserWithTotp(string $envId): array
+{
+    $user = User::create(['environment_id' => $envId]);
+    $secret = TotpSecret::create([
+        'environment_id' => $envId,
+        'user_id' => $user->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    $user->forceFill([
+        'totp_enabled' => true,
+        'two_factor_enabled' => true,
+        'mfa_enabled_at' => now(),
+    ])->save();
+
+    return ['user' => $user->fresh(), 'secret' => $secret];
+}
+
+it('POST /users/{id}/verify-totp returns {verified: true} on a fresh code', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $bundle = makeUserWithTotp($f['env']->id);
+    $code = (new Google2FA)->getCurrentOtp($bundle['secret']->secret);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/users/'.$bundle['user']->id.'/verify-totp'), ['code' => $code]);
+
+    $r->assertOk()->assertExactJson(['verified' => true]);
+});
+
+it('POST /users/{id}/verify-totp returns {verified: false} on a wrong code', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $bundle = makeUserWithTotp($f['env']->id);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/users/'.$bundle['user']->id.'/verify-totp'), ['code' => '000000']);
+
+    $r->assertOk()->assertExactJson(['verified' => false]);
+});
+
+it('POST /users/{id}/verify-totp does not advance last_used_step (read-only check)', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $bundle = makeUserWithTotp($f['env']->id);
+    $code = (new Google2FA)->getCurrentOtp($bundle['secret']->secret);
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/users/'.$bundle['user']->id.'/verify-totp'), ['code' => $code])
+        ->assertOk();
+
+    $secret = TotpSecret::query()->withoutGlobalScopes()->where('id', $bundle['secret']->id)->first();
+    expect($secret->last_used_step)->toBeNull();
+});
+
+it('POST /users/{id}/verify-totp returns 404 totp_not_found when the user has no enrolled TOTP', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $user = User::create(['environment_id' => $f['env']->id]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/users/'.$user->id.'/verify-totp'), ['code' => '123456']);
+
+    $r->assertStatus(404);
+    expect($r->json('errors.0.code'))->toBe('totp_not_found');
+});
+
+it('POST /users/{id}/verify-totp returns 404 user_not_found for an unknown user', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/users/user_DOES_NOT_EXIST/verify-totp'), ['code' => '123456']);
+
+    $r->assertStatus(404);
+    expect($r->json('errors.0.code'))->toBe('user_not_found');
+});
+
+it('POST /users/{id}/verify-totp returns 422 mfa_not_enabled when totp.enabled is false', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $f['env']->forceFill([
+        'user_settings' => array_merge((array) $f['env']->user_settings, [
+            'multi_factor' => ['totp' => ['enabled' => false], 'backup_codes' => ['enabled' => true, 'default_count' => 10]],
+        ]),
+    ])->save();
+    $bundle = makeUserWithTotp($f['env']->id);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/users/'.$bundle['user']->id.'/verify-totp'), ['code' => '123456']);
+
+    $r->assertStatus(422);
+    expect($r->json('errors.0.code'))->toBe('mfa_not_enabled');
+});
+
+it('POST /users/{id}/verify-totp 422s on missing code', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $bundle = makeUserWithTotp($f['env']->id);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/users/'.$bundle['user']->id.'/verify-totp'), []);
+
+    $r->assertStatus(422);
+});
+
+it('DELETE /users/{id}/mfa drops every TotpSecret + BackupCode and flips the User flags', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $bundle = makeUserWithTotp($f['env']->id);
+    BackupCode::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bundle['user']->id,
+        'code_hash' => Hash::make('plain-1'),
+    ]);
+    $bundle['user']->forceFill(['backup_code_enabled' => true])->save();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->deleteJson(BapiTestSupport::url('/users/'.$bundle['user']->id.'/mfa'));
+
+    $r->assertOk();
+    expect(TotpSecret::query()->withoutGlobalScopes()->where('user_id', $bundle['user']->id)->count())->toBe(0);
+    expect(BackupCode::query()->withoutGlobalScopes()->where('user_id', $bundle['user']->id)->whereNull('consumed_at')->count())->toBe(0);
+
+    $user = User::query()->withoutGlobalScopes()->where('id', $bundle['user']->id)->first();
+    expect($user->totp_enabled)->toBeFalse();
+    expect($user->backup_code_enabled)->toBeFalse();
+    expect($user->two_factor_enabled)->toBeFalse();
+    expect($user->mfa_disabled_at)->not->toBeNull();
+});
+
+it('DELETE /users/{id}/mfa is idempotent on a user with no enrolled MFA', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $user = User::create(['environment_id' => $f['env']->id]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->deleteJson(BapiTestSupport::url('/users/'.$user->id.'/mfa'));
+
+    $r->assertOk();
+    $r->assertJsonPath('id', $user->id);
+});
+
+it('DELETE /users/{id}/mfa returns 404 user_not_found for an unknown user', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->deleteJson(BapiTestSupport::url('/users/user_DOES_NOT_EXIST/mfa'));
+
+    $r->assertStatus(404);
+    expect($r->json('errors.0.code'))->toBe('user_not_found');
+});


### PR DESCRIPTION
Closes #93.

## Summary

Two operator-driven BAPI endpoints for support workflows.

### `POST /v1/users/{user_id}/verify-totp`

Server-side TOTP check against the user's enrolled `TotpSecret`. Returns `{ verified: bool }` (no envelope, no `object` field — per the spec). **Read-only** — does NOT stamp `verified_at` on the secret nor advance `last_used_step`. The spec is explicit that this is a verification check, not an enrolment confirmation; the enrolment confirmation path remains FAPI `POST /v1/me/totp/verify` (AU-3).

- 200 `{ verified: true }` on a fresh code in the ±1 step window.
- 200 `{ verified: false }` on a wrong code.
- 404 `user_not_found` for an unknown user.
- 404 `totp_not_found` when the user has no enrolled TOTP.
- 422 `mfa_not_enabled` when `multi_factor.totp.enabled = false` for the env.
- 422 form-validation on a missing or out-of-range code.
- Subject to the existing `users.verify` rate-limit bucket.

### `DELETE /v1/users/{user_id}/mfa`

Operator nuke. Drops every `TotpSecret` plus every unconsumed `BackupCode`, flips `User.totp_enabled` / `backup_code_enabled` / `two_factor_enabled` to `false`, and stamps `mfa_disabled_at`. Returns the updated `User` (full BAPI private shape via `UserResource::from(includePrivate: true)`).

- Idempotent — calling on a user with no MFA enrolled returns the user unchanged (no spurious `mfa_disabled_at` stamp).
- 404 `user_not_found` for an unknown user.
- Subject to the `users.action` rate-limit bucket.
- Audit-log event emission catalog (`auth.mfa.totp_removed`, `auth.mfa.backup_codes_removed`) lands in AU-10 (#97).

## Out of scope

- Audit-log catalog for the MFA events — AU-10.
- Email templates triggered on operator MFA reset — AU-9 (#96).

## Test plan

- [x] **`tests/Feature/Http/Bapi/UserMfaAdminTest.php`** — 10 cases:
  - `POST verify-totp` happy path with the current OTP returns `{verified: true}`.
  - Wrong code returns `{verified: false}`.
  - Admin verify does NOT advance `last_used_step` (read-only check).
  - 404 `totp_not_found` when no TOTP enrolled.
  - 404 `user_not_found` for an unknown user id.
  - 422 `mfa_not_enabled` when env disables `totp`.
  - 422 form validation on missing code.
  - `DELETE mfa` drops all TotpSecret + BackupCode rows, flips every flag, stamps `mfa_disabled_at`.
  - `DELETE mfa` idempotent on a user with no MFA.
  - `DELETE mfa` 404 on unknown user.
- [x] `vendor/bin/pint --test` — clean across 369 files.
- [x] OpenAPI contract validator auto-applies on every feature response.