### PR TITLE
AU-12: end-to-end Pest coverage of the second-factor sign-in flow (#99)

### DIFF
--- a/app/Auth/Mfa/BackupCodesService.php
+++ b/app/Auth/Mfa/BackupCodesService.php
@@ -67,25 +67,37 @@ final class BackupCodesService
      */
     public function consume(User $user, string $plaintext): bool
     {
+        return $this->tryConsume($user, $plaintext) === ConsumeResult::Ok;
+    }
+
+    /**
+     * Try to consume `$plaintext`. Distinguishes a never-issued code
+     * (`NotFound`) from a code that the user previously redeemed
+     * (`AlreadyUsed`) so the caller can surface distinct error codes.
+     */
+    public function tryConsume(User $user, string $plaintext): ConsumeResult
+    {
         $plaintext = strtolower(trim($plaintext));
         if (! preg_match('/^[a-z0-9]{4}-[a-z0-9]{4}$/', $plaintext)) {
-            return false;
+            return ConsumeResult::NotFound;
         }
 
         $rows = BackupCode::query()
             ->where('user_id', $user->id)
-            ->whereNull('consumed_at')
             ->get();
 
         foreach ($rows as $row) {
             if (Hash::check($plaintext, $row->code_hash)) {
+                if ($row->consumed_at !== null) {
+                    return ConsumeResult::AlreadyUsed;
+                }
                 $row->markConsumed();
 
-                return true;
+                return ConsumeResult::Ok;
             }
         }
 
-        return false;
+        return ConsumeResult::NotFound;
     }
 
     /**

--- a/app/Auth/Mfa/ConsumeResult.php
+++ b/app/Auth/Mfa/ConsumeResult.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Mfa;
+
+/**
+ * Outcome of `BackupCodesService::tryConsume`. Distinct from a plain
+ * boolean so AU-12's second-factor flow can surface
+ * `form_code_already_used` separately from `form_code_incorrect`.
+ */
+enum ConsumeResult
+{
+    case Ok;
+
+    case AlreadyUsed;
+
+    case NotFound;
+}

--- a/app/Auth/Strategies/BackupCodeStrategy.php
+++ b/app/Auth/Strategies/BackupCodeStrategy.php
@@ -6,6 +6,7 @@ namespace App\Auth\Strategies;
 
 use App\Auth\ErrorCodes;
 use App\Auth\Mfa\BackupCodesService;
+use App\Auth\Mfa\ConsumeResult;
 use App\Models\EmailAddress;
 use App\Models\SignInAttempt;
 use App\Models\User;
@@ -48,8 +49,12 @@ final class BackupCodeStrategy implements Strategy
             return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'User not found for this attempt.', 422);
         }
 
-        if (! $this->service->consume($user, $code)) {
-            return StrategyResult::fail($attempt, ErrorCodes::FORM_CODE_INCORRECT, 'Backup code is incorrect or already used.');
+        $outcome = $this->service->tryConsume($user, $code);
+        if ($outcome === ConsumeResult::AlreadyUsed) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_CODE_ALREADY_USED, 'Backup code has already been used.');
+        }
+        if ($outcome !== ConsumeResult::Ok) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_CODE_INCORRECT, 'Backup code is incorrect.');
         }
 
         $verification = $params['verification'] ?? null;

