### PR TITLE
AU-3: SmsTemplate model + EnvironmentObserver SMS-defaults seed

### DIFF
--- a/app/Mail/Renderer.php
+++ b/app/Mail/Renderer.php
@@ -6,6 +6,7 @@ namespace App\Mail;
 
 use App\Models\EmailTemplate;
 use App\Models\Environment;
+use App\Models\SmsTemplate;
 use DateTimeInterface;
 
 /**
@@ -54,6 +55,20 @@ final class Renderer
         $text = $this->htmlToText($html);
 
         return new RenderedEmail($subject, $html, $text);
+    }
+
+    /**
+     * Render an SMS template against the same variable bag the email side
+     * uses. Result is a plain string (no subject, no HTML) ready to hand
+     * to the AU-12 send job.
+     *
+     * @param  array<string, mixed>  $vars
+     */
+    public function renderSms(SmsTemplate $template, Environment $environment, array $vars): string
+    {
+        $merged = $this->mergeRecursive($this->defaults($environment), $vars);
+
+        return $this->substitute((string) $template->body, $merged);
     }
 
     /**

--- a/app/Models/SmsTemplate.php
+++ b/app/Models/SmsTemplate.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Per-env SMS template (Liquid-style placeholders, single `body` column —
+ * no MJML / HTML cache, since SMS is plain-text). Sibling of
+ * `EmailTemplate`.
+ *
+ *   - `slug` is the canonical identifier looked up by the AU-12 send jobs.
+ *   - `body` is the Liquid source.
+ *   - `delivered_by_us = false` routes the rendered payload into a
+ *     webhook event (`sms.created`) instead of the configured driver, so
+ *     operators can ship through their own gateway.
+ *   - `from_number_override` lets a specific template ship from a
+ *     different sender than the env-wide default; null falls back to
+ *     `Environment.sms.from_number`.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $slug
+ * @property string $body
+ * @property bool $delivered_by_us
+ * @property ?string $from_number_override
+ * @property ?string $last_modified_by_user_id
+ */
+class SmsTemplate extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    public const SLUG_VERIFICATION_CODE = 'verification_code';
+
+    public const SLUG_RESET_PASSWORD_CODE = 'reset_password_code';
+
+    public const SLUG_INVITATION = 'invitation';
+
+    /**
+     * Active set seeded at env creation. Placeholders use `{{var}}` /
+     * `{{var.path}}`; the renderer HTML-escapes user-supplied substitutions
+     * the same way the email side does.
+     *
+     * @var array<string, array{body:string}>
+     */
+    public const DEFAULT_TEMPLATES = [
+        self::SLUG_VERIFICATION_CODE => [
+            'body' => '{{app.name}}: your verification code is {{otp_code}}. Expires in {{expiry_minutes}} minutes.',
+        ],
+        self::SLUG_RESET_PASSWORD_CODE => [
+            'body' => '{{app.name}}: your password reset code is {{otp_code}}. Expires in {{expiry_minutes}} minutes.',
+        ],
+        self::SLUG_INVITATION => [
+            'body' => "{{app.name}}: you've been invited to {{organization.name}}. Accept: {{action_url}}",
+        ],
+    ];
+
+    protected string $idPrefix = 'tmpl_';
+
+    protected $table = 'sms_templates';
+
+    protected $fillable = [
+        'environment_id',
+        'slug',
+        'body',
+        'delivered_by_us',
+        'from_number_override',
+        'last_modified_by_user_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'delivered_by_us' => 'boolean',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function lastModifiedByUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'last_modified_by_user_id');
+    }
+}

--- a/app/Observers/EnvironmentObserver.php
+++ b/app/Observers/EnvironmentObserver.php
@@ -6,11 +6,13 @@ namespace App\Observers;
 
 use App\Models\EmailTemplate;
 use App\Models\Environment;
