### PR TITLE
AU-1: OauthProvider + ExternalAccount models + Verification.strategies

### DIFF
--- a/app/Models/ExternalAccount.php
+++ b/app/Models/ExternalAccount.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * One row per (User, OauthProvider, provider_user_id). Holds the encrypted
+ * access / refresh / id_token bundle returned by the IdP plus the cached
+ * userinfo subset (`email_address`, `verified`, `scopes`, `public_metadata`)
+ * the rest of the codebase needs without re-hitting the IdP.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $user_id
+ * @property string $oauth_provider_id
+ * @property string $provider_user_id
+ * @property ?string $email_address
+ * @property bool $verified
+ * @property array<int, string> $scopes
+ * @property array<string, mixed> $public_metadata
+ * @property string $encrypted_access_token
+ * @property ?string $encrypted_refresh_token
+ * @property ?string $encrypted_id_token
+ * @property ?\DateTimeInterface $access_token_expires_at
+ * @property \DateTimeInterface $linked_at
+ * @property ?\DateTimeInterface $last_signed_in_at
+ */
+class ExternalAccount extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    protected string $idPrefix = 'ext_';
+
+    protected $fillable = [
+        'environment_id',
+        'user_id',
+        'oauth_provider_id',
+        'provider_user_id',
+        'email_address',
+        'verified',
+        'scopes',
+        'public_metadata',
+        'encrypted_access_token',
+        'encrypted_refresh_token',
+        'encrypted_id_token',
+        'access_token_expires_at',
+        'linked_at',
+        'last_signed_in_at',
+    ];
+
+    protected $hidden = [
+        'encrypted_access_token',
+        'encrypted_refresh_token',
+        'encrypted_id_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'verified' => 'boolean',
+            'scopes' => 'array',
+            'public_metadata' => 'array',
+            'encrypted_access_token' => 'encrypted',
+            'encrypted_refresh_token' => 'encrypted',
+            'encrypted_id_token' => 'encrypted',
+            'access_token_expires_at' => 'immutable_datetime',
+            'linked_at' => 'immutable_datetime',
+            'last_signed_in_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function oauthProvider(): BelongsTo
+    {
+        return $this->belongsTo(OauthProvider::class);
+    }
+}

