### PR TITLE
AU-4: OauthProviderResolver + preset registry + custom-OIDC discovery

### DIFF
--- a/app/Auth/Oauth/Exceptions/OauthDiscoveryFailedException.php
+++ b/app/Auth/Oauth/Exceptions/OauthDiscoveryFailedException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Raised when `<issuer>/.well-known/openid-configuration` can't be loaded
+ * or doesn't validate as an OIDC discovery document. Carries the upstream
+ * status code and (truncated) body so the dashboard can surface a useful
+ * error to the operator on the AU-13 wizard's Save action.
+ */
+final class OauthDiscoveryFailedException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $issuer,
+        public readonly ?int $statusCode,
+        public readonly ?string $upstreamBody,
+        string $message,
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/app/Auth/Oauth/OauthProviderResolver.php
+++ b/app/Auth/Oauth/OauthProviderResolver.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth;
+
+use App\Auth\Oauth\Exceptions\OauthDiscoveryFailedException;
+use App\Models\OauthProvider;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+/**
+ * Layered defaults for an OauthProvider row:
+ *   1. preset (when `provider_kind = 'preset'` and the key matches the
+ *      `PresetRegistry`)
+ *   2. cached discovery (when `provider_kind = 'custom_oidc'` and the
+ *      cache is fresh, or after a refresh)
+ *   3. operator-set values on the row itself.
+ *
+ * Stored values always win — operators can override anything from the
+ * preset (e.g. swap a custom userinfo endpoint).
+ */
+final class OauthProviderResolver
+{
+    /**
+     * Time-to-live for cached `custom_oidc` discovery (PLAN §4.6).
+     */
+    public const DISCOVERY_TTL_SECONDS = 300;
+
+    /**
+     * `<our shape> => <userinfo claim path>` defaults applied to any
+     * non-preset OIDC provider whose row has empty `attribute_mapping`.
+     *
+     * @var array<string, string>
+     */
+    public const DEFAULT_OIDC_ATTRIBUTE_MAPPING = [
+        'email' => 'email',
+        'email_verified' => 'email_verified',
+        'first_name' => 'given_name',
+        'last_name' => 'family_name',
+        'image_url' => 'picture',
+    ];
+
+    public function __construct(private readonly PresetRegistry $presets) {}
+
+    public function resolve(OauthProvider $provider): ResolvedProvider
+    {
+        if ($provider->provider_kind === OauthProvider::KIND_PRESET) {
+            return $this->resolvePreset($provider);
+        }
+
+        if ($provider->provider_kind === OauthProvider::KIND_CUSTOM_OIDC) {
+            return $this->resolveCustomOidc($provider);
+        }
+
+        return $this->resolveCustomOauth2($provider);
+    }
+
+    /**
+     * Fetch + validate `<issuer>/.well-known/openid-configuration`.
+     * Caller is expected to persist the returned shape onto the row;
+     * this method is pure (no DB writes), so the BAPI controller can
+     * preview discovery results without committing them.
+     *
+     * @return array{
+     *     authorization_endpoint:string,
+     *     token_endpoint:string,
+     *     userinfo_endpoint:string,
+     *     jwks_uri:?string,
+     *     id_token_signing_algs:list<string>,
+     * }
+     *
+     * @throws OauthDiscoveryFailedException
+     */
+    public function discoverEndpoints(string $issuer): array
+    {
+        $base = rtrim($issuer, '/');
+        $url = $base.'/.well-known/openid-configuration';
+
+        try {
+            $response = Http::acceptJson()->timeout(10)->get($url);
+        } catch (ConnectionException $e) {
+            throw new OauthDiscoveryFailedException($issuer, null, null, $e->getMessage());
+        } catch (Throwable $e) {
+            throw new OauthDiscoveryFailedException($issuer, null, null, $e->getMessage());
+        }
+
+        if (! $response->successful()) {
+            $body = mb_substr((string) $response->body(), 0, 512);
+            throw new OauthDiscoveryFailedException(
+                $issuer,
+                $response->status(),
+                $body,
+                "Discovery {$url} returned HTTP {$response->status()}",
+            );
+        }
+
+        $document = $response->json();
+        if (! is_array($document)) {
+            throw new OauthDiscoveryFailedException(
+                $issuer,
+                $response->status(),
+                mb_substr((string) $response->body(), 0, 512),
+                "Discovery {$url} did not return a JSON object",
+            );
+        }
+
+        foreach (['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint'] as $required) {
+            if (! is_string($document[$required] ?? null) || $document[$required] === '') {
+                throw new OauthDiscoveryFailedException(
+                    $issuer,
+                    $response->status(),
+                    mb_substr((string) $response->body(), 0, 512),
+                    "Discovery {$url} missing required field {$required}",
+                );
+            }
+        }
+
+        $idTokenAlgs = $document['id_token_signing_alg_values_supported'] ?? [];
+        $idTokenAlgs = is_array($idTokenAlgs) ? array_values(array_filter($idTokenAlgs, 'is_string')) : [];
+
+        return [
+            'authorization_endpoint' => (string) $document['authorization_endpoint'],
+            'token_endpoint' => (string) $document['token_endpoint'],
+            'userinfo_endpoint' => (string) $document['userinfo_endpoint'],
+            'jwks_uri' => is_string($document['jwks_uri'] ?? null) ? (string) $document['jwks_uri'] : null,
+            'id_token_signing_algs' => $idTokenAlgs,
+        ];
+    }
+
+    /**
+     * Whether the row's cached discovery data is still fresh enough to
+     * skip a refresh on the next resolve. `null` cached_at means "never
+     * fetched" → always stale.
+     */
+    public function discoveryIsStale(OauthProvider $provider): bool
+    {
+        if ($provider->discovery_cached_at === null) {
+            return true;
+        }
+
+        return $provider->discovery_cached_at->getTimestamp() + self::DISCOVERY_TTL_SECONDS < now()->getTimestamp();
+    }
+
+    private function resolvePreset(OauthProvider $provider): ResolvedProvider
+    {
+        $preset = $this->presets->get($provider->provider_key);
+        if ($preset === null) {
+            // Fall through as if it were a custom OAuth2 row — the
+            // operator presumably renamed the preset row's key after
+            // creation. Stored endpoints win regardless.
+            return $this->resolveCustomOauth2($provider);
+        }
+
+        $scopes = $this->emptyArrayFallback($provider->scopes, $preset->defaultScopes());
+        $mapping = $this->emptyArrayFallback($provider->attribute_mapping, $preset->defaultAttributeMapping());
+        $authParams = $this->emptyArrayFallback(
+            $provider->additional_authorization_params,
+            $preset->additionalAuthorizationParams(),
+        );
+        $idTokenAlgs = $provider->id_token_signing_algs ?: $preset->idTokenSigningAlgs();
+
+        return new ResolvedProvider(
+            provider: $provider,
+            authorizationEndpoint: $provider->authorization_endpoint ?: $preset->authorizationEndpoint(),
+            tokenEndpoint: $provider->token_endpoint ?: $preset->tokenEndpoint(),
+            userinfoEndpoint: $provider->userinfo_endpoint ?: $preset->userinfoEndpoint(),
+            jwksUri: $provider->jwks_uri ?: $preset->jwksUri(),
+            scopes: array_values($scopes),
+            attributeMapping: $mapping,
+            additionalAuthorizationParams: $authParams,
+            idTokenSigningAlgs: array_values($idTokenAlgs),
+            userinfoMethod: $provider->userinfo_method ?: $preset->userinfoMethod(),
+            userinfoAuth: $provider->userinfo_auth ?: $preset->userinfoAuth(),
+        );
+    }
+
+    private function resolveCustomOidc(OauthProvider $provider): ResolvedProvider
+    {
+        $endpoints = [
+            'authorization_endpoint' => $provider->authorization_endpoint,
+            'token_endpoint' => $provider->token_endpoint,
+            'userinfo_endpoint' => $provider->userinfo_endpoint,
+            'jwks_uri' => $provider->jwks_uri,
+            'id_token_signing_algs' => $provider->id_token_signing_algs ?? [],
+        ];
+
+        if ($provider->issuer !== null && $this->discoveryIsStale($provider)) {
+            try {
+                $endpoints = $this->discoverEndpoints($provider->issuer);
+                $provider->forceFill([
+                    'authorization_endpoint' => $endpoints['authorization_endpoint'],
+                    'token_endpoint' => $endpoints['token_endpoint'],
+                    'userinfo_endpoint' => $endpoints['userinfo_endpoint'],
+                    'jwks_uri' => $endpoints['jwks_uri'],
+                    'id_token_signing_algs' => $endpoints['id_token_signing_algs'],
+                    'discovery_cached_at' => now(),
+                ])->save();
+            } catch (OauthDiscoveryFailedException $e) {
+                if ($provider->authorization_endpoint === null || $provider->token_endpoint === null) {
+                    throw $e;
+                }
+                // Soft-fail: keep serving the last-good cached endpoints.
+            }
+        }
+
+        $mapping = $this->emptyArrayFallback($provider->attribute_mapping, self::DEFAULT_OIDC_ATTRIBUTE_MAPPING);
+
+        return new ResolvedProvider(
+            provider: $provider,
+            authorizationEndpoint: (string) $endpoints['authorization_endpoint'],
+            tokenEndpoint: (string) $endpoints['token_endpoint'],
+            userinfoEndpoint: (string) $endpoints['userinfo_endpoint'],
+            jwksUri: $endpoints['jwks_uri'] !== null ? (string) $endpoints['jwks_uri'] : null,
+            scopes: array_values($provider->scopes ?: ['openid']),
+            attributeMapping: $mapping,
+            additionalAuthorizationParams: $provider->additional_authorization_params ?: [],
+            idTokenSigningAlgs: array_values($endpoints['id_token_signing_algs']),
+            userinfoMethod: $provider->userinfo_method ?: 'GET',
+            userinfoAuth: $provider->userinfo_auth ?: 'bearer',
+        );
+    }
+
+    private function resolveCustomOauth2(OauthProvider $provider): ResolvedProvider
+    {
+        return new ResolvedProvider(
+            provider: $provider,
+            authorizationEndpoint: (string) $provider->authorization_endpoint,
+            tokenEndpoint: (string) $provider->token_endpoint,
+            userinfoEndpoint: (string) $provider->userinfo_endpoint,
+            jwksUri: $provider->jwks_uri,
+            scopes: array_values($provider->scopes ?: []),
+            attributeMapping: $provider->attribute_mapping ?: [],
+            additionalAuthorizationParams: $provider->additional_authorization_params ?: [],
+            idTokenSigningAlgs: array_values($provider->id_token_signing_algs ?: []),
+            userinfoMethod: $provider->userinfo_method ?: 'GET',
+            userinfoAuth: $provider->userinfo_auth ?: 'bearer',
+        );
+    }
+
+    /**
+     * @template T
+     *
+     * @param  ?array<array-key, T>  $stored
+     * @param  array<array-key, T>  $fallback
+     * @return array<array-key, T>
+     */
+    private function emptyArrayFallback(?array $stored, array $fallback): array
+    {
+        return ($stored !== null && $stored !== []) ? $stored : $fallback;
+    }
+}