+use App\Models\SmsTemplate;
 use App\Services\Tenancy\RoleSeeder;
 
 /**
  * Seeds the per-env defaults — system permissions + default roles, plus
- * the active EmailTemplate set — into every freshly-minted environment.
+ * the active EmailTemplate / SmsTemplate sets — into every freshly-minted
+ * environment.
  *
  * The bootstrap service calls RoleSeeder directly so it keeps a handle on
  * the seeded admin role for the workspace owner membership; everywhere
@@ -24,10 +26,11 @@ final class EnvironmentObserver
     public function created(Environment $environment): void
     {
         $this->seeder->seed($environment);
-        $this->seedDefaultTemplates($environment);
+        $this->seedDefaultEmailTemplates($environment);
+        $this->seedDefaultSmsTemplates($environment);
     }
 
-    private function seedDefaultTemplates(Environment $environment): void
+    private function seedDefaultEmailTemplates(Environment $environment): void
     {
         foreach (EmailTemplate::DEFAULT_TEMPLATES as $slug => $payload) {
             $exists = EmailTemplate::query()
@@ -44,6 +47,25 @@ final class EnvironmentObserver
                 'subject' => $payload['subject'],
                 'body_markup' => $payload['body_markup'],
                 'body_html' => $payload['body_html'],
+            ]);
+        }
+    }
+
+    private function seedDefaultSmsTemplates(Environment $environment): void
+    {
+        foreach (SmsTemplate::DEFAULT_TEMPLATES as $slug => $payload) {
+            $exists = SmsTemplate::query()
+                ->withoutGlobalScopes()
+                ->where('environment_id', $environment->id)
+                ->where('slug', $slug)
+                ->exists();
+            if ($exists) {
+                continue;
+            }
+            SmsTemplate::query()->withoutGlobalScopes()->create([
+                'environment_id' => $environment->id,
+                'slug' => $slug,
+                'body' => $payload['body'],
             ]);
         }
     }

--- a/database/migrations/2026_05_10_000002_create_sms_templates.php
+++ b/database/migrations/2026_05_10_000002_create_sms_templates.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Models\SmsTemplate;
+use App\Support\Id;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Per-env SMS templates. Mirror of the v0.1 email-template table —
+ * `slug` keyed, single `body` (Liquid placeholders, no MJML), and a
+ * `from_number_override` for envs that want to send a specific template
+ * from a different sender than the env-wide default.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sms_templates', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('slug', 64);
+            $table->text('body');
+            $table->boolean('delivered_by_us')->default(true);
+            $table->string('from_number_override')->nullable();
+            $table->string('last_modified_by_user_id', 64)->nullable();
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('last_modified_by_user_id')->references('id')->on('users')->nullOnDelete();
+            $table->unique(['environment_id', 'slug']);
+        });
+
+        $envIds = DB::table('environments')->pluck('id');
+        $now = now();
+        foreach ($envIds as $envId) {
+            foreach (SmsTemplate::DEFAULT_TEMPLATES as $slug => $payload) {
+                $exists = DB::table('sms_templates')
+                    ->where('environment_id', $envId)
+                    ->where('slug', $slug)
+                    ->exists();
+                if ($exists) {
+                    continue;
+                }
+                DB::table('sms_templates')->insert([
+                    'id' => Id::generate('tmpl_'),
+                    'environment_id' => $envId,
+                    'slug' => $slug,
+                    'body' => $payload['body'],
+                    'delivered_by_us' => true,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sms_templates');
+    }
+};

--- a/tests/Feature/Models/SmsTemplateTest.php
+++ b/tests/Feature/Models/SmsTemplateTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Mail\Renderer;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\SmsTemplate;
+use App\Observers\EnvironmentObserver;
+
+function envForSmsTpl(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('seeds the three default SMS templates on environment creation', function (): void {
+    $env = envForSmsTpl();
+
+    $rows = SmsTemplate::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->orderBy('slug')
+        ->get();
+
+    expect($rows->pluck('slug')->all())->toBe([
+        SmsTemplate::SLUG_INVITATION,
+        SmsTemplate::SLUG_RESET_PASSWORD_CODE,
+        SmsTemplate::SLUG_VERIFICATION_CODE,
+    ]);
+
+    foreach ($rows as $row) {
+        expect($row->id)->toStartWith('tmpl_');
+        expect($row->body)->not->toBe('');
+        expect($row->delivered_by_us)->toBeTrue();
+    }
+});
+
+it('exposes the canonical default body for each slug', function (): void {
+    $env = envForSmsTpl();
+
+    $verification = SmsTemplate::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('slug', SmsTemplate::SLUG_VERIFICATION_CODE)
+        ->firstOrFail();
+
+    expect($verification->body)->toContain('{{otp_code}}');
+    expect($verification->body)->toContain('{{app.name}}');
+});
+
+it('seeding is idempotent — calling created() twice does not duplicate rows', function (): void {
+    $env = envForSmsTpl();
+
+    app(EnvironmentObserver::class)->created($env);
+
+    $count = SmsTemplate::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->count();
+
+    expect($count)->toBe(3);
+});
+
+it('renders a template against the env defaults via the shared Renderer', function (): void {
+    config()->set('app.name', 'Authn');
+    $env = envForSmsTpl();
+    $env->forceFill(['appearance' => ['application_name' => 'Acme']])->save();
+
+    $template = SmsTemplate::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('slug', SmsTemplate::SLUG_VERIFICATION_CODE)
+        ->firstOrFail();
+
+    $rendered = app(Renderer::class)->renderSms($template, $env->refresh(), [
+        'otp_code' => '123456',
+        'expiry_minutes' => 10,
+    ]);
+
+    expect($rendered)->toBe('Acme: your verification code is 123456. Expires in 10 minutes.');
+});


### PR DESCRIPTION
Closes #122.

## Summary

- New `sms_templates` table mirrors `email_templates` — ULID `tmpl_…`, unique `(environment_id, slug)`, single `body` column (SMS is plain-text — no MJML / HTML cache), `delivered_by_us` toggle, optional `from_number_override`.
- `SmsTemplate::DEFAULT_TEMPLATES` covers `verification_code`, `reset_password_code`, `invitation` with the canonical Liquid bodies (`{{otp_code}}` / `{{app.name}}` / `{{organization.name}}`).
- `EnvironmentObserver::created()` now seeds both email and SMS defaults — idempotent on both sides.
- Migration backfills existing envs (matches the v0.1 email-template pattern).
- `Renderer::renderSms()` reuses the email-side substitution + escape rules so both engines share one pipeline.

## Test plan

- [x] `vendor/bin/pest` — 546 / 546 passing
- [x] `vendor/bin/pest --filter SmsTemplate` — 4 / 4 passing
- [x] `vendor/bin/pint --test` — clean
- [x] `php artisan migrate:fresh` runs cleanly on the SQLite test DB