--- a/app/Models/OauthProvider.php
+++ b/app/Models/OauthProvider.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use App\Support\Url;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Per-environment OAuth/OIDC connection. One row drives one
+ * `oauth_<provider_key>` strategy, identifiable in the `Verification.strategy`
+ * enum via the regex carve-out on `Verification::isValidStrategy()`.
+ *
+ * `provider_kind` is one of:
+ *   - `preset`        — first-party preset (google, github, apple, microsoft);
+ *                       endpoints + default scopes baked into AU-4's registry.
+ *   - `custom_oidc`   — issuer URL + auto-fetched discovery; cached 5 minutes.
+ *   - `custom_oauth2` — admin-supplied authorization / token / userinfo.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $provider_kind
+ * @property string $provider_key
+ * @property string $name
+ * @property bool $enabled
+ * @property bool $allow_sign_in
+ * @property bool $allow_sign_up
+ * @property bool $block_email_subaddresses
+ * @property string $client_id
+ * @property string $encrypted_client_secret
+ * @property array<int, string> $scopes
+ * @property array<string, mixed> $additional_authorization_params
+ * @property array<string, mixed> $attribute_mapping
+ * @property ?string $issuer
+ * @property ?string $discovery_endpoint
+ * @property ?\DateTimeInterface $discovery_cached_at
+ * @property ?string $authorization_endpoint
+ * @property ?string $token_endpoint
+ * @property ?string $userinfo_endpoint
+ * @property ?string $jwks_uri
+ * @property ?array<int, string> $id_token_signing_algs
+ * @property ?string $userinfo_method
+ * @property ?string $userinfo_auth
+ * @property-read string $redirect_uri
+ */
+class OauthProvider extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+    use SoftDeletes;
+
+    public const KIND_PRESET = 'preset';
+
+    public const KIND_CUSTOM_OIDC = 'custom_oidc';
+
+    public const KIND_CUSTOM_OAUTH2 = 'custom_oauth2';
+
+    public const KINDS = [
+        self::KIND_PRESET,
+        self::KIND_CUSTOM_OIDC,
+        self::KIND_CUSTOM_OAUTH2,
+    ];
+
+    public const USERINFO_METHOD_GET = 'GET';
+
+    public const USERINFO_METHOD_POST = 'POST';
+
+    public const USERINFO_AUTH_BEARER = 'bearer';
+
+    public const USERINFO_AUTH_BASIC = 'basic';
+
+    public const USERINFO_AUTH_QUERY = 'query';
+
+    protected string $idPrefix = 'oauthp_';
+
+    protected $fillable = [
+        'environment_id',
+        'provider_kind',
+        'provider_key',
+        'name',
+        'enabled',
+        'allow_sign_in',
+        'allow_sign_up',
+        'block_email_subaddresses',
+        'client_id',
+        'encrypted_client_secret',
+        'scopes',
+        'additional_authorization_params',
+        'attribute_mapping',
+        'issuer',
+        'discovery_endpoint',
+        'discovery_cached_at',
+        'authorization_endpoint',
+        'token_endpoint',
+        'userinfo_endpoint',
+        'jwks_uri',
+        'id_token_signing_algs',
+        'userinfo_method',
+        'userinfo_auth',
+    ];
+
+    protected $hidden = [
+        'encrypted_client_secret',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+            'allow_sign_in' => 'boolean',
+            'allow_sign_up' => 'boolean',
+            'block_email_subaddresses' => 'boolean',
+            'encrypted_client_secret' => 'encrypted',
+            'scopes' => 'array',
+            'additional_authorization_params' => 'array',
+            'attribute_mapping' => 'array',
+            'id_token_signing_algs' => 'array',
+            'discovery_cached_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function externalAccounts(): HasMany
+    {
+        return $this->hasMany(ExternalAccount::class);
+    }
+
+    /**
+     * The canonical callback URL the IdP redirects back to. Format is
+     * stable (env's FAPI host + `/v1/oauth-callback/<provider_key>`) so the
+     * dashboard can copy-paste it into the provider's allow-list at create
+     * time. AU-6 mounts the matching route.
+     */
+    protected function redirectUri(): Attribute
+    {
+        return Attribute::get(function (): string {
+            return Url::fapi($this->environment, '/v1/oauth-callback/'.$this->provider_key);
+        });
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -138,6 +138,11 @@ class User extends Model implements AuthenticatableContract
         return $this->hasMany(EmailAddress::class);
     }
 
+    public function externalAccounts(): HasMany
+    {
+        return $this->hasMany(ExternalAccount::class);
+    }
+
     public function primaryEmailAddress(): BelongsTo
     {
         return $this->belongsTo(EmailAddress::class, 'primary_email_address_id');

--- a/app/Models/Verification.php
+++ b/app/Models/Verification.php
@@ -81,6 +81,8 @@ class Verification extends Model
 
     public const STRATEGY_BACKUP_CODE = 'backup_code';
 
+    public const STRATEGY_PHONE_CODE = 'phone_code';
+
     public const STRATEGIES = [
         self::STRATEGY_PASSWORD,
         self::STRATEGY_EMAIL_CODE,
@@ -90,7 +92,15 @@ class Verification extends Model
         self::STRATEGY_DOMAIN_DNS_TXT,
         self::STRATEGY_TOTP,
         self::STRATEGY_BACKUP_CODE,
+        self::STRATEGY_PHONE_CODE,
     ];
+
+    /**
+     * Regex for the v0.4 `oauth_<provider_key>` strategy family. One match
+     * per registered `OauthProvider` row; per-env enabled-providers narrowing
+     * lives on `StrategyResolver`.
+     */
+    public const OAUTH_STRATEGY_PATTERN = '/^oauth_[a-z][a-z0-9_]*$/';
 
     protected string $idPrefix = 'ver_';
 
@@ -150,5 +160,28 @@ class Verification extends Model
     public function isExpired(): bool
     {
         return $this->expire_at->isPast();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function strategies(): array
+    {
+        return self::STRATEGIES;
+    }
+
+    /**
+     * Whether `$strategy` is one this codebase recognises. Accepts the
+     * fixed enum plus any `oauth_<provider_key>` matching the registered
+     * pattern. Per-environment "is this provider actually enabled?" narrowing
+     * lives on StrategyResolver — this is the syntactic gate.
+     */
+    public static function isValidStrategy(string $strategy): bool
+    {
+        if (in_array($strategy, self::STRATEGIES, true)) {
+            return true;
+        }
+
+        return preg_match(self::OAUTH_STRATEGY_PATTERN, $strategy) === 1;
     }
 }

--- a/app/Services/Verification/VerificationManager.php
+++ b/app/Services/Verification/VerificationManager.php
@@ -37,7 +37,7 @@ final class VerificationManager
      */
     public function start(Model $owner, string $strategy, int $ttlSeconds, ?string $purpose = null): Verification
     {
-        if (! in_array($strategy, Verification::STRATEGIES, true)) {
+        if (! Verification::isValidStrategy($strategy)) {
             throw new InvalidArgumentException("Strategy {$strategy} is not supported.");
         }
 

--- a/database/migrations/2026_05_10_000000_create_oauth_providers_and_external_accounts.php
+++ b/database/migrations/2026_05_10_000000_create_oauth_providers_and_external_accounts.php
@@ -1,0 +1,86 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * v0.4 social sign-in spine. Per-environment OauthProvider rows feed the
+ * `oauth_<provider_key>` strategy family; ExternalAccount rows link a User
+ * to a successful sign-in via one of those providers.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('oauth_providers', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('provider_kind', 24);
+            $table->string('provider_key', 64);
+            $table->string('name');
+            $table->boolean('enabled')->default(true);
+            $table->boolean('allow_sign_in')->default(true);
+            $table->boolean('allow_sign_up')->default(true);
+            $table->boolean('block_email_subaddresses')->default(false);
+
+            $table->string('client_id');
+            $table->text('encrypted_client_secret');
+
+            $table->jsonb('scopes')->default(json_encode([]));
+            $table->jsonb('additional_authorization_params')->default(json_encode((object) []));
+            $table->jsonb('attribute_mapping')->default(json_encode((object) []));
+
+            $table->string('issuer')->nullable();
+            $table->string('discovery_endpoint')->nullable();
+            $table->timestamp('discovery_cached_at')->nullable();
+            $table->string('authorization_endpoint')->nullable();
+            $table->string('token_endpoint')->nullable();
+            $table->string('userinfo_endpoint')->nullable();
+            $table->string('jwks_uri')->nullable();
+            $table->jsonb('id_token_signing_algs')->nullable();
+            $table->string('userinfo_method', 8)->nullable();
+            $table->string('userinfo_auth', 16)->nullable();
+
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->unique(['environment_id', 'provider_key']);
+        });
+
+        Schema::create('external_accounts', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('user_id', 64);
+            $table->string('oauth_provider_id', 64);
+
+            $table->string('provider_user_id');
+            $table->string('email_address')->nullable();
+            $table->boolean('verified')->default(false);
+            $table->jsonb('scopes')->default(json_encode([]));
+            $table->jsonb('public_metadata')->default(json_encode((object) []));
+
+            $table->text('encrypted_access_token');
+            $table->text('encrypted_refresh_token')->nullable();
+            $table->text('encrypted_id_token')->nullable();
+            $table->timestamp('access_token_expires_at')->nullable();
+
+            $table->timestamp('linked_at');
+            $table->timestamp('last_signed_in_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->foreign('oauth_provider_id')->references('id')->on('oauth_providers')->cascadeOnDelete();
+            $table->unique(['environment_id', 'oauth_provider_id', 'provider_user_id']);
+            $table->index(['user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('external_accounts');
+        Schema::dropIfExists('oauth_providers');
+    }
+};

--- a/tests/Feature/Models/OauthProviderTest.php
+++ b/tests/Feature/Models/OauthProviderTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Verification;
+use Illuminate\Database\QueryException;
+
+function makeEnvForOauth(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('mints a oauthp_ prefixed id and casts JSON columns to arrays', function (): void {
+    $env = makeEnvForOauth();
+
+    $provider = OauthProvider::create([
+        'environment_id' => $env->id,
+        'provider_kind' => OauthProvider::KIND_PRESET,
+        'provider_key' => 'google',
+        'name' => 'Google',
+        'client_id' => 'gid',
+        'encrypted_client_secret' => 'gsecret',
+        'scopes' => ['openid', 'email'],
+        'attribute_mapping' => ['email' => 'email_address'],
+    ]);
+
+    expect($provider->id)->toStartWith('oauthp_');
+    expect($provider->scopes)->toBe(['openid', 'email']);
+    expect($provider->attribute_mapping)->toBe(['email' => 'email_address']);
+
+    $reloaded = $provider->fresh();
+    expect($reloaded->enabled)->toBeTrue();
+    expect($reloaded->allow_sign_in)->toBeTrue();
+    expect($reloaded->allow_sign_up)->toBeTrue();
+    expect($reloaded->block_email_subaddresses)->toBeFalse();
+});
+
+it('encrypts the client secret at rest and hides it from array serialization', function (): void {
+    $env = makeEnvForOauth();
+
+    $provider = OauthProvider::create([
+        'environment_id' => $env->id,
+        'provider_kind' => OauthProvider::KIND_PRESET,
+        'provider_key' => 'github',
+        'name' => 'GitHub',
+        'client_id' => 'cid',
+        'encrypted_client_secret' => 'super-secret-value',
+    ]);
+
+    expect($provider->encrypted_client_secret)->toBe('super-secret-value');
+
+    $raw = (string) DB::table('oauth_providers')->where('id', $provider->id)->value('encrypted_client_secret');
+    expect($raw)->not->toBe('super-secret-value');
+    expect(strlen($raw))->toBeGreaterThan(20);
+
+    expect(array_key_exists('encrypted_client_secret', $provider->toArray()))->toBeFalse();
+});
+
+it('enforces unique (environment_id, provider_key)', function (): void {
+    $env = makeEnvForOauth();
+
+    OauthProvider::create([
+        'environment_id' => $env->id,
+        'provider_kind' => OauthProvider::KIND_PRESET,
+        'provider_key' => 'google',
+        'name' => 'Google',
+        'client_id' => 'a',
+        'encrypted_client_secret' => 'b',
+    ]);
+
+    expect(fn () => OauthProvider::create([
+        'environment_id' => $env->id,
+        'provider_kind' => OauthProvider::KIND_PRESET,
+        'provider_key' => 'google',
+        'name' => 'Google',
+        'client_id' => 'c',
+        'encrypted_client_secret' => 'd',
+    ]))->toThrow(QueryException::class);
+});
+
+it('computes the redirect_uri off the env FAPI host and provider_key', function (): void {
+    config()->set('authn.app_host', 'authn.sh');
+    config()->set('authn.app_scheme', 'https');
+    config()->set('authn.routing_mode', 'subdomain');
+    config()->set('authn.app_port_suffix', '');
+
+    $env = makeEnvForOauth('acme');
+    $provider = OauthProvider::create([
+        'environment_id' => $env->id,
+        'provider_kind' => OauthProvider::KIND_PRESET,
+        'provider_key' => 'google',
+        'name' => 'Google',
+        'client_id' => 'gid',
+        'encrypted_client_secret' => 'gsecret',
+    ]);
+
+    expect($provider->redirect_uri)->toBe('https://acme.authn.sh/v1/oauth-callback/google');
+});
+
+it('relates ExternalAccount → OauthProvider + User', function (): void {
+    $env = makeEnvForOauth();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $provider = OauthProvider::create([
+        'environment_id' => $env->id,
+        'provider_kind' => OauthProvider::KIND_PRESET,
+        'provider_key' => 'google',
+        'name' => 'Google',
+        'client_id' => 'gid',
+        'encrypted_client_secret' => 'gsecret',
+    ]);
+
+    $account = ExternalAccount::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'oauth_provider_id' => $provider->id,
+        'provider_user_id' => '1234567890',
+        'email_address' => 'alice@example.com',
+        'verified' => true,
+        'scopes' => ['openid', 'email'],
+        'encrypted_access_token' => 'at-token',
+        'encrypted_refresh_token' => 'rt-token',
+        'linked_at' => now(),
+    ]);
+
+    expect($account->id)->toStartWith('ext_');
+    expect($account->oauthProvider->id)->toBe($provider->id);
+    expect($account->user->id)->toBe($user->id);
+    expect($user->refresh()->externalAccounts->pluck('id')->all())->toBe([$account->id]);
+});
+
+it('hides encrypted token columns and stores ciphertext on disk', function (): void {
+    $env = makeEnvForOauth();
+    $user = User::create(['environment_id' => $env->id]);
+    $provider = OauthProvider::create([
+        'environment_id' => $env->id,
+        'provider_kind' => OauthProvider::KIND_PRESET,
+        'provider_key' => 'google',
+        'name' => 'Google',
+        'client_id' => 'gid',
+        'encrypted_client_secret' => 'gsecret',
+    ]);
+
+    $account = ExternalAccount::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'oauth_provider_id' => $provider->id,
+        'provider_user_id' => 'abc',
+        'encrypted_access_token' => 'cleartext-access',
+        'encrypted_refresh_token' => 'cleartext-refresh',
+        'encrypted_id_token' => 'cleartext-id',
+        'linked_at' => now(),
+    ]);
+
+    expect($account->encrypted_access_token)->toBe('cleartext-access');
+
+    $arr = $account->toArray();
+    expect(array_key_exists('encrypted_access_token', $arr))->toBeFalse();
+    expect(array_key_exists('encrypted_refresh_token', $arr))->toBeFalse();
+    expect(array_key_exists('encrypted_id_token', $arr))->toBeFalse();
+
+    $rawAccess = (string) DB::table('external_accounts')->where('id', $account->id)->value('encrypted_access_token');
+    expect($rawAccess)->not->toBe('cleartext-access');
+});
+
+it('enforces unique (environment_id, oauth_provider_id, provider_user_id)', function (): void {
+    $env = makeEnvForOauth();
+    $user = User::create(['environment_id' => $env->id]);
+    $provider = OauthProvider::create([
+        'environment_id' => $env->id,
+        'provider_kind' => OauthProvider::KIND_PRESET,
+        'provider_key' => 'google',
+        'name' => 'Google',
+        'client_id' => 'gid',
+        'encrypted_client_secret' => 'gsecret',
+    ]);
+
+    ExternalAccount::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'oauth_provider_id' => $provider->id,
+        'provider_user_id' => 'pid',
+        'encrypted_access_token' => 't',
+        'linked_at' => now(),
+    ]);
+
+    expect(fn () => ExternalAccount::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'oauth_provider_id' => $provider->id,
+        'provider_user_id' => 'pid',
+        'encrypted_access_token' => 't2',
+        'linked_at' => now(),
+    ]))->toThrow(QueryException::class);
+});
+
+it('extends Verification::strategies() with phone_code and accepts oauth_<key> patterns', function (): void {
+    expect(Verification::strategies())->toContain(Verification::STRATEGY_PHONE_CODE);
+
+    expect(Verification::isValidStrategy('phone_code'))->toBeTrue();
+    expect(Verification::isValidStrategy('oauth_google'))->toBeTrue();
+    expect(Verification::isValidStrategy('oauth_acme_corp'))->toBeTrue();
+    expect(Verification::isValidStrategy('oauth_'))->toBeFalse();
+    expect(Verification::isValidStrategy('OAUTH_google'))->toBeFalse();
+    expect(Verification::isValidStrategy('not_a_strategy'))->toBeFalse();
+});

