### PR TITLE
Point AU-12 env-toggle test comment at the canonical follow-up #109

### DIFF
--- a/tests/Feature/Fapi/MfaSecondFactorFlowTest.php
+++ b/tests/Feature/Fapi/MfaSecondFactorFlowTest.php
@@ -187,9 +187,9 @@ it('user without MFA enrolled completes sign-in in one round-trip', function ():
 
 it('env disable of both totp + backup_codes mid-flight falls through to complete (loose semantic)', function (): void {
     // NOTE: pending decision on env-toggle vs enrolled-user-lockout
-    // semantic — see https://github.com/authn-sh/authn/issues/110.
+    // semantic — see https://github.com/authn-sh/authn/issues/109.
     // This test pins the AU-5 loose semantic currently shipped:
-    // operator toggle bypasses enrolled MFA. If issue #110 resolves
+    // operator toggle bypasses enrolled MFA. If issue #109 resolves
     // toward strict, flip this assertion to needs_second_factor.
     $f = SignInTestSupport::bootEnv();
     $bundle = SignInTestSupport::makeUser($f['env']);


### PR DESCRIPTION
Trivial comment fix. AU-12 (#114, merged) was authored before team-lead filed the canonical follow-up at #109 and referenced my superseded \`#110\` instead. Updates two lines of the env-toggle test comment so the future strict-vs-loose debate has the right trail.

No code changes; comment-only.