--- a/tests/Feature/Fapi/MfaSecondFactorFlowTest.php
+++ b/tests/Feature/Fapi/MfaSecondFactorFlowTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Mfa\BackupCodesService;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Session;
+use App\Models\SignInAttempt;
+use App\Models\TotpSecret;
+use App\Models\User;
+use App\Services\Sessions\SessionTokenIssuer;
+use Illuminate\Testing\TestResponse;
+use PragmaRX\Google2FA\Google2FA;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+use Tests\Feature\Http\SignIn\SignInTestSupport;
+
+/**
+ * End-to-end coverage for the v0.3 second-factor sign-in flow. Walks
+ * the full controller arc the way `<SignIn />` will when JS-3 lands.
+ */
+function flowReq(string $method, string $url, array $body, array $headers, ?string $cookie): TestResponse
+{
+    $req = test()->withCredentials()->withHeaders($headers);
+    if ($cookie !== null) {
+        $req = $req->withUnencryptedCookie('__client', $cookie);
+    }
+
+    return $req->json($method, $url, $body);
+}
+
+function seedTotpForFlow(Environment $env, User $user): TotpSecret
+{
+    $secret = TotpSecret::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    $user->forceFill([
+        'totp_enabled' => true,
+        'two_factor_enabled' => true,
+        'mfa_enabled_at' => now(),
+    ])->save();
+
+    return $secret;
+}
+
+/**
+ * @return list<string>
+ */
+function seedBackupCodesForFlow(Environment $env, User $user, int $n = 10): array
+{
+    app()->instance(Environment::class, $env);
+    $codes = app(BackupCodesService::class)->regenerate($user, $env, $n);
+    $user->forceFill(['backup_code_enabled' => true, 'two_factor_enabled' => true])->save();
+
+    return $codes;
+}
+
+it('happy-path TOTP-only sign-in: password → needs_second_factor → totp answer → complete', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    $secret = seedTotpForFlow($f['env'], $bundle['user']);
+    $cb = SignInTestSupport::clientWithCookie($f['env']);
+    $headers = ['Host' => 'acme.authn.local', 'Origin' => $f['origin']];
+
+    $r1 = flowReq('POST', 'https://acme.authn.local/v1/client/sign-ins', [
+        'identifier' => 'alice@example.com',
+        'strategy' => 'password',
+        'password' => 'super-secret-password',
+    ], $headers, $cb['cookie']);
+
+    $r1->assertOk()
+        ->assertJsonPath('response.status', 'needs_second_factor')
+        ->assertJsonPath('response.supported_strategies', ['totp']);
+    expect($r1->json('response.created_session_id'))->toBeNull();
+
+    $sid = $r1->json('response.id');
+    $code = (new Google2FA)->getCurrentOtp($secret->secret);
+
+    $r2 = flowReq('POST', "https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", [
+        'strategy' => 'totp',
+        'code' => $code,
+    ], $headers, $cb['cookie']);
+
+    $r2->assertOk();
+    expect(Session::query()->withoutGlobalScopes()->where('user_id', $bundle['user']->id)->where('status', 'active')->exists())->toBeTrue();
+});
+
+it('happy-path backup-code fallback: burns one code and GET /me/backup-codes reflects 9 unspent', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    seedTotpForFlow($f['env'], $bundle['user']);
+    $codes = seedBackupCodesForFlow($f['env'], $bundle['user'], 10);
+    $cb = SignInTestSupport::clientWithCookie($f['env']);
+    $headers = ['Host' => 'acme.authn.local', 'Origin' => $f['origin']];
+
+    $r1 = flowReq('POST', 'https://acme.authn.local/v1/client/sign-ins', [
+        'identifier' => 'alice@example.com',
+        'strategy' => 'password',
+        'password' => 'super-secret-password',
+    ], $headers, $cb['cookie']);
+    expect($r1->json('response.supported_strategies'))->toContain('totp')->toContain('backup_code');
+    $sid = $r1->json('response.id');
+
+    flowReq('POST', "https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", [
+        'strategy' => 'backup_code',
+        'code' => $codes[0],
+    ], $headers, $cb['cookie'])->assertOk();
+
+    expect(Session::query()->withoutGlobalScopes()->where('user_id', $bundle['user']->id)->where('status', 'active')->exists())->toBeTrue();
+    expect(app(BackupCodesService::class)->unspentCount($bundle['user']->fresh()))->toBe(9);
+});
+
+it('replayed backup code returns form_code_already_used (distinct from form_code_incorrect)', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    seedTotpForFlow($f['env'], $bundle['user']);
+    $codes = seedBackupCodesForFlow($f['env'], $bundle['user'], 4);
+    $headers = ['Host' => 'acme.authn.local', 'Origin' => $f['origin']];
+
+    // First sign-in burns codes[0].
+    $cb1 = SignInTestSupport::clientWithCookie($f['env']);
+    $first = flowReq('POST', 'https://acme.authn.local/v1/client/sign-ins', [
+        'identifier' => 'alice@example.com',
+        'strategy' => 'password',
+        'password' => 'super-secret-password',
+    ], $headers, $cb1['cookie']);
+    flowReq('POST', "https://acme.authn.local/v1/client/sign-ins/{$first->json('response.id')}/challenges", [
+        'strategy' => 'backup_code',
+        'code' => $codes[0],
+    ], $headers, $cb1['cookie'])->assertOk();
+
+    // Second sign-in tries the same code — form_code_already_used.
+    $cb2 = SignInTestSupport::clientWithCookie($f['env']);
+    $second = flowReq('POST', 'https://acme.authn.local/v1/client/sign-ins', [
+        'identifier' => 'alice@example.com',
+        'strategy' => 'password',
+        'password' => 'super-secret-password',
+    ], $headers, $cb2['cookie']);
+    $replay = flowReq('POST', "https://acme.authn.local/v1/client/sign-ins/{$second->json('response.id')}/challenges", [
+        'strategy' => 'backup_code',
+        'code' => $codes[0],
+    ], $headers, $cb2['cookie']);
+
+    $replay->assertStatus(422)->assertJsonPath('errors.0.code', 'form_code_already_used');
+});
+
+it('wrong TOTP code returns form_code_incorrect, attempt stays in needs_second_factor', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    seedTotpForFlow($f['env'], $bundle['user']);
+    $cb = SignInTestSupport::clientWithCookie($f['env']);
+    $headers = ['Host' => 'acme.authn.local', 'Origin' => $f['origin']];
+
+    $first = flowReq('POST', 'https://acme.authn.local/v1/client/sign-ins', [
+        'identifier' => 'alice@example.com',
+        'strategy' => 'password',
+        'password' => 'super-secret-password',
+    ], $headers, $cb['cookie']);
+    $sid = $first->json('response.id');
+
+    $r = flowReq('POST', "https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", [
+        'strategy' => 'totp',
+        'code' => '000000',
+    ], $headers, $cb['cookie']);
+    $r->assertStatus(422)->assertJsonPath('errors.0.code', 'form_code_incorrect');
+
+    expect(SignInAttempt::query()->withoutGlobalScopes()->where('id', $sid)->first()->status)
+        ->toBe('needs_second_factor');
+});
+
+it('user without MFA enrolled completes sign-in in one round-trip', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    SignInTestSupport::makeUser($f['env']);
+    $headers = ['Host' => 'acme.authn.local', 'Origin' => $f['origin']];
+
+    $r = flowReq('POST', 'https://acme.authn.local/v1/client/sign-ins', [
+        'identifier' => 'alice@example.com',
+        'strategy' => 'password',
+        'password' => 'super-secret-password',
+    ], $headers, null);
+
+    $r->assertOk()->assertJsonPath('response.status', 'complete');
+});
+
+it('env disable of both totp + backup_codes mid-flight falls through to complete (loose semantic)', function (): void {
+    // NOTE: pending decision on env-toggle vs enrolled-user-lockout
+    // semantic — see https://github.com/authn-sh/authn/issues/110.
+    // This test pins the AU-5 loose semantic currently shipped:
+    // operator toggle bypasses enrolled MFA. If issue #110 resolves
+    // toward strict, flip this assertion to needs_second_factor.
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    seedTotpForFlow($f['env'], $bundle['user']);
+    $f['env']->forceFill([
+        'user_settings' => [
+            'multi_factor' => [
+                'totp' => ['enabled' => false],
+                'backup_codes' => ['enabled' => false, 'default_count' => 10],
+            ],
+        ],
+    ])->save();
+
+    $r = flowReq('POST', 'https://acme.authn.local/v1/client/sign-ins', [
+        'identifier' => 'alice@example.com',
+        'strategy' => 'password',
+        'password' => 'super-secret-password',
+    ], ['Host' => 'acme.authn.local', 'Origin' => $f['origin']], null);
+
+    $r->assertOk()->assertJsonPath('response.status', 'complete');
+});
+
+it('mfa_already_verified on re-enrol after a successful verify', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    seedTotpForFlow($f['env'], $bundle['user']);
+
+    $headers = ['Host' => 'acme.authn.local', 'Origin' => $f['origin'], 'Authorization' => 'Bearer '.signInJwt($f, $bundle['user'])];
+
+    $r = test()->withCredentials()->withHeaders($headers)
+        ->postJson('https://acme.authn.local/v1/me/totp', []);
+
+    $r->assertStatus(409);
+    expect($r->json('errors.0.code'))->toBe('mfa_already_verified');
+});
+
+it('BAPI DELETE /v1/users/{id}/mfa clears, then user signs in with first-factor only', function (): void {
+    // Boot with the BAPI host setup so the BAPI DELETE works.
+    $bapiBoot = BapiTestSupport::bootEnv();
+    SignInTestSupport::makeUser($bapiBoot['env']);
+    $signInUser = User::query()->withoutGlobalScopes()
+        ->where('environment_id', $bapiBoot['env']->id)
+        ->orderBy('created_at')
+        ->first();
+    seedTotpForFlow($bapiBoot['env'], $signInUser);
+
+    test()->withHeaders(BapiTestSupport::headers($bapiBoot['token']))
+        ->deleteJson(BapiTestSupport::url('/users/'.$signInUser->id.'/mfa'))
+        ->assertOk();
+
+    // Now reload routes for FAPI to sign in.
+    SignInTestSupport::reloadRoutes();
+    $headers = ['Host' => $bapiBoot['env']->slug.'.authn.local', 'Origin' => 'https://app.example.com'];
+
+    $r = test()->withCredentials()->withHeaders($headers)
+        ->postJson('https://'.$bapiBoot['env']->slug.'.authn.local/v1/client/sign-ins', [
+            'identifier' => 'alice@example.com',
+            'strategy' => 'password',
+            'password' => 'super-secret-password',
+        ]);
+
+    $r->assertOk()->assertJsonPath('response.status', 'complete');
+});
+
+function signInJwt(array $f, User $user): string
+{
+    // Use MeTestSupport pattern — mint a session token JWT for the user.
+    $client = Client::create(['environment_id' => $f['env']->id]);
+    $session = Session::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $client->id,
+        'user_id' => $user->id,
+        'status' => Session::STATUS_ACTIVE,
+    ]);
+    $minted = app(SessionTokenIssuer::class)->mint($session->fresh());
+
+    return $minted['jwt'];
+}

