### PR TITLE
AU-9: email templates totp_enabled / mfa_disabled / backup_codes_generated (#96)

### DIFF
--- a/app/Http/Controllers/Bapi/UsersController.php
+++ b/app/Http/Controllers/Bapi/UsersController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\Bapi\Users\UpdateUserRequest;
 use App\Http\Requests\Bapi\Users\VerifyPasswordRequest;
 use App\Http\Requests\Bapi\Users\VerifyTotpRequest;
 use App\Http\Resources\UserResource;
+use App\Jobs\Mail\SendMfaDisabledNotification;
 use App\Models\BackupCode;
 use App\Models\EmailAddress;
 use App\Models\Environment;
@@ -267,13 +268,15 @@ final class UsersController
         TotpSecret::query()->withoutGlobalScopes()->where('user_id', $user->id)->delete();
         BackupCode::query()->withoutGlobalScopes()->where('user_id', $user->id)->whereNull('consumed_at')->delete();
 
-        if ($hadTotp || $hadBackup || $user->two_factor_enabled) {
+        $disabledMfa = $hadTotp || $hadBackup || $user->two_factor_enabled;
+        if ($disabledMfa) {
             $user->forceFill([
                 'totp_enabled' => false,
                 'backup_code_enabled' => false,
                 'two_factor_enabled' => false,
                 'mfa_disabled_at' => now(),
             ])->save();
+            SendMfaDisabledNotification::dispatch($user->id);
         }
 
         return response()->json(UserResource::from($user->fresh(), includePrivate: true))

--- a/app/Http/Controllers/Fapi/MeBackupCodesController.php
+++ b/app/Http/Controllers/Fapi/MeBackupCodesController.php
@@ -9,6 +9,7 @@ use App\Auth\Mfa\BackupCodesService;
 use App\Http\Resources\BackupCodeBatchResource;
 use App\Http\Resources\ClientResource;
 use App\Jobs\Mail\SendBackupCodesGeneratedNotification;
+use App\Jobs\Mail\SendMfaDisabledNotification;
 use App\Models\BackupCode;
 use App\Models\Client;
 use App\Models\Environment;
@@ -66,7 +67,7 @@ final class MeBackupCodesController
         }
         $user->save();
 
-        SendBackupCodesGeneratedNotification::dispatch($user->id);
+        SendBackupCodesGeneratedNotification::dispatch($user->id, count($codes));
 
         return $this->clientEnvelope(BackupCodeBatchResource::from($user->fresh(), $codes));
     }
@@ -100,11 +101,17 @@ final class MeBackupCodesController
             ->where('user_id', $user->id)
             ->whereNotNull('verified_at')
             ->exists();
+        $disabledMfa = false;
         if (! $hasTotp) {
             $user->two_factor_enabled = false;
             $user->mfa_disabled_at = now();
+            $disabledMfa = true;
         }
         $user->save();
+
+        if ($disabledMfa) {
+            SendMfaDisabledNotification::dispatch($user->id);
+        }
 
         return $this->clientEnvelope(BackupCodeBatchResource::empty($user->fresh()));
     }

--- a/app/Http/Controllers/Fapi/MeTotpController.php
+++ b/app/Http/Controllers/Fapi/MeTotpController.php
@@ -8,6 +8,7 @@ use App\Auth\ErrorCodes;
 use App\Auth\Mfa\TotpEnrolmentService;
 use App\Http\Resources\ClientResource;
 use App\Http\Resources\TotpSecretResource;
+use App\Jobs\Mail\SendMfaDisabledNotification;
 use App\Jobs\Mail\SendTotpEnabledNotification;
 use App\Models\Client;
 use App\Models\EmailAddress;
@@ -143,11 +144,17 @@ final class MeTotpController
         $this->enrolment->remove($user);
 
         $user->totp_enabled = false;
+        $disabledMfa = false;
         if (! $user->backup_code_enabled) {
             $user->two_factor_enabled = false;
             $user->mfa_disabled_at = now();
+            $disabledMfa = true;
         }
         $user->save();
+
+        if ($disabledMfa) {
+            SendMfaDisabledNotification::dispatch($user->id);
+        }
 
         return $this->clientEnvelope($shape);
     }

