### PR TITLE
AU-2: PhoneNumber model + User phone columns + UserResource shape

### DIFF
--- a/app/Http/Resources/PhoneNumberResource.php
+++ b/app/Http/Resources/PhoneNumberResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\PhoneNumber;
+
+final class PhoneNumberResource
+{
+    public static function from(PhoneNumber $phone): array
+    {
+        return [
+            'object' => 'phone_number',
+            'id' => $phone->id,
+            'phone_number' => $phone->phone_number,
+            'verified' => $phone->verified_at !== null,
+            'current_challenge_id' => $phone->current_challenge_id,
+            'is_primary' => (bool) $phone->is_primary,
+            'reserved_for_second_factor' => (bool) $phone->reserved_for_second_factor,
+            'default_second_factor' => (bool) $phone->default_second_factor,
+            'linked_to' => $phone->linked_to_external_account_id !== null
+                ? [['id' => $phone->linked_to_external_account_id, 'type' => 'external_account']]
+                : [],
+            'created_at' => $phone->created_at?->getTimestampMs(),
+            'updated_at' => $phone->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -18,6 +18,7 @@ final class UserResource
     public static function from(User $user, bool $includePrivate = false): array
     {
         $emails = $user->emailAddresses()->withoutGlobalScopes()->get();
+        $phones = $user->phoneNumbers()->withoutGlobalScopes()->get();
 
         $shape = [
             'object' => 'user',
@@ -30,8 +31,9 @@ final class UserResource
             'has_image' => (bool) $user->has_image,
             'primary_email_address_id' => $user->primary_email_address_id,
             'email_addresses' => $emails->map(fn ($email) => EmailAddressResource::from($email))->all(),
-            // v0.1: stable arrays so SDK types are forward-compatible.
-            'phone_numbers' => [],
+            'primary_phone_number_id' => $user->primary_phone_number_id,
+            'phone_numbers' => $phones->map(fn ($phone) => PhoneNumberResource::from($phone))->all(),
+            // v0.5+: stable arrays so SDK types are forward-compatible.
             'external_accounts' => [],
             'enterprise_accounts' => [],
             'passkeys' => [],

--- a/app/Models/PhoneNumber.php
+++ b/app/Models/PhoneNumber.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use App\Observers\PhoneNumberObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+/**
+ * One row per phone a user has registered. Verification proof lives on the
+ * polymorphic `Verification` model via the morphMany relation; the
+ * `verified_at` timestamp is the cached "this phone is good" flag the rest
+ * of the codebase reads.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $user_id
+ * @property string $phone_number
+ * @property ?\DateTimeInterface $verified_at
+ * @property bool $is_primary
+ * @property bool $reserved_for_second_factor
+ * @property bool $default_second_factor
+ * @property ?string $linked_to_external_account_id
+ * @property ?string $current_challenge_id
+ */
+#[ObservedBy([PhoneNumberObserver::class])]
+class PhoneNumber extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    protected string $idPrefix = 'phn_';
+
+    protected $table = 'phone_numbers';
+
+    protected $fillable = [
+        'environment_id',
+        'user_id',
+        'phone_number',
+        'verified_at',
+        'is_primary',
+        'reserved_for_second_factor',
+        'default_second_factor',
+        'linked_to_external_account_id',
+        'current_challenge_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'verified_at' => 'immutable_datetime',
+            'is_primary' => 'boolean',
+            'reserved_for_second_factor' => 'boolean',
+            'default_second_factor' => 'boolean',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function verifications(): MorphMany
+    {
+        return $this->morphMany(Verification::class, 'verifiable');
+    }
+
+    public function isVerified(): bool
+    {
+        return $this->verified_at !== null;
+    }
+
+    /**
+     * Flip `verified_at` to `now()` and refresh the user's
+     * `phone_number_enabled` flag in lock-step. Idempotent — calling on an
+     * already-verified row is a no-op.
+     */
+    public function markVerified(): void
+    {
+        if ($this->verified_at !== null) {
+            return;
+        }
+
+        $this->forceFill(['verified_at' => now()])->save();
+
+        User::query()
+            ->withoutGlobalScopes()
+            ->whereKey($this->user_id)
+            ->update(['phone_number_enabled' => true]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -35,6 +35,8 @@ use Illuminate\Support\Facades\Hash;
  * @property ?string $image_url
  * @property bool $has_image
  * @property ?string $primary_email_address_id
+ * @property ?string $primary_phone_number_id
+ * @property bool $phone_number_enabled
  * @property ?string $password_hash
  * @property ?\DateTimeInterface $password_changed_at
  * @property bool $two_factor_enabled
@@ -73,6 +75,8 @@ class User extends Model implements AuthenticatableContract
         'image_url',
         'has_image',
         'primary_email_address_id',
+        'primary_phone_number_id',
+        'phone_number_enabled',
         'password',
         'password_hash',
         'password_changed_at',
@@ -104,6 +108,7 @@ class User extends Model implements AuthenticatableContract
     {
         return [
             'has_image' => 'boolean',
+            'phone_number_enabled' => 'boolean',
             'password_imported' => 'boolean',
             'two_factor_enabled' => 'boolean',
             'totp_enabled' => 'boolean',
@@ -146,6 +151,16 @@ class User extends Model implements AuthenticatableContract
     public function primaryEmailAddress(): BelongsTo
     {
         return $this->belongsTo(EmailAddress::class, 'primary_email_address_id');
+    }
+
+    public function phoneNumbers(): HasMany
+    {
+        return $this->hasMany(PhoneNumber::class);
+    }
+
+    public function primaryPhoneNumber(): BelongsTo
+    {
+        return $this->belongsTo(PhoneNumber::class, 'primary_phone_number_id');
     }
 
     public function organizationMemberships(): BelongsToMany

--- a/app/Observers/PhoneNumberObserver.php
+++ b/app/Observers/PhoneNumberObserver.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\PhoneNumber;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Mirror of `EmailAddressObserver`. Whenever a PhoneNumber row is saved
+ * with `is_primary = true`, every other row on the same user is demoted
+ * and the user's `primary_phone_number_id` column is updated.
+ *
+ * `default_second_factor` is mutually exclusive across a user's verified
+ * phones too — promote one, demote the rest. Demote is a no-op on
+ * `primary_phone_number_id` (operator must promote a different row).
+ */
+final class PhoneNumberObserver
+{
+    public function saved(PhoneNumber $phone): void
+    {
+        if ($phone->is_primary) {
+            DB::transaction(function () use ($phone): void {
+                PhoneNumber::query()
+                    ->withoutGlobalScopes()
+                    ->where('user_id', $phone->user_id)
+                    ->whereKeyNot($phone->getKey())
+                    ->where('is_primary', true)
+                    ->update(['is_primary' => false]);
+
+                User::query()
+                    ->withoutGlobalScopes()
+                    ->whereKey($phone->user_id)
+                    ->update(['primary_phone_number_id' => $phone->getKey()]);
+            });
+        }
+
+        if ($phone->default_second_factor) {
+            PhoneNumber::query()
+                ->withoutGlobalScopes()
+                ->where('user_id', $phone->user_id)
+                ->whereKeyNot($phone->getKey())
+                ->where('default_second_factor', true)
+                ->update(['default_second_factor' => false]);
+        }
+    }
+}

--- a/database/migrations/2026_05_10_000001_create_phone_numbers.php
+++ b/database/migrations/2026_05_10_000001_create_phone_numbers.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * v0.4 phone-number spine. Mirror of the v0.1 EmailAddress shape — one row
+ * per phone, flat `verified_at` cache, `current_challenge_id` scoped via the
+ * AU-9 phone_code Challenge dance.
+ *
+ * `email_addresses.linked_to_external_account_id` already lands in the v0.1
+ * `0004_…_create_email_verifications` migration, so this one only adds
+ * the new `phone_numbers` table + the matching `users` columns.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('phone_numbers', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('user_id', 64);
+            $table->string('phone_number');
+            $table->timestamp('verified_at')->nullable();
+            $table->boolean('is_primary')->default(false);
+            $table->boolean('reserved_for_second_factor')->default(false);
+            $table->boolean('default_second_factor')->default(false);
+            $table->string('linked_to_external_account_id', 64)->nullable();
+            $table->string('current_challenge_id', 64)->nullable();
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->unique(['environment_id', 'phone_number']);
+            $table->index(['user_id']);
+        });
+
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('primary_phone_number_id', 64)->nullable()->after('primary_email_address_id');
+            $table->boolean('phone_number_enabled')->default(false)->after('primary_phone_number_id');
+
+            $table->foreign('primary_phone_number_id')->references('id')->on('phone_numbers')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropForeign(['primary_phone_number_id']);
+            $table->dropColumn(['primary_phone_number_id', 'phone_number_enabled']);
+        });
+
+        Schema::dropIfExists('phone_numbers');
+    }
+};

--- a/tests/Feature/Models/PhoneNumberTest.php
+++ b/tests/Feature/Models/PhoneNumberTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Resources\UserResource;
+use App\Models\Environment;
+use App\Models\PhoneNumber;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+
+function makeEnvForPhones(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('mints a phn_ prefixed id and stores E.164 format', function (): void {
+    $env = makeEnvForPhones();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $phone = PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15555550100',
+    ]);
+
+    expect($phone->id)->toStartWith('phn_');
+    expect($phone->phone_number)->toBe('+15555550100');
+    expect($phone->isVerified())->toBeFalse();
+});
+
+it('enforces unique (environment_id, phone_number)', function (): void {
+    $env = makeEnvForPhones();
+    $user = User::create(['environment_id' => $env->id]);
+
+    PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15555550101',
+    ]);
+
+    expect(fn () => PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15555550101',
+    ]))->toThrow(QueryException::class);
+});
+
+it('promotes a primary phone and demotes the previous primary via the observer', function (): void {
+    $env = makeEnvForPhones();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $first = PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15555550110',
+        'is_primary' => true,
+    ]);
+
+    expect($user->refresh()->primary_phone_number_id)->toBe($first->id);
+
+    $second = PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15555550111',
+        'is_primary' => true,
+    ]);
+
+    expect($first->refresh()->is_primary)->toBeFalse();
+    expect($second->refresh()->is_primary)->toBeTrue();
+    expect($user->refresh()->primary_phone_number_id)->toBe($second->id);
+});
+
+it('keeps default_second_factor mutually exclusive across a user', function (): void {
+    $env = makeEnvForPhones();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $first = PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15555550120',
+        'default_second_factor' => true,
+    ]);
+
+    $second = PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15555550121',
+        'default_second_factor' => true,
+    ]);
+
+    expect($first->refresh()->default_second_factor)->toBeFalse();
+    expect($second->refresh()->default_second_factor)->toBeTrue();
+});
+
+it('markVerified() flips verified_at and toggles user.phone_number_enabled', function (): void {
+    $env = makeEnvForPhones();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $phone = PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15555550130',
+    ]);
+
+    expect($user->refresh()->phone_number_enabled)->toBeFalse();
+
+    $phone->markVerified();
+
+    expect($phone->refresh()->verified_at)->not->toBeNull();
+    expect($user->refresh()->phone_number_enabled)->toBeTrue();
+});
+
+it('exposes phoneNumbers + primaryPhoneNumber on User', function (): void {
+    $env = makeEnvForPhones();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $phone = PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15555550140',
+        'is_primary' => true,
+    ]);
+
+    expect($user->refresh()->phoneNumbers->pluck('id')->all())->toBe([$phone->id]);
+    expect($user->refresh()->primaryPhoneNumber->id)->toBe($phone->id);
+});
+
+it('serialises phone_numbers on UserResource with the flat shape', function (): void {
+    $env = makeEnvForPhones();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $phone = PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15555550150',
+        'is_primary' => true,
+        'reserved_for_second_factor' => true,
+    ]);
+    $phone->markVerified();
+
+    $payload = UserResource::from($user->refresh());
+
+    expect($payload['primary_phone_number_id'])->toBe($phone->id);
+    expect($user->refresh()->phone_number_enabled)->toBeTrue();
+    expect($payload['phone_numbers'])->toHaveCount(1);
+    $entry = $payload['phone_numbers'][0];
+    expect($entry['object'])->toBe('phone_number');
+    expect($entry['id'])->toBe($phone->id);
+    expect($entry['phone_number'])->toBe('+15555550150');
+    expect($entry['verified'])->toBeTrue();
+    expect($entry['is_primary'])->toBeTrue();
+    expect($entry['reserved_for_second_factor'])->toBeTrue();
+    expect($entry['default_second_factor'])->toBeFalse();
+    expect($entry)->toHaveKey('current_challenge_id');
+    expect($entry['linked_to'])->toBe([]);
+});


### PR DESCRIPTION
Closes #121.

## Summary

- New `phone_numbers` table mirrors `email_addresses` — ULID `phn_…`, unique on `(environment_id, phone_number)`, flat `verified_at` cache, `current_challenge_id` for the AU-9 phone_code Challenge dance, plus `is_primary` / `reserved_for_second_factor` / `default_second_factor` / `linked_to_external_account_id`.
- `users` gains `primary_phone_number_id` (FK, null-on-delete) + `phone_number_enabled` (flipped by `PhoneNumber::markVerified()` the first time any phone is verified).
- `PhoneNumberObserver` enforces single-primary + single default_second_factor per user (mirror of `EmailAddressObserver`).
- `PhoneNumberResource` exposes the flat `verified` + `current_challenge_id` shape; `UserResource` populates `phone_numbers[]` + `primary_phone_number_id` + `phone_number_enabled`.
- `User->phoneNumbers()` + `User->primaryPhoneNumber()` relations.

## Test plan

- [x] `vendor/bin/pest` — 549 / 549 passing
- [x] `vendor/bin/pest --filter PhoneNumber` — 7 / 7 passing
- [x] `vendor/bin/pint --test` — clean
- [x] `php artisan migrate:fresh` runs cleanly on the SQLite test DB