--- a/app/Auth/Oauth/OauthProviderSeeder.php
+++ b/app/Auth/Oauth/OauthProviderSeeder.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth;
+
+use App\Models\Environment;
+use App\Models\OauthProvider;
+
+/**
+ * Seeds the four preset OauthProvider rows on environment creation, all
+ * starting at `enabled = false` with blank `client_id` /
+ * `encrypted_client_secret`. The dashboard renders them as "configured
+ * but disabled" until the operator fills in credentials.
+ */
+final class OauthProviderSeeder
+{
+    public function __construct(private readonly PresetRegistry $presets) {}
+
+    public function seed(Environment $environment): void
+    {
+        foreach ($this->presets->all() as $preset) {
+            $exists = OauthProvider::query()
+                ->withoutGlobalScopes()
+                ->where('environment_id', $environment->id)
+                ->where('provider_key', $preset->key())
+                ->exists();
+            if ($exists) {
+                continue;
+            }
+
+            OauthProvider::query()->withoutGlobalScopes()->create([
+                'environment_id' => $environment->id,
+                'provider_kind' => OauthProvider::KIND_PRESET,
+                'provider_key' => $preset->key(),
+                'name' => $preset->name(),
+                'enabled' => false,
+                'allow_sign_in' => true,
+                'allow_sign_up' => true,
+                'block_email_subaddresses' => false,
+                'client_id' => '',
+                'encrypted_client_secret' => '',
+                'scopes' => $preset->defaultScopes(),
+                'attribute_mapping' => $preset->defaultAttributeMapping(),
+                'additional_authorization_params' => $preset->additionalAuthorizationParams(),
+                'authorization_endpoint' => $preset->authorizationEndpoint(),
+                'token_endpoint' => $preset->tokenEndpoint(),
+                'userinfo_endpoint' => $preset->userinfoEndpoint(),
+                'jwks_uri' => $preset->jwksUri(),
+                'id_token_signing_algs' => $preset->idTokenSigningAlgs(),
+                'userinfo_method' => $preset->userinfoMethod(),
+                'userinfo_auth' => $preset->userinfoAuth(),
+            ]);
+        }
+    }
+}