--- a/app/Jobs/Mail/SendBackupCodesGeneratedNotification.php
+++ b/app/Jobs/Mail/SendBackupCodesGeneratedNotification.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Jobs\Mail;
 
+use App\Mail\EmailPipeline;
+use App\Models\EmailAddress;
+use App\Models\EmailTemplate;
+use App\Models\Environment;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -13,9 +17,9 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
 /**
- * Heads-up email sent when a user (re)generates backup codes. Body
- * wiring (template lookup, EmailPipeline dispatch) lands in AU-9; this
- * stub keeps the dispatch site stable so AU-9 is a one-line replace.
+ * Heads-up email sent when a user (re)generates backup codes — "New
+ * backup codes were generated for your account." Triggered by
+ * `MeBackupCodesController::regenerate`.
  */
 final class SendBackupCodesGeneratedNotification implements ShouldQueue
 {
@@ -26,8 +30,10 @@ final class SendBackupCodesGeneratedNotification implements ShouldQueue
 
     public int $tries = 3;
 
-    public function __construct(public readonly string $userId)
-    {
+    public function __construct(
+        public readonly string $userId,
+        public readonly int $count,
+    ) {
         $this->onQueue('mail');
     }
 
@@ -36,17 +42,38 @@ final class SendBackupCodesGeneratedNotification implements ShouldQueue
         return [10, 60, 300];
     }
 
-    public function handle(): void
+    public function handle(EmailPipeline $pipeline): void
     {
         $user = User::query()->withoutGlobalScopes()->where('id', $this->userId)->first();
         if ($user === null) {
-            Log::warning('mail_user_missing', ['user_id' => $this->userId, 'template' => 'backup_codes_generated']);
+            Log::warning('mail_user_missing', ['user_id' => $this->userId, 'template' => EmailTemplate::SLUG_BACKUP_CODES_GENERATED]);
 
             return;
         }
-        Log::info('mfa.backup_codes_generated_notification.queued', [
-            'user_id' => $user->id,
-            'environment_id' => $user->environment_id,
-        ]);
+        $env = Environment::query()->withoutGlobalScopes()->where('id', $user->environment_id)->first();
+        if ($env === null) {
+            return;
+        }
+        $email = EmailAddress::query()->withoutGlobalScopes()
+            ->where('id', (string) $user->primary_email_address_id)
+            ->first();
+        if ($email === null) {
+            return;
+        }
+
+        $pipeline->dispatch(
+            environment: $env,
+            templateSlug: EmailTemplate::SLUG_BACKUP_CODES_GENERATED,
+            toEmail: $email->email_address,
+            toName: $user->first_name,
+            vars: [
+                'user' => [
+                    'first_name' => (string) ($user->first_name ?? ''),
+                    'last_name' => (string) ($user->last_name ?? ''),
+                    'email_address' => $email->email_address,
+                ],
+                'count' => $this->count,
+            ],
+        );
     }
 }

--- a/app/Jobs/Mail/SendMfaDisabledNotification.php
+++ b/app/Jobs/Mail/SendMfaDisabledNotification.php
@@ -17,10 +17,13 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
 /**
- * Heads-up email sent when a user enables TOTP — "An authenticator app
- * was added to your account." Triggered by `MeTotpController::verify`.
+ * Heads-up email sent when MFA goes from on to off on a user account.
+ * Triggered by:
+ * - `MeTotpController::destroy` when no other factor remains.
+ * - `MeBackupCodesController::destroy` when no other factor remains.
+ * - `Bapi\UsersController::deleteMfa` (operator nuke; always fires).
  */
