### PR TITLE
Strict MFA enforcement: env toggle gates enrolment, never bypasses an enrolled user (#109)

### DIFF
--- a/app/Http/Controllers/Fapi/ChallengeController.php
+++ b/app/Http/Controllers/Fapi/ChallengeController.php
@@ -31,7 +31,6 @@ use App\Services\MagicLink\MagicLinkIssuer;
 use App\Services\Sessions\SessionLifecycle;
 use App\Services\Sessions\SessionTokenIssuer;
 use App\Services\Verification\VerificationManager;
-use App\Settings\MultiFactorSettings;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -218,10 +217,16 @@ final class ChallengeController
         // needs_second_factor instead of completing. Second-factor
         // strategies (totp, backup_code) skip this branch — their answer
         // promotes the attempt straight to complete.
+        //
+        // The pivot is purely a function of user enrolment; the env-level
+        // multi_factor toggle gates *new enrolments* (in MeTotpController
+        // / MeBackupCodesController) but never bypasses an already-
+        // enrolled user's second factor. Operator policy changes don't
+        // silently downgrade a user from "I expect MFA" to "first-factor-
+        // only".
         if ($challenge->step === Challenge::STEP_FIRST
             && $user !== null
             && $this->userHasEnrolledSecondFactor($user)
-            && $this->envOffersSecondFactor($attempt)
         ) {
             $attempt->status = SignInAttempt::STATUS_NEEDS_SECOND_FACTOR;
             $attempt->save();
@@ -236,7 +241,7 @@ final class ChallengeController
 
     private function userHasEnrolledSecondFactor(User $user): bool
     {
-        $hasTotp = TotpSecret::query()
+        $hasTotp = (bool) $user->totp_enabled && TotpSecret::query()
             ->withoutGlobalScopes()
             ->where('user_id', $user->id)
             ->whereNotNull('verified_at')
@@ -245,22 +250,11 @@ final class ChallengeController
             return true;
         }
 
-        return BackupCode::query()
+        return (bool) $user->backup_code_enabled && BackupCode::query()
             ->withoutGlobalScopes()
             ->where('user_id', $user->id)
             ->whereNull('consumed_at')
             ->exists();
-    }
-
-    private function envOffersSecondFactor(SignInAttempt $attempt): bool
-    {
-        $env = Environment::query()->withoutGlobalScopes()->where('id', $attempt->environment_id)->first();
-        if ($env === null) {
-            return false;
-        }
-        $settings = MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
-
-        return $settings->totpEnabled || $settings->backupCodesEnabled;
     }
 
     public function showForSignIn(Request $request): JsonResponse
@@ -812,44 +806,39 @@ final class ChallengeController
     }
 
     /**
-     * Narrow second-factor strategies by per-env enable toggles AND
-     * per-user enrolment. Empty if MFA is disabled at the env level.
+     * Narrow second-factor strategies purely by per-user enrolment.
+     * The env-level `multi_factor.{totp,backup_codes}.enabled` toggle
+     * gates *new enrolments* (in MeTotpController / MeBackupCodesController)
+     * but does not strip already-enrolled users of their second factor.
+     * An operator who turns the toggle off after users have enrolled
+     * MUST clear those rows (BAPI `DELETE /v1/users/{id}/mfa`) to
+     * actually downgrade them.
      *
      * @return list<string>
      */
     private function signInSecondFactorStrategies(SignInAttempt $attempt): array
     {
-        $env = Environment::query()->withoutGlobalScopes()->where('id', $attempt->environment_id)->first();
-        if ($env === null) {
-            return [];
-        }
-        $settings = MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
-
         $user = $this->resolveUserForSignIn($attempt);
         if ($user === null) {
             return [];
         }
 
         $strategies = [];
-        if ($settings->totpEnabled) {
-            $hasTotp = TotpSecret::query()
-                ->withoutGlobalScopes()
-                ->where('user_id', $user->id)
-                ->whereNotNull('verified_at')
-                ->exists();
-            if ($hasTotp) {
-                $strategies[] = Verification::STRATEGY_TOTP;
-            }
+        $hasTotp = (bool) $user->totp_enabled && TotpSecret::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->exists();
+        if ($hasTotp) {
+            $strategies[] = Verification::STRATEGY_TOTP;
         }
-        if ($settings->backupCodesEnabled) {
-            $hasUnspent = BackupCode::query()
-                ->withoutGlobalScopes()
-                ->where('user_id', $user->id)
-                ->whereNull('consumed_at')
-                ->exists();
-            if ($hasUnspent) {
-                $strategies[] = Verification::STRATEGY_BACKUP_CODE;
-            }
+        $hasUnspent = (bool) $user->backup_code_enabled && BackupCode::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNull('consumed_at')
+            ->exists();
+        if ($hasUnspent) {
+            $strategies[] = Verification::STRATEGY_BACKUP_CODE;
         }
 
         return $strategies;

--- a/app/Http/Controllers/Fapi/SignInController.php
+++ b/app/Http/Controllers/Fapi/SignInController.php
@@ -24,7 +24,6 @@ use App\Models\Verification;
 use App\Services\Client\ClientResolver;
 use App\Services\Sessions\SessionLifecycle;
 use App\Services\Sessions\SessionTokenIssuer;
-use App\Settings\MultiFactorSettings;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -279,30 +278,25 @@ final class SignInController
 
     private function shouldPivotToSecondFactor(SignInAttempt $attempt, User $user): bool
     {
-        $env = Environment::query()->withoutGlobalScopes()->where('id', $attempt->environment_id)->first();
-        if ($env === null) {
-            return false;
-        }
-        $settings = MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
-        if (! $settings->totpEnabled && ! $settings->backupCodesEnabled) {
-            return false;
-        }
-
-        $hasTotp = TotpSecret::query()
+        // Strict semantic: pivot when the user is enrolled, regardless
+        // of the env-level multi_factor toggle. The toggle gates new
+        // enrolments only; an operator who turns it off after users
+        // have enrolled MUST clear their rows via BAPI
+        // `DELETE /v1/users/{id}/mfa` to actually downgrade them.
+        $hasTotp = (bool) $user->totp_enabled && TotpSecret::query()
             ->withoutGlobalScopes()
             ->where('user_id', $user->id)
             ->whereNotNull('verified_at')
             ->exists();
-        if ($hasTotp && $settings->totpEnabled) {
+        if ($hasTotp) {
             return true;
         }
-        $hasBackup = BackupCode::query()
+
+        return (bool) $user->backup_code_enabled && BackupCode::query()
             ->withoutGlobalScopes()
             ->where('user_id', $user->id)
             ->whereNull('consumed_at')
             ->exists();
-
-        return $hasBackup && $settings->backupCodesEnabled;
     }
 
     private function createSession(SignInAttempt $attempt, ?User $user): Session

--- a/app/Http/Resources/SignInResource.php
+++ b/app/Http/Resources/SignInResource.php
@@ -6,12 +6,10 @@ namespace App\Http\Resources;
 
 use App\Models\BackupCode;
 use App\Models\EmailAddress;
-use App\Models\Environment;
 use App\Models\SignInAttempt;
 use App\Models\TotpSecret;
 use App\Models\User;
 use App\Models\Verification;
-use App\Settings\MultiFactorSettings;
 
 /**
  * Mirrors openapi `SignIn`. Factor verification state is no longer
@@ -78,6 +76,11 @@ final class SignInResource
     }
 
     /**
+     * Strict semantic: second-factor availability is purely per-user
+     * enrolment. The env-level `multi_factor.{totp,backup_codes}.enabled`
+     * toggle gates new enrolments only — operator policy changes never
+     * silently downgrade an already-enrolled user.
+     *
      * @return list<string>
      */
     private static function secondFactorStrategies(SignInAttempt $attempt): array
@@ -86,32 +89,23 @@ final class SignInResource
         if ($user === null) {
             return [];
         }
-        $env = Environment::query()->withoutGlobalScopes()->where('id', $attempt->environment_id)->first();
-        if ($env === null) {
-            return [];
-        }
-        $settings = MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
 
         $strategies = [];
-        if ($settings->totpEnabled) {
-            $hasTotp = TotpSecret::query()
-                ->withoutGlobalScopes()
-                ->where('user_id', $user->id)
-                ->whereNotNull('verified_at')
-                ->exists();
-            if ($hasTotp) {
-                $strategies[] = Verification::STRATEGY_TOTP;
-            }
+        $hasTotp = (bool) $user->totp_enabled && TotpSecret::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->exists();
+        if ($hasTotp) {
+            $strategies[] = Verification::STRATEGY_TOTP;
         }
-        if ($settings->backupCodesEnabled) {
-            $hasUnspent = BackupCode::query()
-                ->withoutGlobalScopes()
-                ->where('user_id', $user->id)
-                ->whereNull('consumed_at')
-                ->exists();
-            if ($hasUnspent) {
-                $strategies[] = Verification::STRATEGY_BACKUP_CODE;
-            }
+        $hasUnspent = (bool) $user->backup_code_enabled && BackupCode::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNull('consumed_at')
+            ->exists();
+        if ($hasUnspent) {
+            $strategies[] = Verification::STRATEGY_BACKUP_CODE;
         }
 
         return $strategies;

--- a/tests/Feature/Fapi/MfaSecondFactorFlowTest.php
+++ b/tests/Feature/Fapi/MfaSecondFactorFlowTest.php
@@ -185,15 +185,15 @@ it('user without MFA enrolled completes sign-in in one round-trip', function ():
     $r->assertOk()->assertJsonPath('response.status', 'complete');
 });
 
-it('env disable of both totp + backup_codes mid-flight falls through to complete (loose semantic)', function (): void {
-    // NOTE: pending decision on env-toggle vs enrolled-user-lockout
-    // semantic — see https://github.com/authn-sh/authn/issues/109.
-    // This test pins the AU-5 loose semantic currently shipped:
-    // operator toggle bypasses enrolled MFA. If issue #109 resolves
-    // toward strict, flip this assertion to needs_second_factor.
+it('env disable of both totp + backup_codes does NOT downgrade an enrolled user (strict semantic)', function (): void {
+    // Strict semantic per issue #109: the env-level multi_factor toggle
+    // gates new enrolments only. An already-enrolled user is still
+    // required to provide a second factor at sign-in. Operator policy
+    // changes never silently drop a user from "I expect MFA" to
+    // first-factor-only — they must DELETE /v1/users/{id}/mfa to do that.
     $f = SignInTestSupport::bootEnv();
     $bundle = SignInTestSupport::makeUser($f['env']);
-    seedTotpForFlow($f['env'], $bundle['user']);
+    $secret = seedTotpForFlow($f['env'], $bundle['user']);
     $f['env']->forceFill([
         'user_settings' => [
             'multi_factor' => [
@@ -203,13 +203,68 @@ it('env disable of both totp + backup_codes mid-flight falls through to complete
         ],
     ])->save();
 
+    $cb = SignInTestSupport::clientWithCookie($f['env']);
+    $headers = ['Host' => 'acme.authn.local', 'Origin' => $f['origin']];
     $r = flowReq('POST', 'https://acme.authn.local/v1/client/sign-ins', [
         'identifier' => 'alice@example.com',
         'strategy' => 'password',
         'password' => 'super-secret-password',
-    ], ['Host' => 'acme.authn.local', 'Origin' => $f['origin']], null);
+    ], $headers, $cb['cookie']);
 
-    $r->assertOk()->assertJsonPath('response.status', 'complete');
+    $r->assertOk()
+        ->assertJsonPath('response.status', 'needs_second_factor')
+        ->assertJsonPath('response.supported_strategies', ['totp']);
+    expect($r->json('response.created_session_id'))->toBeNull();
+
+    // Enrolled user can still complete sign-in by answering the second factor.
+    $sid = $r->json('response.id');
+    $code = (new Google2FA)->getCurrentOtp($secret->secret);
+    flowReq('POST', "https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", [
+        'strategy' => 'totp',
+        'code' => $code,
+    ], $headers, $cb['cookie'])->assertOk();
+    expect(Session::query()->withoutGlobalScopes()->where('user_id', $bundle['user']->id)->where('status', 'active')->exists())->toBeTrue();
+});
+
+it('operator flips totp.enabled to false post-enrolment but the user must still complete TOTP (strict)', function (): void {
+    // The narrow operator-disabled-after-enrolment path: user enrolled
+    // while totp.enabled=true; operator later disables; the user's
+    // next sign-in still requires the second factor and completes
+    // successfully when they answer.
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    $secret = seedTotpForFlow($f['env'], $bundle['user']);
+
+    // Operator flips the toggle off after enrolment.
+    $f['env']->forceFill([
+        'user_settings' => [
+            'multi_factor' => [
+                'totp' => ['enabled' => false],
+                'backup_codes' => ['enabled' => true, 'default_count' => 10],
+            ],
+        ],
+    ])->save();
+
+    $cb = SignInTestSupport::clientWithCookie($f['env']);
+    $headers = ['Host' => 'acme.authn.local', 'Origin' => $f['origin']];
+    $first = flowReq('POST', 'https://acme.authn.local/v1/client/sign-ins', [
+        'identifier' => 'alice@example.com',
+        'strategy' => 'password',
+        'password' => 'super-secret-password',
+    ], $headers, $cb['cookie']);
+
+    $first->assertOk()
+        ->assertJsonPath('response.status', 'needs_second_factor')
+        ->assertJsonPath('response.supported_strategies', ['totp']);
+
+    $sid = $first->json('response.id');
+    $code = (new Google2FA)->getCurrentOtp($secret->secret);
+    flowReq('POST', "https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", [
+        'strategy' => 'totp',
+        'code' => $code,
+    ], $headers, $cb['cookie'])->assertOk();
+
+    expect(Session::query()->withoutGlobalScopes()->where('user_id', $bundle['user']->id)->where('status', 'active')->exists())->toBeTrue();
 });
 
 it('mfa_already_verified on re-enrol after a successful verify', function (): void {

--- a/tests/Feature/Http/SignIn/SecondFactorTest.php
+++ b/tests/Feature/Http/SignIn/SecondFactorTest.php
@@ -160,7 +160,10 @@ it('rejects a replayed backup code with form_code_already_used on the second use
     $replay->assertStatus(422)->assertJsonPath('errors.0.code', 'form_code_already_used');
 });
 
-it('omits second_factors when the env disables both totp and backup_codes mid-flight', function (): void {
+it('still requires second factor when the env disables both totp and backup_codes (strict)', function (): void {
+    // Strict semantic per #109: env-level multi_factor toggles gate
+    // new enrolments only; an enrolled user is never silently
+    // downgraded by an operator policy change.
     $f = SignInTestSupport::bootEnv();
     $bundle = SignInTestSupport::makeUser($f['env']);
     TotpSecret::create([
@@ -182,10 +185,12 @@ it('omits second_factors when the env disables both totp and backup_codes mid-fl
 
     $r = signInPost($f, ['identifier' => 'alice@example.com', 'strategy' => 'password', 'password' => 'super-secret-password']);
 
-    $r->assertOk()->assertJsonPath('response.status', 'complete');
+    $r->assertOk()
+        ->assertJsonPath('response.status', 'needs_second_factor')
+        ->assertJsonPath('response.supported_strategies', ['totp']);
 });
 
-it('narrows supported_strategies to [backup_code] when totp.enabled is false but the user has backup codes', function (): void {
+it('exposes [totp, backup_code] when both are enrolled regardless of env toggle (strict)', function (): void {
     $f = SignInTestSupport::bootEnv();
     $bundle = SignInTestSupport::makeUser($f['env']);
     TotpSecret::create([
@@ -214,5 +219,5 @@ it('narrows supported_strategies to [backup_code] when totp.enabled is false but
 
     $r->assertOk()
         ->assertJsonPath('response.status', 'needs_second_factor')
-        ->assertJsonPath('response.supported_strategies', ['backup_code']);
+        ->assertJsonPath('response.supported_strategies', ['totp', 'backup_code']);
 });


### PR DESCRIPTION
Closes #109.

## Summary

Flips the v0.3 second-factor sign-in narrowing from **loose → strict** semantic. The env-level \`multi_factor.{totp,backup_codes}.enabled\` toggle now governs *new enrolments only*; an already-enrolled user is never silently downgraded by an operator policy change.

### Why

AU-5 shipped with the loose reading: env toggle empties \`supported_strategies\` for enrolled users → falls through to \`complete\`. That means an operator flipping the toggle would silently bypass MFA for users who'd already set it up. \`#109\` opted for strict — preserve the enrolled user's security expectation; if an operator wants to actually downgrade specific users, they go through BAPI \`DELETE /v1/users/{id}/mfa\`.

### What changed

- **\`ChallengeController::signInSecondFactorStrategies\`** — drops \`MultiFactorSettings\` consultation. Emits \`totp\` / \`backup_code\` purely from \`User.totp_enabled\` + verified TotpSecret / \`User.backup_code_enabled\` + unspent BackupCode.
- **\`ChallengeController::runSignInAnswer\`** — drops the \`envOffersSecondFactor()\` gate on the first-factor → second-factor pivot. Helper deleted.
- **\`SignInController::shouldPivotToSecondFactor\`** (one-shot password path) — same simplification.
- **\`SignInResource::secondFactorStrategies\`** — public mirror matches the same strict logic.
- Drops the now-unused \`MultiFactorSettings\` + \`Environment\` imports across \`ChallengeController\`, \`SignInController\`, \`SignInResource\`.

### What did **not** change

- \`MeTotpController::start\` and \`MeBackupCodesController::regenerate\` still consult \`MultiFactorSettings::strategyEnabled\` to gate new enrolments — that's the right place for the env toggle.
- \`Bapi\\UsersController::deleteMfa\` is unchanged — operators still nuke MFA per-user from there.
- \`Environment.auth_config.second_factors\` (public bootstrap) is unchanged — that surface advertises which strategies operators have enabled at the env level for *new* enrolments.

## Tests

- **AU-12 scenario 6** (\`tests/Feature/Fapi/MfaSecondFactorFlowTest\`) — flipped from "env disable falls through to complete" to "env disable still requires the enrolled second factor; user completes by answering". The comment referencing #109 is dropped — the test body IS the resolution.
- **AU-12 new scenario** — operator flips \`totp.enabled = false\` after a user has enrolled; user is required to provide TOTP and signs in successfully when they do.
- **AU-5 \`SecondFactorTest::it omits second_factors when env disables both\`** — flipped to "still requires second factor (strict)".
- **AU-5 \`SecondFactorTest::it narrows supported_strategies to [backup_code]\`** — flipped to "[totp, backup_code] regardless of env toggle" (the test setup enrolled in both; under strict the env toggle doesn't strip the totp).

## Test plan

- [x] Sequential sweep across \`tests/Feature/Mfa\`, \`tests/Feature/Http/SignIn\`, \`tests/Feature/Fapi\`, \`tests/Feature/Http/Bapi/InstanceTest\`, \`tests/Feature/Http/Fapi\`, \`tests/Feature/AuditLog\` — **126 passed, 424 assertions**, no regressions.
- [x] \`vendor/bin/pint --test\` — clean across 377 files.
- [ ] \`php artisan test --parallel\` — local stale worker DBs report 12 failures unrelated to this change (the test_N sqlites haven't been re-migrated since the AU-1 schema edits). CI runs fresh so it should be green.