--- a/tests/Feature/Services/Verification/VerificationManagerTest.php
+++ b/tests/Feature/Services/Verification/VerificationManagerTest.php
@@ -46,7 +46,7 @@ it('refuses unsupported strategies', function (): void {
     $f = vmFixture();
     $manager = app(VerificationManager::class);
 
-    expect(fn () => $manager->start($f['email'], 'oauth_google', 600))
+    expect(fn () => $manager->start($f['email'], 'not_a_real_strategy', 600))
         ->toThrow(InvalidArgumentException::class, 'is not supported');
 });
 


### PR DESCRIPTION
Closes #120.

## Summary

- Adds the `oauth_providers` and `external_accounts` tables that drive v0.4 social sign-in.
- `OauthProvider` carries the encrypted `client_secret`, JSON `scopes` / `attribute_mapping` / `additional_authorization_params`, both OIDC (`issuer`, `discovery_endpoint`, `jwks_uri`, `id_token_signing_algs`, …) and OAuth2-only (`userinfo_method`, `userinfo_auth`) columns, soft-delete, and a `redirect_uri` accessor that computes `https://<env_fapi_host>/v1/oauth-callback/<provider_key>` via the existing `Url::fapi()` helper.
- `ExternalAccount` carries the encrypted `access_token` / `refresh_token` / `id_token` (all hidden from serialization), the cached userinfo subset, and a unique `(environment_id, oauth_provider_id, provider_user_id)` index.
- `Verification::STRATEGIES` gains `phone_code`. New `Verification::isValidStrategy()` extends syntactic validation to also accept the `^oauth_[a-z][a-z0-9_]*$` family; `VerificationManager::start()` delegates to it. Per-env enabled-providers narrowing stays a `StrategyResolver` concern (AU-4 / AU-9).
- `User::externalAccounts()` HasMany relation.

## Test plan

- [x] `vendor/bin/pest` — 550 / 550 passing
- [x] `vendor/bin/pest --filter Oauth` — 8 / 8 passing
- [x] `vendor/bin/pint --test` — clean
- [x] `php artisan migrate:fresh` runs cleanly on the SQLite test DB