-final class SendTotpEnabledNotification implements ShouldQueue
+final class SendMfaDisabledNotification implements ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;
@@ -43,7 +46,7 @@ final class SendTotpEnabledNotification implements ShouldQueue
     {
         $user = User::query()->withoutGlobalScopes()->where('id', $this->userId)->first();
         if ($user === null) {
-            Log::warning('mail_user_missing', ['user_id' => $this->userId, 'template' => EmailTemplate::SLUG_TOTP_ENABLED]);
+            Log::warning('mail_user_missing', ['user_id' => $this->userId, 'template' => EmailTemplate::SLUG_MFA_DISABLED]);
 
             return;
         }
@@ -60,7 +63,7 @@ final class SendTotpEnabledNotification implements ShouldQueue
 
         $pipeline->dispatch(
             environment: $env,
-            templateSlug: EmailTemplate::SLUG_TOTP_ENABLED,
+            templateSlug: EmailTemplate::SLUG_MFA_DISABLED,
             toEmail: $email->email_address,
             toName: $user->first_name,
             vars: [

--- a/app/Models/EmailTemplate.php
+++ b/app/Models/EmailTemplate.php
@@ -66,6 +66,12 @@ class EmailTemplate extends Model
 
     public const SLUG_PASSKEY_REMOVED = 'passkey_removed';
 
+    public const SLUG_TOTP_ENABLED = 'totp_enabled';
+
+    public const SLUG_MFA_DISABLED = 'mfa_disabled';
+
+    public const SLUG_BACKUP_CODES_GENERATED = 'backup_codes_generated';
+
     /**
      * Active set seeded at bootstrap. Every entry has a body_markup (MJML
      * source) and a precompiled body_html (the result of running the mjml
@@ -122,6 +128,21 @@ class EmailTemplate extends Model
             'subject' => "You've been invited to join {{organization.name}}",
             'body_markup' => '<mjml><mj-body><mj-section><mj-column><mj-text>{{inviter.name}} ({{inviter.email}}) has invited you to join <strong>{{organization.name}}</strong> on {{app.name}}.</mj-text><mj-text>You\'ll be added with the <strong>{{role.name}}</strong> role.</mj-text><mj-button href="{{action_url}}">Accept invitation</mj-button><mj-text>This invitation expires {{expires_at_human}}.</mj-text></mj-column></mj-section></mj-body></mjml>',
             'body_html' => '<!doctype html><html><body><p>{{inviter.name}} ({{inviter.email}}) has invited you to join <strong>{{organization.name}}</strong> on {{app.name}}.</p><p>You\'ll be added with the <strong>{{role.name}}</strong> role.</p><p><a href="{{action_url}}" style="display:inline-block;padding:12px 24px;background:#000;color:#fff;text-decoration:none;border-radius:4px;">Accept invitation</a></p><p>This invitation expires {{expires_at_human}}.</p></body></html>',
+        ],
+        self::SLUG_TOTP_ENABLED => [
+            'subject' => 'Two-step verification turned on for {{app.name}}',
+            'body_markup' => "<mjml><mj-body><mj-section><mj-column><mj-text>Hi {{user.first_name}},</mj-text><mj-text>An authenticator app was just added to your {{app.name}} account. From now on, you'll be asked for a 6-digit code from your authenticator after your password.</mj-text><mj-text>If this wasn't you, contact {{app.support_email}} immediately.</mj-text></mj-column></mj-section></mj-body></mjml>",
+            'body_html' => "<!doctype html><html><body><p>Hi {{user.first_name}},</p><p>An authenticator app was just added to your {{app.name}} account. From now on, you'll be asked for a 6-digit code from your authenticator after your password.</p><p>If this wasn't you, contact {{app.support_email}} immediately.</p></body></html>",
+        ],
+        self::SLUG_MFA_DISABLED => [
+            'subject' => 'Two-step verification turned off for {{app.name}}',
+            'body_markup' => "<mjml><mj-body><mj-section><mj-column><mj-text>Hi {{user.first_name}},</mj-text><mj-text>Two-step verification was just turned off on your {{app.name}} account. Future sign-ins will only require your password.</mj-text><mj-text>If this wasn't you, contact {{app.support_email}} immediately.</mj-text></mj-column></mj-section></mj-body></mjml>",
+            'body_html' => "<!doctype html><html><body><p>Hi {{user.first_name}},</p><p>Two-step verification was just turned off on your {{app.name}} account. Future sign-ins will only require your password.</p><p>If this wasn't you, contact {{app.support_email}} immediately.</p></body></html>",
+        ],
+        self::SLUG_BACKUP_CODES_GENERATED => [
+            'subject' => 'New backup codes for {{app.name}}',
+            'body_markup' => "<mjml><mj-body><mj-section><mj-column><mj-text>Hi {{user.first_name}},</mj-text><mj-text>{{count}} new backup codes were just generated for your {{app.name}} account. Any backup codes from before this change no longer work.</mj-text><mj-text>If this wasn't you, contact {{app.support_email}} immediately.</mj-text></mj-column></mj-section></mj-body></mjml>",
+            'body_html' => "<!doctype html><html><body><p>Hi {{user.first_name}},</p><p>{{count}} new backup codes were just generated for your {{app.name}} account. Any backup codes from before this change no longer work.</p><p>If this wasn't you, contact {{app.support_email}} immediately.</p></body></html>",
         ],
     ];
 

--- a/tests/Feature/Mfa/Mail/MfaNotificationTest.php
+++ b/tests/Feature/Mfa/Mail/MfaNotificationTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\Mail\SendBackupCodesGeneratedNotification;
+use App\Jobs\Mail\SendMfaDisabledNotification;
+use App\Jobs\Mail\SendTotpEnabledNotification;
+use App\Models\BackupCode;
+use App\Models\EmailTemplate;
+use App\Models\TotpSecret;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Testing\TestResponse;
+use PragmaRX\Google2FA\Google2FA;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function totpReqMail(string $method, string $path, string $jwt, array $body = []): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+it('queues SendTotpEnabledNotification on a successful TOTP verify', function (): void {
+    Bus::fake();
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    totpReqMail('POST', '/me/totp', $auth['jwt'])->assertOk();
+    $row = TotpSecret::query()->withoutGlobalScopes()->where('user_id', $auth['user']->id)->first();
+    $code = (new Google2FA)->getCurrentOtp($row->secret);
+
+    totpReqMail('POST', '/me/totp/verify', $auth['jwt'], ['code' => $code])->assertOk();
+
+    Bus::assertDispatched(SendTotpEnabledNotification::class, fn ($job) => $job->userId === $auth['user']->id);
+});
+
+it('queues SendBackupCodesGeneratedNotification with the count on regenerate', function (): void {
+    Bus::fake();
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+
+    totpReqMail('POST', '/me/backup-codes', $auth['jwt'])->assertOk();
+
+    Bus::assertDispatched(
+        SendBackupCodesGeneratedNotification::class,
+        fn ($job) => $job->userId === $auth['user']->id && $job->count === 10,
+    );
+});
+
+it('queues SendMfaDisabledNotification when DELETE /me/totp removes the last factor', function (): void {
+    Bus::fake();
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    $auth['user']->forceFill([
+        'totp_enabled' => true,
+        'two_factor_enabled' => true,
+        'mfa_enabled_at' => now(),
+    ])->save();
+
+    totpReqMail('DELETE', '/me/totp', $auth['jwt'])->assertOk();
+
+    Bus::assertDispatched(SendMfaDisabledNotification::class, fn ($job) => $job->userId === $auth['user']->id);
+});
+
+it('does not queue SendMfaDisabledNotification when DELETE /me/totp leaves backup codes behind', function (): void {
+    Bus::fake();
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    BackupCode::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'code_hash' => Hash::make('plain-1'),
+    ]);
+    $auth['user']->forceFill([
+        'totp_enabled' => true,
+        'backup_code_enabled' => true,
+        'two_factor_enabled' => true,
+        'mfa_enabled_at' => now(),
+    ])->save();
+
+    totpReqMail('DELETE', '/me/totp', $auth['jwt'])->assertOk();
+
+    Bus::assertNotDispatched(SendMfaDisabledNotification::class);
+});
+
+it('queues SendMfaDisabledNotification when DELETE /me/backup-codes removes the last factor', function (): void {
+    Bus::fake();
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    BackupCode::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'code_hash' => Hash::make('plain-1'),
+    ]);
+    $auth['user']->forceFill([
+        'backup_code_enabled' => true,
+        'two_factor_enabled' => true,
+        'mfa_enabled_at' => now(),
+    ])->save();
+
+    totpReqMail('DELETE', '/me/backup-codes', $auth['jwt'])->assertOk();
+
+    Bus::assertDispatched(SendMfaDisabledNotification::class, fn ($job) => $job->userId === $auth['user']->id);
+});
+
+it('queues SendMfaDisabledNotification when BAPI DELETE /users/{id}/mfa nukes an enrolled user', function (): void {
+    Bus::fake();
+    $f = BapiTestSupport::bootEnv();
+    $user = User::create(['environment_id' => $f['env']->id]);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    $user->forceFill(['totp_enabled' => true, 'two_factor_enabled' => true])->save();
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->deleteJson(BapiTestSupport::url('/users/'.$user->id.'/mfa'))
+        ->assertOk();
+
+    Bus::assertDispatched(SendMfaDisabledNotification::class, fn ($job) => $job->userId === $user->id);
+});
+
+it('does not queue SendMfaDisabledNotification when BAPI DELETE /users/{id}/mfa hits a non-enrolled user', function (): void {
+    Bus::fake();
+    $f = BapiTestSupport::bootEnv();
+    $user = User::create(['environment_id' => $f['env']->id]);
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->deleteJson(BapiTestSupport::url('/users/'.$user->id.'/mfa'))
+        ->assertOk();
+
+    Bus::assertNotDispatched(SendMfaDisabledNotification::class);
+});
+
+it('seeds the new email templates for newly created environments', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $slugs = EmailTemplate::query()
+        ->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->pluck('slug')
+        ->all();
+    expect($slugs)->toContain('totp_enabled');
+    expect($slugs)->toContain('mfa_disabled');
+    expect($slugs)->toContain('backup_codes_generated');
+});


### PR DESCRIPTION
Closes #96.

## Summary

Three new transactional security emails for v0.3.

| Slug | Subject | Triggered by |
|---|---|---|
| \`totp_enabled\` | Two-step verification turned on for {{app.name}} | \`MeTotpController::verify\` (first successful code) |
| \`mfa_disabled\` | Two-step verification turned off for {{app.name}} | Last-factor removal (FAPI TOTP destroy / FAPI backup-codes destroy) + BAPI \`DELETE /v1/users/{id}/mfa\` |
| \`backup_codes_generated\` | New backup codes for {{app.name}} | \`MeBackupCodesController::regenerate\` (carries the \`{{count}}\` for the body) |

### Seeding

Slot into the existing \`EmailTemplate::DEFAULT_TEMPLATES\` constant. New envs get the templates automatically via \`EnvironmentObserver::created\` (which iterates the constant); the AU-1 v0.1 migration also reads the constant and backfills existing envs. **No new migration needed.**

### Job classes

- \`SendTotpEnabledNotification\` — existing stub from AU-3 promoted from \`Log::info\` to a real \`EmailPipeline::dispatch\`.
- \`SendBackupCodesGeneratedNotification\` — existing stub from AU-4 promoted; constructor now accepts \`(\$userId, \$count)\` so the count flows into the email body.
- \`SendMfaDisabledNotification\` — **new**, mirrors the other two. Dispatched from:
  - \`MeTotpController::destroy\` when no other factor remains.
  - \`MeBackupCodesController::destroy\` when no TOTP remains.
  - \`Bapi\\UsersController::deleteMfa\` when the user had any MFA enrolled (no spurious email on a no-op admin nuke).

## Out of scope

- Localisation overrides — v0.5.
- SMS variants — v0.4+ when SMS support lands.
- Audit-log emission for the same triggers — AU-10 (#97).

## Test plan

- [x] **\`tests/Feature/Mfa/Mail/MfaNotificationTest.php\`** — 8 cases:
  - \`SendTotpEnabledNotification\` dispatched on \`POST /me/totp/verify\` happy path.
  - \`SendBackupCodesGeneratedNotification\` dispatched with \`count = 10\` on regenerate.
  - \`SendMfaDisabledNotification\` dispatched on the three trigger sites:
    - \`DELETE /me/totp\` last-factor.
    - \`DELETE /me/backup-codes\` last-factor.
    - BAPI \`DELETE /v1/users/{id}/mfa\` on an enrolled user.
  - **Not** dispatched when:
    - \`DELETE /me/totp\` leaves backup codes behind.
    - BAPI \`DELETE /v1/users/{id}/mfa\` hits a user with no MFA.
  - \`EmailTemplate::DEFAULT_TEMPLATES\` seeds the three new slugs on env create.
- [x] \`vendor/bin/pint --test\` — clean across 371 files.