### PR TITLE
AU-8: Dashboard Configure → Multi-factor subsection (#95)

### DIFF
--- a/app/Http/Controllers/Dashboard/DashboardController.php
+++ b/app/Http/Controllers/Dashboard/DashboardController.php
@@ -23,6 +23,7 @@ use App\Models\User;
 use App\Models\WebhookDelivery;
 use App\Models\WebhookEndpoint;
 use App\Services\Keys\KeyGenerator;
+use App\Settings\MultiFactorSettings;
 use App\Support\RoutingLabel;
 use App\Support\Url;
 use Illuminate\Http\RedirectResponse;
@@ -252,7 +253,40 @@ final class DashboardController
             'allowed_origins' => is_array($env->allowed_origins) ? $env->allowed_origins : [],
             'appearance' => is_array($env->appearance) ? $env->appearance : [],
             'signup_mode' => $env->signup_mode,
+            'multi_factor' => MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : [])->toArray(),
         ]);
+    }
+
+    public function updateMultiFactor(Request $request, string $project_slug, string $env_slug): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+
+        $request->validate([
+            'totp.enabled' => ['required', 'boolean'],
+            'backup_codes.enabled' => ['required', 'boolean'],
+            'backup_codes.default_count' => [
+                'required', 'integer',
+                'between:'.MultiFactorSettings::MIN_BACKUP_CODE_COUNT.','.MultiFactorSettings::MAX_BACKUP_CODE_COUNT,
+            ],
+        ]);
+
+        $userSettings = is_array($env->user_settings) ? $env->user_settings : [];
+        $previous = MultiFactorSettings::fromUserSettings($userSettings);
+        $next = $previous->withPatch([
+            'totp' => ['enabled' => $request->boolean('totp.enabled')],
+            'backup_codes' => [
+                'enabled' => $request->boolean('backup_codes.enabled'),
+                'default_count' => (int) $request->input('backup_codes.default_count'),
+            ],
+        ]);
+        $userSettings['multi_factor'] = $next->toArray();
+        $env->forceFill(['user_settings' => $userSettings])->save();
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/multi-factor")
+            ->with('multi_factor_saved', true);
     }
 
     public function emailTemplates(string $project_slug, string $env_slug): InertiaResponse|RedirectResponse

--- a/resources/js/dashboard/pages/Configure.tsx
+++ b/resources/js/dashboard/pages/Configure.tsx
@@ -1,19 +1,142 @@
+import { Link, useForm, usePage } from '@inertiajs/react'
+import { useDashboard, useDashboardUrl } from '../shared'
+
+type MultiFactorSettings = {
+    totp: { enabled: boolean }
+    backup_codes: { enabled: boolean; default_count: number }
+}
+
 type Props = {
     section: string
     user_settings: Record<string, unknown>
     allowed_origins: string[]
     appearance: Record<string, unknown>
     signup_mode: string
+    multi_factor: MultiFactorSettings
 }
 