--- a/app/Auth/Oauth/PresetRegistry.php
+++ b/app/Auth/Oauth/PresetRegistry.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth;
+
+use App\Auth\Oauth\Presets\ApplePreset;
+use App\Auth\Oauth\Presets\GitHubPreset;
+use App\Auth\Oauth\Presets\GooglePreset;
+use App\Auth\Oauth\Presets\MicrosoftPreset;
+use App\Auth\Oauth\Presets\PresetContract;
+
+/**
+ * Canonical list of preset providers shipped with v0.4. Adding a new
+ * preset is a one-line change here plus the corresponding implementation
+ * under `app/Auth/Oauth/Presets/`.
+ */
+final class PresetRegistry
+{
+    /** @var array<string, PresetContract>|null */
+    private ?array $cache = null;
+
+    /**
+     * @return array<string, PresetContract>
+     */
+    public function all(): array
+    {
+        return $this->cache ??= [
+            (new GooglePreset)->key() => new GooglePreset,
+            (new GitHubPreset)->key() => new GitHubPreset,
+            (new ApplePreset)->key() => new ApplePreset,
+            (new MicrosoftPreset)->key() => new MicrosoftPreset,
+        ];
+    }
+
+    public function get(string $key): ?PresetContract
+    {
+        return $this->all()[$key] ?? null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function keys(): array
+    {
+        return array_keys($this->all());
+    }
+}

--- a/app/Auth/Oauth/Presets/ApplePreset.php
+++ b/app/Auth/Oauth/Presets/ApplePreset.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * Apple's "Sign in with Apple" requires `response_mode=form_post` so the
+ * IdP POSTs back to the redirect URI instead of a query-string redirect;
+ * AU-6's callback honours both transport methods.
+ */
+final class ApplePreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'apple';
+    }
+
+    public function name(): string
+    {
+        return 'Apple';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://appleid.apple.com/auth/authorize';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://appleid.apple.com/auth/token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        // Apple does not expose a separate userinfo endpoint — claims
+        // come back in the id_token. AU-6's callback short-circuits the
+        // userinfo round-trip when `userinfo_endpoint` matches the token
+        // endpoint.
+        return 'https://appleid.apple.com/auth/token';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return 'https://appleid.apple.com/auth/keys';
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['name', 'email'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'email' => 'email',
+            'email_verified' => 'email_verified',
+            'first_name' => 'given_name',
+            'last_name' => 'family_name',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return ['response_mode' => 'form_post'];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return ['ES256'];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'POST';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/GitHubPreset.php
+++ b/app/Auth/Oauth/Presets/GitHubPreset.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+final class GitHubPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'github';
+    }
+
+    public function name(): string
+    {
+        return 'GitHub';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://github.com/login/oauth/authorize';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://github.com/login/oauth/access_token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://api.github.com/user';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return null;
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['read:user', 'user:email'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'email' => 'email',
+            'first_name' => 'name',
+            'image_url' => 'avatar_url',
+            'username' => 'login',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return [];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/GooglePreset.php
+++ b/app/Auth/Oauth/Presets/GooglePreset.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+final class GooglePreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'google';
+    }
+
+    public function name(): string
+    {
+        return 'Google';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://accounts.google.com/o/oauth2/v2/auth';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://oauth2.googleapis.com/token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://openidconnect.googleapis.com/v1/userinfo';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return 'https://www.googleapis.com/oauth2/v3/certs';
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['openid', 'email', 'profile'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'email' => 'email',
+            'email_verified' => 'email_verified',
+            'first_name' => 'given_name',
+            'last_name' => 'family_name',
+            'image_url' => 'picture',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return ['access_type' => 'online', 'prompt' => 'select_account'];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return ['RS256'];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/MicrosoftPreset.php
+++ b/app/Auth/Oauth/Presets/MicrosoftPreset.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * Microsoft Entra "common" multi-tenant endpoints. Operators that want
+ * to lock the integration to a single tenant override the
+ * `additional_authorization_params.tenant` value via the BAPI patch
+ * surface (AU-5) or the dashboard wizard (AU-13).
+ */
+final class MicrosoftPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'microsoft';
+    }
+
+    public function name(): string
+    {
+        return 'Microsoft';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://graph.microsoft.com/oidc/userinfo';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return 'https://login.microsoftonline.com/common/discovery/v2.0/keys';
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['openid', 'email', 'profile'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'email' => 'email',
+            'email_verified' => 'email_verified',
+            'first_name' => 'given_name',
+            'last_name' => 'family_name',
+            'image_url' => 'picture',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return ['response_mode' => 'query'];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return ['RS256'];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/PresetContract.php
+++ b/app/Auth/Oauth/Presets/PresetContract.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * Each preset returns the canonical endpoints + default scopes and
+ * attribute-mapping for one IdP. Implementations are pure value
+ * functions — no DB access, no HTTP calls — so the resolver can mix
+ * them with stored OauthProvider state cheaply.
+ */
+interface PresetContract
+{
+    /**
+     * Stable key used as the `provider_key` on seeded rows and the
+     * suffix in `oauth_<key>` strategy strings.
+     */
+    public function key(): string;
+
+    /**
+     * Operator-facing display name (rendered in Configure → Social
+     * providers + on the SignIn social buttons).
+     */
+    public function name(): string;
+
+    public function authorizationEndpoint(): string;
+
+    public function tokenEndpoint(): string;
+
+    public function userinfoEndpoint(): string;
+
+    public function jwksUri(): ?string;
+
+    /**
+     * Default OAuth scopes requested when the operator hasn't
+     * overridden them. Always includes `openid` for OIDC presets.
+     *
+     * @return array<int, string>
+     */
+    public function defaultScopes(): array;
+
+    /**
+     * `<our shape> => <userinfo claim path>` map applied when the
+     * stored `attribute_mapping` is empty.
+     *
+     * @return array<string, string>
+     */
+    public function defaultAttributeMapping(): array;
+
+    /**
+     * Provider-specific authorization-URL params (`response_mode`,
+     * tenant overrides, …).
+     *
+     * @return array<string, mixed>
+     */
+    public function additionalAuthorizationParams(): array;
+
+    /**
+     * @return list<string>
+     */
+    public function idTokenSigningAlgs(): array;
+
+    /**
+     * `GET` (default) or `POST`. Apple uses POST.
+     */
+    public function userinfoMethod(): string;
+
+    /**
+     * `bearer` (default), `basic`, or `query` — how the access token
+     * is presented to userinfo.
+     */
+    public function userinfoAuth(): string;
+}

--- a/app/Auth/Oauth/ResolvedProvider.php
+++ b/app/Auth/Oauth/ResolvedProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth;
+
+use App\Models\OauthProvider;
+
+/**
+ * Read-only view of an OauthProvider with all preset / discovery defaults
+ * applied. Returned by `OauthProviderResolver::resolve()`. Callers
+ * (BAPI test endpoint, FAPI callback) work against this struct rather
+ * than the raw model so the layered defaults are computed once.
+ */
+final class ResolvedProvider
+{
+    /**
+     * @param  array<int, string>  $scopes
+     * @param  array<string, string>  $attributeMapping
+     * @param  array<string, mixed>  $additionalAuthorizationParams
+     * @param  list<string>  $idTokenSigningAlgs
+     */
+    public function __construct(
+        public readonly OauthProvider $provider,
+        public readonly string $authorizationEndpoint,
+        public readonly string $tokenEndpoint,
+        public readonly string $userinfoEndpoint,
+        public readonly ?string $jwksUri,
+        public readonly array $scopes,
+        public readonly array $attributeMapping,
+        public readonly array $additionalAuthorizationParams,
+        public readonly array $idTokenSigningAlgs,
+        public readonly string $userinfoMethod,
+        public readonly string $userinfoAuth,
+    ) {}
+}

--- a/app/Models/OauthProvider.php
+++ b/app/Models/OauthProvider.php
@@ -150,8 +150,11 @@ class OauthProvider extends Model
      */
     protected function redirectUri(): Attribute
     {
-        return Attribute::get(function (): string {
-            return Url::fapi($this->environment, '/v1/oauth-callback/'.$this->provider_key);
-        });
+        return Attribute::get(fn (): string => $this->computeRedirectUri());
+    }
+
+    public function computeRedirectUri(): string
+    {
+        return Url::fapi($this->environment, '/v1/oauth-callback/'.$this->provider_key);
     }
 }

--- a/app/Observers/EnvironmentObserver.php
+++ b/app/Observers/EnvironmentObserver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Observers;
 
+use App\Auth\Oauth\OauthProviderSeeder;
 use App\Models\EmailTemplate;
 use App\Models\Environment;
 use App\Models\SmsTemplate;
@@ -11,8 +12,8 @@ use App\Services\Tenancy\RoleSeeder;
 
 /**
  * Seeds the per-env defaults — system permissions + default roles, plus
- * the active EmailTemplate / SmsTemplate sets — into every freshly-minted
- * environment.
+ * the active EmailTemplate / SmsTemplate sets + OauthProvider preset rows
+ * — into every freshly-minted environment.
  *
  * The bootstrap service calls RoleSeeder directly so it keeps a handle on
  * the seeded admin role for the workspace owner membership; everywhere
@@ -21,13 +22,17 @@ use App\Services\Tenancy\RoleSeeder;
  */
 final class EnvironmentObserver
 {
-    public function __construct(private readonly RoleSeeder $seeder) {}
+    public function __construct(
+        private readonly RoleSeeder $seeder,
+        private readonly OauthProviderSeeder $oauthSeeder,
+    ) {}
 
     public function created(Environment $environment): void
     {
         $this->seeder->seed($environment);
         $this->seedDefaultEmailTemplates($environment);
         $this->seedDefaultSmsTemplates($environment);
+        $this->oauthSeeder->seed($environment);
     }
 
     private function seedDefaultEmailTemplates(Environment $environment): void

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "laravel/tinker": "^3.0",
         "lcobucci/clock": "^3.6",
         "lcobucci/jwt": "^5.6",
+        "league/oauth2-client": "^2.9",
         "pragmarx/google2fa": "^9.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7891590dc01810c800675efe727d2155",
+    "content-hash": "17d251ef92871f21d06f7316ebc81020",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -2368,6 +2368,71 @@
                 }
             ],
             "time": "2024-09-21T08:32:55+00:00"
+        },
+        {
+            "name": "league/oauth2-client",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth2-client.git",
+                "reference": "26e8c5da4f3d78cede7021e09b1330a0fc093d5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-client/zipball/26e8c5da4f3d78cede7021e09b1330a0fc093d5e",
+                "reference": "26e8c5da4f3d78cede7021e09b1330a0fc093d5e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
+                "php": "^7.1 || >=8.0.0 <8.6.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.5",
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth2\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Bilbie",
+                    "email": "hello@alexbilbie.com",
+                    "homepage": "http://www.alexbilbie.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "homepage": "https://github.com/shadowhand",
+                    "role": "Contributor"
+                }
+            ],
+            "description": "OAuth 2.0 Client Library",
+            "keywords": [
+                "Authentication",
+                "SSO",
+                "authorization",
+                "identity",
+                "idp",
+                "oauth",
+                "oauth2",
+                "single sign on"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth2-client/issues",
+                "source": "https://github.com/thephpleague/oauth2-client/tree/2.9.0"
+            },
+            "time": "2025-11-25T22:17:17+00:00"
         },
         {
             "name": "league/uri",

--- a/tests/Feature/Auth/Oauth/OauthProviderResolverTest.php
+++ b/tests/Feature/Auth/Oauth/OauthProviderResolverTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Oauth\Exceptions\OauthDiscoveryFailedException;
+use App\Auth\Oauth\OauthProviderResolver;
+use App\Auth\Oauth\PresetRegistry;
+use App\Models\Environment;
+use App\Models\OauthProvider;
+use App\Models\Project;
+use Illuminate\Support\Facades\Http;
+
+function makeEnvForResolver(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+function blankPresetProvider(Environment $env, string $key): OauthProvider
+{
+    return OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('provider_key', $key)
+        ->firstOrFail();
+}
+
+it('hydrates a Google preset row with the canonical endpoints + scopes', function (): void {
+    $env = makeEnvForResolver();
+    $row = blankPresetProvider($env, 'google');
+
+    $resolved = app(OauthProviderResolver::class)->resolve($row);
+
+    expect($resolved->authorizationEndpoint)->toBe('https://accounts.google.com/o/oauth2/v2/auth');
+    expect($resolved->tokenEndpoint)->toBe('https://oauth2.googleapis.com/token');
+    expect($resolved->userinfoEndpoint)->toBe('https://openidconnect.googleapis.com/v1/userinfo');
+    expect($resolved->jwksUri)->toBe('https://www.googleapis.com/oauth2/v3/certs');
+    expect($resolved->scopes)->toBe(['openid', 'email', 'profile']);
+    expect($resolved->attributeMapping)->toMatchArray([
+        'email' => 'email',
+        'first_name' => 'given_name',
+        'last_name' => 'family_name',
+    ]);
+    expect($resolved->idTokenSigningAlgs)->toBe(['RS256']);
+    expect($resolved->userinfoMethod)->toBe('GET');
+});
+
+it('hydrates a GitHub preset row (non-OIDC, no jwks_uri)', function (): void {
+    $env = makeEnvForResolver();
+    $row = blankPresetProvider($env, 'github');
+
+    $resolved = app(OauthProviderResolver::class)->resolve($row);
+
+    expect($resolved->authorizationEndpoint)->toBe('https://github.com/login/oauth/authorize');
+    expect($resolved->jwksUri)->toBeNull();
+    expect($resolved->scopes)->toBe(['read:user', 'user:email']);
+    expect($resolved->attributeMapping['username'] ?? null)->toBe('login');
+});
+
+it('hydrates Apple preset with form_post + ES256', function (): void {
+    $env = makeEnvForResolver();
+    $row = blankPresetProvider($env, 'apple');
+
+    $resolved = app(OauthProviderResolver::class)->resolve($row);
+
+    expect($resolved->additionalAuthorizationParams['response_mode'] ?? null)->toBe('form_post');
+    expect($resolved->idTokenSigningAlgs)->toBe(['ES256']);
+    expect($resolved->userinfoMethod)->toBe('POST');
+});
+
+it('hydrates Microsoft preset with the common-tenant endpoints', function (): void {
+    $env = makeEnvForResolver();
+    $row = blankPresetProvider($env, 'microsoft');
+
+    $resolved = app(OauthProviderResolver::class)->resolve($row);
+
+    expect($resolved->authorizationEndpoint)->toContain('login.microsoftonline.com/common');
+    expect($resolved->tokenEndpoint)->toContain('login.microsoftonline.com/common');
+    expect($resolved->scopes)->toBe(['openid', 'email', 'profile']);
+});
+
+it('lets stored values override preset defaults', function (): void {
+    $env = makeEnvForResolver();
+    $row = blankPresetProvider($env, 'google');
+    $row->forceFill([
+        'scopes' => ['openid', 'email'],
+        'authorization_endpoint' => 'https://example.test/authorize',
+    ])->save();
+
+    $resolved = app(OauthProviderResolver::class)->resolve($row->refresh());
+
+    expect($resolved->scopes)->toBe(['openid', 'email']);
+    expect($resolved->authorizationEndpoint)->toBe('https://example.test/authorize');
+    expect($resolved->tokenEndpoint)->toBe('https://oauth2.googleapis.com/token');
+});
+
+it('discovers OIDC endpoints via the well-known document', function (): void {
+    Http::fake([
+        'https://idp.test/.well-known/openid-configuration' => Http::response([
+            'authorization_endpoint' => 'https://idp.test/authorize',
+            'token_endpoint' => 'https://idp.test/token',
+            'userinfo_endpoint' => 'https://idp.test/userinfo',
+            'jwks_uri' => 'https://idp.test/jwks',
+            'id_token_signing_alg_values_supported' => ['RS256', 'ES256'],
+        ], 200),
+    ]);
+
+    $endpoints = app(OauthProviderResolver::class)->discoverEndpoints('https://idp.test');
+
+    expect($endpoints['authorization_endpoint'])->toBe('https://idp.test/authorize');
+    expect($endpoints['userinfo_endpoint'])->toBe('https://idp.test/userinfo');
+    expect($endpoints['id_token_signing_algs'])->toBe(['RS256', 'ES256']);
+});
+
+it('caches discovery on the row and reuses it within the TTL', function (): void {
+    $env = makeEnvForResolver();
+    $row = OauthProvider::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'provider_kind' => OauthProvider::KIND_CUSTOM_OIDC,
+        'provider_key' => 'idp_one',
+        'name' => 'IdP One',
+        'client_id' => 'cid',
+        'encrypted_client_secret' => 'sec',
+        'issuer' => 'https://idp.test',
+    ]);
+
+    Http::fake([
+        'https://idp.test/.well-known/openid-configuration' => Http::response([
+            'authorization_endpoint' => 'https://idp.test/authorize',
+            'token_endpoint' => 'https://idp.test/token',
+            'userinfo_endpoint' => 'https://idp.test/userinfo',
+        ], 200),
+    ]);
+
+    $resolver = app(OauthProviderResolver::class);
+
+    $resolver->resolve($row->fresh());
+    $resolver->resolve($row->fresh());
+
+    Http::assertSentCount(1);
+    expect($row->fresh()->discovery_cached_at)->not->toBeNull();
+});
+
+it('refreshes discovery after the TTL elapses', function (): void {
+    $env = makeEnvForResolver();
+    $row = OauthProvider::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'provider_kind' => OauthProvider::KIND_CUSTOM_OIDC,
+        'provider_key' => 'idp_two',
+        'name' => 'IdP Two',
+        'client_id' => 'cid',
+        'encrypted_client_secret' => 'sec',
+        'issuer' => 'https://idp.test',
+        'authorization_endpoint' => 'https://idp.test/authorize',
+        'token_endpoint' => 'https://idp.test/token',
+        'userinfo_endpoint' => 'https://idp.test/userinfo',
+        'discovery_cached_at' => now()->subSeconds(OauthProviderResolver::DISCOVERY_TTL_SECONDS + 60),
+    ]);
+
+    Http::fake([
+        'https://idp.test/.well-known/openid-configuration' => Http::response([
+            'authorization_endpoint' => 'https://idp.test/authorize-v2',
+            'token_endpoint' => 'https://idp.test/token-v2',
+            'userinfo_endpoint' => 'https://idp.test/userinfo-v2',
+        ], 200),
+    ]);
+
+    $resolved = app(OauthProviderResolver::class)->resolve($row->fresh());
+
+    expect($resolved->authorizationEndpoint)->toBe('https://idp.test/authorize-v2');
+    expect($row->fresh()->authorization_endpoint)->toBe('https://idp.test/authorize-v2');
+});
+
+it('throws OauthDiscoveryFailedException on HTTP 5xx', function (): void {
+    Http::fake([
+        'https://idp.test/.well-known/openid-configuration' => Http::response('upstream blew up', 502),
+    ]);
+
+    expect(fn () => app(OauthProviderResolver::class)->discoverEndpoints('https://idp.test'))
+        ->toThrow(OauthDiscoveryFailedException::class, 'HTTP 502');
+});
+
+it('rejects discovery responses that are missing required fields', function (): void {
+    Http::fake([
+        'https://idp.test/.well-known/openid-configuration' => Http::response([
+            'authorization_endpoint' => 'https://idp.test/authorize',
+            // missing token_endpoint + userinfo_endpoint
+        ], 200),
+    ]);
+
+    expect(fn () => app(OauthProviderResolver::class)->discoverEndpoints('https://idp.test'))
+        ->toThrow(OauthDiscoveryFailedException::class, 'token_endpoint');
+});
+
+it('falls back to stored endpoints on transient discovery failure', function (): void {
+    $env = makeEnvForResolver();
+    $row = OauthProvider::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'provider_kind' => OauthProvider::KIND_CUSTOM_OIDC,
+        'provider_key' => 'idp_three',
+        'name' => 'IdP Three',
+        'client_id' => 'cid',
+        'encrypted_client_secret' => 'sec',
+        'issuer' => 'https://idp.test',
+        'authorization_endpoint' => 'https://cached.test/authorize',
+        'token_endpoint' => 'https://cached.test/token',
+        'userinfo_endpoint' => 'https://cached.test/userinfo',
+    ]);
+
+    Http::fake([
+        'https://idp.test/.well-known/openid-configuration' => Http::response('upstream down', 503),
+    ]);
+
+    $resolved = app(OauthProviderResolver::class)->resolve($row);
+
+    expect($resolved->authorizationEndpoint)->toBe('https://cached.test/authorize');
+});
+
+it('applies the default OIDC attribute mapping when none is stored', function (): void {
+    $env = makeEnvForResolver();
+    $row = OauthProvider::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'provider_kind' => OauthProvider::KIND_CUSTOM_OIDC,
+        'provider_key' => 'idp_four',
+        'name' => 'IdP Four',
+        'client_id' => 'cid',
+        'encrypted_client_secret' => 'sec',
+        'authorization_endpoint' => 'https://x.test/authorize',
+        'token_endpoint' => 'https://x.test/token',
+        'userinfo_endpoint' => 'https://x.test/userinfo',
+    ]);
+
+    $resolved = app(OauthProviderResolver::class)->resolve($row);
+
+    expect($resolved->attributeMapping)->toBe(OauthProviderResolver::DEFAULT_OIDC_ATTRIBUTE_MAPPING);
+});
+
+it('seeds the four preset rows on environment creation, all disabled', function (): void {
+    $env = makeEnvForResolver('seedme');
+
+    $rows = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->orderBy('provider_key')
+        ->get();
+
+    expect($rows->pluck('provider_key')->all())->toBe(['apple', 'github', 'google', 'microsoft']);
+    foreach ($rows as $row) {
+        expect($row->enabled)->toBeFalse();
+        expect($row->client_id)->toBe('');
+        expect($row->provider_kind)->toBe(OauthProvider::KIND_PRESET);
+    }
+});
+
+it('OauthProvider::computeRedirectUri() builds the canonical callback URL', function (): void {
+    config()->set('authn.app_host', 'authn.sh');
+    config()->set('authn.app_scheme', 'https');
+    config()->set('authn.routing_mode', 'subdomain');
+    config()->set('authn.app_port_suffix', '');
+
+    $env = makeEnvForResolver('acme');
+    $row = blankPresetProvider($env->refresh(), 'google');
+
+    expect($row->computeRedirectUri())->toBe('https://acme.authn.sh/v1/oauth-callback/google');
+    expect($row->redirect_uri)->toBe('https://acme.authn.sh/v1/oauth-callback/google');
+});
+
+it('PresetRegistry exposes all four canonical preset keys', function (): void {
+    $registry = app(PresetRegistry::class);
+    expect($registry->keys())->toBe(['google', 'github', 'apple', 'microsoft']);
+});