--- a/tests/Feature/Http/SignIn/SecondFactorTest.php
+++ b/tests/Feature/Http/SignIn/SecondFactorTest.php
@@ -130,7 +130,7 @@ it('answers the second-factor backup-code challenge inline and completes the sig
     expect(Session::query()->withoutGlobalScopes()->where('user_id', $bundle['user']->id)->where('status', 'active')->exists())->toBeTrue();
 });
 
-it('rejects a replayed backup code with form_code_incorrect on the second use', function (): void {
+it('rejects a replayed backup code with form_code_already_used on the second use', function (): void {
     $f = SignInTestSupport::bootEnv();
     $bundle = SignInTestSupport::makeUser($f['env']);
     TotpSecret::create([
@@ -157,7 +157,7 @@ it('rejects a replayed backup code with form_code_incorrect on the second use', 
     $second = signInPost($f, ['identifier' => 'alice@example.com', 'strategy' => 'password', 'password' => 'super-secret-password'], $cb2['cookie']);
     $replay = signInChallenge($second->json('response.id'), $f, ['strategy' => 'backup_code', 'code' => $codes[0]], $cb2['cookie']);
 
-    $replay->assertStatus(422)->assertJsonPath('errors.0.code', 'form_code_incorrect');
+    $replay->assertStatus(422)->assertJsonPath('errors.0.code', 'form_code_already_used');
 });
 
 it('omits second_factors when the env disables both totp and backup_codes mid-flight', function (): void {


### PR DESCRIPTION
Closes #99.

## Summary

8-scenario integration suite walking the full \`SignIn → Challenge → Session\` arc the way the JS-3 \`<SignIn />\` component will when it consumes this. Lives in \`tests/Feature/Fapi/MfaSecondFactorFlowTest.php\`.

## Scenarios

1. **Happy path TOTP-only** — \`POST /sign-ins\` with password → \`needs_second_factor\` with \`supported_strategies = [totp]\` → \`POST /challenges\` with synthesised current OTP → \`complete\` + active \`Session\`.
2. **Backup-code fallback happy path** — same setup with TOTP + 10 backup codes → \`supported_strategies\` contains \`[totp, backup_code]\` → burn one via \`backup_code\` strategy → \`complete\` + 9 unspent left.
3. **Replayed backup code** — second sign-in tries the burnt code → \`form_code_already_used\` (now **distinct from** \`form_code_incorrect\`).
4. **Wrong TOTP code** — 422 \`form_code_incorrect\`, attempt stays in \`needs_second_factor\`.
5. **No-MFA user one-shot** — completes via single \`POST /sign-ins\`.
6. **Env disables both \`totp\` + \`backup_codes\` mid-flight** — \`supported_strategies\` empty, falls through to \`complete\`. **Pins the AU-5 loose semantic** with a comment pointing at #110 for the strict-vs-loose decision.
7. **\`mfa_already_verified\` on re-enrol** — \`POST /me/totp\` after a successful enrol returns 409.
8. **BAPI \`DELETE /v1/users/{id}/mfa\` clears**, then the user signs in with first-factor only.

## Service change to surface \`form_code_already_used\`

The AU-5 design check noted that the openapi spec is silent on whether replay vs wrong returns distinct codes; AU-12's issue body explicitly asks for \`form_code_already_used\`. Added a 1-method service change:

- New enum \`App\\Auth\\Mfa\\ConsumeResult\` — \`Ok\` / \`AlreadyUsed\` / \`NotFound\`.
- \`BackupCodesService::tryConsume(\$user, \$plain): ConsumeResult\` — looks up by hash on **all** the user's rows (consumed and unspent) so it can distinguish a replay from a never-issued code.
- \`BackupCodeStrategy::attempt\` branches on the enum: \`AlreadyUsed → form_code_already_used\`, anything else \`→ form_code_incorrect\`.
- The legacy \`consume(\$user, \$plain): bool\` wrapper stays for callers that want the boolean.

## Out of scope

- Browser-driven (Dusk) tests of the Account Portal — out of v0.3 scope per the issue body.

## Test plan

- [x] **\`tests/Feature/Fapi/MfaSecondFactorFlowTest.php\`** — 8 scenarios above, all green sequentially.
- [x] AU-5's \`tests/Feature/Http/SignIn/SecondFactorTest::it rejects a replayed backup code\` test updated for the new \`form_code_already_used\` semantic.
- [x] All Mfa / Http/SignIn / Fapi tests green together: **65 passed, 249 assertions**.
- [x] \`vendor/bin/pint --test\` — clean across 372 files.