-export default function Configure({ section, user_settings, signup_mode }: Props) {
+const SECTIONS = [
+    { slug: 'attributes', label: 'Attributes' },
+    { slug: 'multi-factor', label: 'Multi-factor' },
+] as const
+
+export default function Configure(props: Props) {
+    const url = useDashboardUrl()
+    const { active_project, active_environment } = useDashboard()
+    const baseConfigure = active_project && active_environment
+        ? `/${active_project.slug}/${active_environment.slug}/configure`
+        : '/configure'
+
     return (
         <div>
-            <h1>Configure → {section}</h1>
-            <p>Sign-up mode: <strong>{signup_mode}</strong></p>
-            <pre style={{ background: '#f1f5f9', padding: 12, borderRadius: 6 }}>
-                {JSON.stringify(user_settings, null, 2)}
-            </pre>
+            <h1>Configure</h1>
+            <nav style={{ display: 'flex', gap: 12, marginBottom: 24, borderBottom: '1px solid #e5e7eb', paddingBottom: 8 }}>
+                {SECTIONS.map(s => (
+                    <Link
+                        key={s.slug}
+                        href={url(`${baseConfigure}/${s.slug}`)}
+                        style={{
+                            padding: '6px 10px',
+                            borderRadius: 6,
+                            background: props.section === s.slug ? '#0f172a' : 'transparent',
+                            color: props.section === s.slug ? '#fff' : '#0f172a',
+                            textDecoration: 'none',
+                        }}
+                    >
+                        {s.label}
+                    </Link>
+                ))}
+            </nav>
+            {props.section === 'multi-factor'
+                ? <MultiFactorSection multiFactor={props.multi_factor} />
+                : <AttributesPlaceholder section={props.section} userSettings={props.user_settings} signupMode={props.signup_mode} />}
         </div>
+    )
+}
+
+function AttributesPlaceholder({ section, userSettings, signupMode }: { section: string; userSettings: Record<string, unknown>; signupMode: string }) {
+    return (
+        <>
+            <h2>{section}</h2>
+            <p>Sign-up mode: <strong>{signupMode}</strong></p>
+            <pre style={{ background: '#f1f5f9', padding: 12, borderRadius: 6 }}>
+                {JSON.stringify(userSettings, null, 2)}
+            </pre>
+        </>
+    )
+}
+
+function MultiFactorSection({ multiFactor }: { multiFactor: MultiFactorSettings }) {
+    const url = useDashboardUrl()
+    const { active_project, active_environment } = useDashboard()
+    const { props: pageProps } = usePage<{ flash?: { multi_factor_saved?: boolean } }>()
+    const form = useForm({
+        totp: { enabled: multiFactor.totp.enabled },
+        backup_codes: {
+            enabled: multiFactor.backup_codes.enabled,
+            default_count: multiFactor.backup_codes.default_count,
+        },
+    })
+
+    if (!active_project || !active_environment) {
+        return <p>No active environment.</p>
+    }
+    const action = url(`/${active_project.slug}/${active_environment.slug}/configure/multi-factor`)
+
+    return (
+        <section>
+            <h2>Multi-factor authentication</h2>
+            <p>Per-environment toggles. Disabling a strategy keeps existing enrollment rows but stops them from completing sign-in.</p>
+            {pageProps.flash?.multi_factor_saved && (
+                <div style={{ padding: 12, background: '#dcfce7', borderRadius: 6, marginBottom: 16 }}>
+                    Saved.
+                </div>
+            )}
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault()
+                    form.patch(action, { preserveScroll: true })
+                }}
+            >
+                <fieldset style={{ marginBottom: 16, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+                    <legend><strong>TOTP (authenticator app)</strong></legend>
+                    <label style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                        <input
+                            type="checkbox"
+                            checked={form.data.totp.enabled}
+                            onChange={(e) => form.setData('totp', { enabled: e.target.checked })}
+                        />
+                        Allow users to enroll an authenticator app as a second factor.
+                    </label>
+                    {form.errors['totp.enabled'] && <span style={{ color: '#c00', fontSize: 12 }}>{form.errors['totp.enabled']}</span>}
+                </fieldset>
+                <fieldset style={{ marginBottom: 16, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+                    <legend><strong>Backup codes</strong></legend>
+                    <label style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
+                        <input
+                            type="checkbox"
+                            checked={form.data.backup_codes.enabled}
+                            onChange={(e) => form.setData('backup_codes', { ...form.data.backup_codes, enabled: e.target.checked })}
+                        />
+                        Allow users to generate single-use recovery codes.
+                    </label>
+                    <label style={{ display: 'block' }}>
+                        Codes per regeneration (4–24)
+                        <input
+                            type="number"
+                            min={4}
+                            max={24}
+                            value={form.data.backup_codes.default_count}
+                            onChange={(e) => form.setData('backup_codes', { ...form.data.backup_codes, default_count: Number(e.target.value) })}
+                            style={{ display: 'block', marginTop: 4, padding: 6, width: 120 }}
+                        />
+                    </label>
+                    {form.errors['backup_codes.default_count'] && <span style={{ color: '#c00', fontSize: 12 }}>{form.errors['backup_codes.default_count']}</span>}
+                </fieldset>
+                <button type="submit" disabled={form.processing}>
+                    {form.processing ? 'Saving…' : 'Save'}
+                </button>
+            </form>
+        </section>
     )
 }

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -39,6 +39,7 @@ Route::prefix('{project_slug}/{env_slug}')->group(function (): void {
     Route::get('/allowlist', [DashboardController::class, 'allowlist'])->name('dashboard.allowlist');
     Route::get('/blocklist', [DashboardController::class, 'blocklist'])->name('dashboard.blocklist');
     Route::get('/configure/{section?}', [DashboardController::class, 'configure'])->name('dashboard.configure');
+    Route::patch('/configure/multi-factor', [DashboardController::class, 'updateMultiFactor'])->name('dashboard.configure.multi_factor.update');
     Route::get('/email-templates', [DashboardController::class, 'emailTemplates'])->name('dashboard.email_templates');
 
     Route::get('/api-keys', [DashboardController::class, 'apiKeys'])->name('dashboard.api_keys');

--- a/tests/Feature/Http/Dashboard/DashboardTest.php
+++ b/tests/Feature/Http/Dashboard/DashboardTest.php
@@ -322,3 +322,73 @@ it('redirects on unknown organization id back to organizations list', function (
     $r->assertRedirect();
     expect($r->headers->get('Location'))->toContain('/acme/production/organizations');
 });
+
+it('Configure renders the multi-factor subsection with spec defaults when user_settings.multi_factor is unset', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->get('http://dashboard.authn.local/acme/production/configure/multi-factor');
+
+    $r->assertOk()
+        ->assertJsonPath('component', 'Dashboard/Configure')
+        ->assertJsonPath('props.section', 'multi-factor')
+        ->assertJsonPath('props.multi_factor.totp.enabled', true)
+        ->assertJsonPath('props.multi_factor.backup_codes.enabled', true)
+        ->assertJsonPath('props.multi_factor.backup_codes.default_count', 10);
+});
+
+it('PATCH /configure/multi-factor writes the toggles through to user_settings.multi_factor', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->patch('http://dashboard.authn.local/acme/production/configure/multi-factor', [
+            'totp' => ['enabled' => false],
+            'backup_codes' => ['enabled' => true, 'default_count' => 16],
+        ]);
+
+    $r->assertRedirect();
+    expect($env->fresh()->user_settings['multi_factor']['totp']['enabled'])->toBeFalse();
+    expect($env->fresh()->user_settings['multi_factor']['backup_codes']['default_count'])->toBe(16);
+    expect(session('multi_factor_saved'))->toBeTrue();
+});
+
+it('PATCH /configure/multi-factor rejects default_count outside 4..24 with validation errors', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->patch('http://dashboard.authn.local/acme/production/configure/multi-factor', [
+            'totp' => ['enabled' => true],
+            'backup_codes' => ['enabled' => true, 'default_count' => 3],
+        ]);
+
+    $r->assertStatus(422);
+    $errors = $r->json('errors');
+    expect($errors)->toHaveKey('backup_codes.default_count');
+});


### PR DESCRIPTION
Closes #95.

## Summary

Per the dashboard convention (see \`DashboardController\` docblock), this does **not** proxy through BAPI — \`DashboardController::updateMultiFactor\` writes directly to \`Environment.user_settings.multi_factor\` using the same persistence shape AU-2 wired for the BAPI path. Operator browser never sees \`sk_…\`.

### Server side (\`app/Http/Controllers/Dashboard/DashboardController.php\` + \`routes/dashboard.php\`)

- New \`PATCH /{project}/{env}/configure/multi-factor\` route.
- New \`updateMultiFactor\` handler:
  - Laravel validation: \`totp.enabled\` boolean, \`backup_codes.enabled\` boolean, \`backup_codes.default_count\` integer between **4 and 24** (matches AU-2's server validation).
  - Applies the patch via \`MultiFactorSettings::withPatch\` so partial updates leave omitted fields alone.
  - Persists into \`env.user_settings.multi_factor\`.
  - Redirects back to the multi-factor section with a \`multi_factor_saved\` flash flag.
- \`configure\` action now surfaces a resolved \`multi_factor\` prop (from \`MultiFactorSettings::fromUserSettings\`) so the page hydrates with spec defaults when unset.

### React (\`resources/js/dashboard/pages/Configure.tsx\`)

- Promoted from a single JSON dump to a section-router with a top-of-page section nav (\`Attributes\`, \`Multi-factor\`).
- New \`MultiFactorSection\` component:
  - Three controls — totp toggle, backup-codes toggle, codes-per-regeneration number input (\`min=4 max=24\` to match server-side).
  - Submits via Inertia's \`form.patch\` to the new route.
  - Surfaces inline validation errors and a "Saved." confirmation banner from the flash bag.

## Out of scope

- The Attributes section is still the existing placeholder (per AU-13 plans).
- UI polish on the section nav — kept minimal per design check.
- Account Portal Security section — AU-7 (next, after the JS-3 SDK 0.3.0 publish).

## Test plan

- [x] **\`tests/Feature/Http/Dashboard/DashboardTest.php\`** — 3 new cases:
  - GET \`/configure/multi-factor\` renders the section with spec defaults (\`totp.enabled = true\`, \`backup_codes.enabled = true\`, \`default_count = 10\`).
  - PATCH writes through to \`user_settings.multi_factor\` and stashes \`multi_factor_saved\` in the flash bag.
  - PATCH returns 422 with \`backup_codes.default_count\` validation error when value is outside 4..24.
- [x] All existing dashboard tests still green: **12 passed, 67 assertions**.
- [x] \`vendor/bin/pint --test\` — clean across 376 files.