--- a/tests/Feature/Http/Bapi/InstancePhoneAndOauthTest.php
+++ b/tests/Feature/Http/Bapi/InstancePhoneAndOauthTest.php
@@ -79,15 +79,11 @@ it('GET /environment narrows first_factors and oauth_providers based on env stat
         ])
         ->assertOk();
 
-    OauthProvider::query()->withoutGlobalScopes()->create([
-        'environment_id' => $f['env']->id,
-        'provider_kind' => OauthProvider::KIND_PRESET,
-        'provider_key' => 'google',
-        'name' => 'Google',
-        'enabled' => true,
-        'client_id' => 'gid',
-        'encrypted_client_secret' => 'gsecret',
-    ]);
+    // AU-4's seeder pre-creates the four preset rows; flip Google to enabled.
+    OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('provider_key', 'google')
+        ->update(['enabled' => true, 'client_id' => 'gid', 'encrypted_client_secret' => 'gsecret']);
 
     // Render the resource directly — full FAPI route reload would clobber
     // the BAPI routes the bootEnv() above just installed.

--- a/tests/Feature/Models/OauthProviderTest.php
+++ b/tests/Feature/Models/OauthProviderTest.php
@@ -28,8 +28,8 @@ it('mints a oauthp_ prefixed id and casts JSON columns to arrays', function (): 
     $provider = OauthProvider::create([
         'environment_id' => $env->id,
         'provider_kind' => OauthProvider::KIND_PRESET,
-        'provider_key' => 'google',
-        'name' => 'Google',
+        'provider_key' => 'acme',
+        'name' => 'Acme',
         'client_id' => 'gid',
         'encrypted_client_secret' => 'gsecret',
         'scopes' => ['openid', 'email'],
@@ -53,8 +53,8 @@ it('encrypts the client secret at rest and hides it from array serialization', f
     $provider = OauthProvider::create([
         'environment_id' => $env->id,
         'provider_kind' => OauthProvider::KIND_PRESET,
-        'provider_key' => 'github',
-        'name' => 'GitHub',
+        'provider_key' => 'beta',
+        'name' => 'Beta',
         'client_id' => 'cid',
         'encrypted_client_secret' => 'super-secret-value',
     ]);
@@ -74,8 +74,8 @@ it('enforces unique (environment_id, provider_key)', function (): void {
     OauthProvider::create([
         'environment_id' => $env->id,
         'provider_kind' => OauthProvider::KIND_PRESET,
-        'provider_key' => 'google',
-        'name' => 'Google',
+        'provider_key' => 'acme',
+        'name' => 'Acme',
         'client_id' => 'a',
         'encrypted_client_secret' => 'b',
     ]);
@@ -83,8 +83,8 @@ it('enforces unique (environment_id, provider_key)', function (): void {
     expect(fn () => OauthProvider::create([
         'environment_id' => $env->id,
         'provider_kind' => OauthProvider::KIND_PRESET,
-        'provider_key' => 'google',
-        'name' => 'Google',
+        'provider_key' => 'acme',
+        'name' => 'Acme',
         'client_id' => 'c',
         'encrypted_client_secret' => 'd',
     ]))->toThrow(QueryException::class);
@@ -100,13 +100,13 @@ it('computes the redirect_uri off the env FAPI host and provider_key', function 
     $provider = OauthProvider::create([
         'environment_id' => $env->id,
         'provider_kind' => OauthProvider::KIND_PRESET,
-        'provider_key' => 'google',
-        'name' => 'Google',
+        'provider_key' => 'acme',
+        'name' => 'Acme',
         'client_id' => 'gid',
         'encrypted_client_secret' => 'gsecret',
     ]);
 
-    expect($provider->redirect_uri)->toBe('https://acme.authn.sh/v1/oauth-callback/google');
+    expect($provider->redirect_uri)->toBe('https://acme.authn.sh/v1/oauth-callback/acme');
 });
 
 it('relates ExternalAccount → OauthProvider + User', function (): void {
@@ -116,8 +116,8 @@ it('relates ExternalAccount → OauthProvider + User', function (): void {
     $provider = OauthProvider::create([
         'environment_id' => $env->id,
         'provider_kind' => OauthProvider::KIND_PRESET,
-        'provider_key' => 'google',
-        'name' => 'Google',
+        'provider_key' => 'acme',
+        'name' => 'Acme',
         'client_id' => 'gid',
         'encrypted_client_secret' => 'gsecret',
     ]);
@@ -147,8 +147,8 @@ it('hides encrypted token columns and stores ciphertext on disk', function (): v
     $provider = OauthProvider::create([
         'environment_id' => $env->id,
         'provider_kind' => OauthProvider::KIND_PRESET,
-        'provider_key' => 'google',
-        'name' => 'Google',
+        'provider_key' => 'acme',
+        'name' => 'Acme',
         'client_id' => 'gid',
         'encrypted_client_secret' => 'gsecret',
     ]);
@@ -181,8 +181,8 @@ it('enforces unique (environment_id, oauth_provider_id, provider_user_id)', func
     $provider = OauthProvider::create([
         'environment_id' => $env->id,
         'provider_kind' => OauthProvider::KIND_PRESET,
-        'provider_key' => 'google',
-        'name' => 'Google',
+        'provider_key' => 'acme',
+        'name' => 'Acme',
         'client_id' => 'gid',
         'encrypted_client_secret' => 'gsecret',
     ]);


### PR DESCRIPTION
Closes #123.

## Summary

- New `App\Auth\Oauth\OauthProviderResolver` returns a hydrated `ResolvedProvider` struct that layers stored values on top of preset/discovered defaults; callers (BAPI test endpoint in AU-5, FAPI callback in AU-6) work against the resolved shape regardless of `provider_kind`.
- Four hand-rolled presets under `app/Auth/Oauth/Presets/{Google,GitHub,Apple,Microsoft}Preset.php` — canonical endpoints, default scopes, attribute mapping, and provider-specific authorization params (Apple's `response_mode=form_post` + ES256 id_token, Google's `prompt=select_account`, Microsoft's `common`-tenant base).
- `discoverEndpoints(string $issuer)` fetches and validates `<issuer>/.well-known/openid-configuration`. Required-field validation throws `OauthDiscoveryFailedException` carrying the upstream status + truncated body so the dashboard can surface errors. 5-minute TTL caches the resolved endpoints onto the row; soft-fails to last-good cache on transient HTTP errors.
- `OauthProviderSeeder` registers all four preset rows on env creation with `enabled = false` and blank credentials. Hooked from `EnvironmentObserver::created()`.
- New explicit `OauthProvider::computeRedirectUri()` method (alongside the existing accessor).
- composer.json gains `league/oauth2-client` for AU-6's authorization-code dance. Preset implementations re-use no third-party packages.

## Test plan

- [x] `vendor/bin/pest --filter Oauth` — 23 / 23 passing (15 resolver + 8 model)
- [x] `vendor/bin/pest` — 557 / 565 passing; the 8 failures are pre-existing on main (`InstanceTest`'s contract validator demands `multi_factor.phone_code`, which is AU-10's scope after the OA-7 spec bump)
- [x] `vendor/bin/pint --test` — clean
- [x] `php artisan migrate:fresh` runs cleanly + seeder installs the four preset rows per env