### PR TITLE
AU-11: PruneMfaArtifacts maintenance job (#98)

### DIFF
--- a/app/Jobs/Maintenance/PruneMfaArtifacts.php
+++ b/app/Jobs/Maintenance/PruneMfaArtifacts.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Maintenance;
+
+use App\Models\BackupCode;
+use App\Models\Environment;
+use App\Models\TotpSecret;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Two MFA-table reapers running off the same daily tick:
+ *
+ *   - `TotpSecret` rows where `verified_at IS NULL` and `created_at`
+ *     is older than 24h — abandoned enrolment attempts (the user
+ *     closed the modal without typing the first code).
+ *   - `BackupCode` rows with a stamped `consumed_at` older than the
+ *     env's `audit_log_retention_days` setting (default 90). Once a
+ *     code has been consumed, the audit/observability story moves to
+ *     the `auth.mfa.*` log entries; the hash itself is no longer
+ *     needed and just bloats the table.
+ *
+ * Per-env retention so an operator who sets `audit_log_retention_days`
+ * to 30 doesn't keep consumed code rows for 90.
+ */
+final class PruneMfaArtifacts implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public const ABANDONED_TOTP_HOURS = 24;
+
+    public const DEFAULT_BACKUP_CODE_RETENTION_DAYS = 90;
+
+    public function __construct() {}
+
+    public function handle(): void
+    {
+        $this->pruneAbandonedTotpSecrets();
+        $this->pruneStaleConsumedBackupCodes();
+    }
+
+    private function pruneAbandonedTotpSecrets(): void
+    {
+        $threshold = now()->subHours(self::ABANDONED_TOTP_HOURS);
+
+        TotpSecret::query()
+            ->withoutGlobalScopes()
+            ->whereNull('verified_at')
+            ->where('created_at', '<', $threshold)
+            ->delete();
+    }
+
+    private function pruneStaleConsumedBackupCodes(): void
+    {
+        $envs = Environment::query()->withoutGlobalScopes()->get(['id', 'user_settings']);
+        foreach ($envs as $env) {
+            $retentionDays = $this->retentionDaysFor($env);
+            $threshold = now()->subDays($retentionDays);
+
+            BackupCode::query()
+                ->withoutGlobalScopes()
+                ->where('environment_id', $env->id)
+                ->whereNotNull('consumed_at')
+                ->where('consumed_at', '<', $threshold)
+                ->delete();
+        }
+    }
+
+    private function retentionDaysFor(Environment $env): int
+    {
+        $userSettings = is_array($env->user_settings) ? $env->user_settings : [];
+        $value = $userSettings['audit_log_retention_days'] ?? null;
+        if (is_int($value) && $value > 0) {
+            return $value;
+        }
+
+        return self::DEFAULT_BACKUP_CODE_RETENTION_DAYS;
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Jobs\Maintenance\ExpireSessions;
+use App\Jobs\Maintenance\PruneMfaArtifacts;
 use App\Jobs\Maintenance\PruneVerificationCodes;
 use App\Jobs\Maintenance\ReapAbandonedAttempts;
 use App\Jobs\Maintenance\RecheckVerifiedDomains;
@@ -40,5 +41,9 @@ Schedule::job(RotateSigningKey::class)
     ->withoutOverlapping();
 
 Schedule::job(RecheckVerifiedDomains::class)
+    ->daily()
+    ->withoutOverlapping();
+
+Schedule::job(PruneMfaArtifacts::class)
     ->daily()
     ->withoutOverlapping();

--- a/tests/Feature/Mfa/PruneMfaArtifactsTest.php
+++ b/tests/Feature/Mfa/PruneMfaArtifactsTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\Maintenance\PruneMfaArtifacts;
+use App\Models\BackupCode;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\TotpSecret;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+function makeReaperEnv(string $slug, ?int $auditDays = null): Environment
+{
+    $project = Project::create(['name' => 'P-'.$slug, 'slug' => 'p-'.$slug]);
+    $userSettings = $auditDays !== null ? ['audit_log_retention_days' => $auditDays] : [];
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+        'user_settings' => $userSettings,
+    ]);
+}
+
+it('prunes unverified TotpSecrets older than 24h, keeps recent unverified, leaves verified untouched', function (): void {
+    $env = makeReaperEnv('reaper-totp');
+    $user = User::create(['environment_id' => $env->id]);
+
+    $oldUnverified = TotpSecret::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'secret' => 'AAAA',
+    ]);
+    $oldUnverified->forceFill(['created_at' => now()->subHours(48)])->save();
+
+    $recentUnverified = TotpSecret::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'secret' => 'BBBB',
+    ]);
+
+    $verified = TotpSecret::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'secret' => 'CCCC',
+        'verified_at' => now(),
+    ]);
+    $verified->forceFill(['created_at' => now()->subHours(72)])->save();
+
+    (new PruneMfaArtifacts)->handle();
+
+    expect(TotpSecret::query()->withoutGlobalScopes()->where('id', $oldUnverified->id)->exists())->toBeFalse();
+    expect(TotpSecret::query()->withoutGlobalScopes()->where('id', $recentUnverified->id)->exists())->toBeTrue();
+    expect(TotpSecret::query()->withoutGlobalScopes()->where('id', $verified->id)->exists())->toBeTrue();
+});
+
+it('prunes consumed BackupCodes older than retention, keeps recent consumed and unspent rows', function (): void {
+    $env = makeReaperEnv('reaper-bcc');
+    $user = User::create(['environment_id' => $env->id]);
+
+    $oldConsumed = BackupCode::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'code_hash' => Hash::make('a'),
+        'consumed_at' => now()->subDays(120),
+    ]);
+
+    $recentConsumed = BackupCode::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'code_hash' => Hash::make('b'),
+        'consumed_at' => now()->subDays(7),
+    ]);
+
+    $unspent = BackupCode::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'code_hash' => Hash::make('c'),
+    ]);
+
+    (new PruneMfaArtifacts)->handle();
+
+    expect(BackupCode::query()->withoutGlobalScopes()->where('id', $oldConsumed->id)->exists())->toBeFalse();
+    expect(BackupCode::query()->withoutGlobalScopes()->where('id', $recentConsumed->id)->exists())->toBeTrue();
+    expect(BackupCode::query()->withoutGlobalScopes()->where('id', $unspent->id)->exists())->toBeTrue();
+});
+
+it('honours per-env audit_log_retention_days when pruning consumed codes', function (): void {
+    $envA = makeReaperEnv('reaper-a', auditDays: 30);
+    $envB = makeReaperEnv('reaper-b', auditDays: 90);
+    $userA = User::create(['environment_id' => $envA->id]);
+    $userB = User::create(['environment_id' => $envB->id]);
+
+    $consumedA = BackupCode::create([
+        'environment_id' => $envA->id,
+        'user_id' => $userA->id,
+        'code_hash' => Hash::make('a'),
+        'consumed_at' => now()->subDays(45),
+    ]);
+    $consumedB = BackupCode::create([
+        'environment_id' => $envB->id,
+        'user_id' => $userB->id,
+        'code_hash' => Hash::make('b'),
+        'consumed_at' => now()->subDays(45),
+    ]);
+
+    (new PruneMfaArtifacts)->handle();
+
+    expect(BackupCode::query()->withoutGlobalScopes()->where('id', $consumedA->id)->exists())->toBeFalse();
+    expect(BackupCode::query()->withoutGlobalScopes()->where('id', $consumedB->id)->exists())->toBeTrue();
+});
+
+it('runs idempotently — second invocation deletes nothing more', function (): void {
+    $env = makeReaperEnv('reaper-idem');
+    $user = User::create(['environment_id' => $env->id]);
+    BackupCode::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'code_hash' => Hash::make('a'),
+        'consumed_at' => now()->subDays(120),
+    ]);
+
+    (new PruneMfaArtifacts)->handle();
+    $afterFirst = BackupCode::query()->withoutGlobalScopes()->where('environment_id', $env->id)->count();
+    (new PruneMfaArtifacts)->handle();
+    $afterSecond = BackupCode::query()->withoutGlobalScopes()->where('environment_id', $env->id)->count();
+
+    expect($afterFirst)->toBe(0);
+    expect($afterSecond)->toBe(0);
+});


### PR DESCRIPTION
Closes #98.

## Summary

New \`App\Jobs\Maintenance\PruneMfaArtifacts\` daily reaper covering both MFA tables:

1. **Abandoned TOTP enrolments** — \`TotpSecret\` rows where \`verified_at IS NULL\` and \`created_at\` older than **24h**. The user closed the enrolment modal without typing the first code; the row is unspendable.
2. **Stale consumed backup codes** — \`BackupCode\` rows with \`consumed_at\` older than the env's \`audit_log_retention_days\` setting (default **90**, read from \`Environment.user_settings.audit_log_retention_days\`). Per-env retention so an operator who sets 30 doesn't keep consumed code rows for 90.

Per-env iteration on the backup-codes pass; single \`DELETE WHERE\` per env. Cap-per-tick from \`PruneVerificationCodes\` isn't replicated — MFA tables are orders of magnitude smaller (1 row/user max for \`TotpSecret\`, ~10/user for \`BackupCode\`).

Scheduled in \`routes/console.php\` alongside the other maintenance entries: \`Schedule::job(PruneMfaArtifacts::class)->daily()->withoutOverlapping()\`.

## Out of scope

- Anything outside the two MFA tables.
- Cap-per-tick batching (rejected on size grounds — see above).

## Test plan

- [x] **\`tests/Feature/Mfa/PruneMfaArtifactsTest.php\`** — 4 cases:
  - Unverified TotpSecret older than 24h pruned; recent unverified kept; verified untouched regardless of age.
  - Consumed BackupCode older than env retention pruned; recent consumed kept; unspent untouched.
  - Per-env retention honoured: env-A with \`audit_log_retention_days = 30\` removes a 45-day-old consumed code; env-B with \`= 90\` keeps the same-age row.
  - Job runs idempotently — second invocation deletes nothing more.
- [x] \`vendor/bin/pint --test\` — clean across 371 files.