### PR TITLE
AU-12: SMS engine + drivers (Twilio/Vonage/Null) + BAPI /v1/sms-templates

### DIFF
--- a/app/Http/Controllers/Bapi/SmsTemplatesController.php
+++ b/app/Http/Controllers/Bapi/SmsTemplatesController.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Models\Environment;
+use App\Models\SmsTemplate;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ *   GET    /v1/sms-templates                — list active templates
+ *   GET    /v1/sms-templates/{slug}         — read one
+ *   PATCH  /v1/sms-templates/{slug}         — update body / overrides
+ *   POST   /v1/sms-templates/{slug}/revert  — restore the seeded default
+ *
+ * Slug-keyed since `SmsTemplate.slug` is the canonical identifier the
+ * send pipeline looks up. Per-env scoping comes from the bound
+ * `Environment` instance.
+ */
+final class SmsTemplatesController
+{
+    public function index(): JsonResponse
+    {
+        $env = app(Environment::class);
+        $rows = SmsTemplate::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->orderBy('slug')
+            ->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (SmsTemplate $r) => $this->shape($r))->all(),
+            'total_count' => $rows->count(),
+        ]);
+    }
+
+    public function show(string $slug): JsonResponse
+    {
+        $row = $this->find($slug);
+        if ($row === null) {
+            return $this->notFound($slug);
+        }
+
+        return response()->json($this->shape($row));
+    }
+
+    public function update(Request $request, string $slug): JsonResponse
+    {
+        $row = $this->find($slug);
+        if ($row === null) {
+            return $this->notFound($slug);
+        }
+
+        $request->validate([
+            'body' => ['nullable', 'string', 'max:1600'],
+            'delivered_by_us' => ['nullable', 'boolean'],
+            'from_number_override' => ['nullable', 'string', 'max:32'],
+        ]);
+
+        $patch = array_filter([
+            'body' => $request->input('body'),
+            'delivered_by_us' => $request->has('delivered_by_us') ? $request->boolean('delivered_by_us') : null,
+            'from_number_override' => $request->input('from_number_override'),
+        ], static fn ($v) => $v !== null);
+
+        $row->forceFill($patch)->save();
+
+        return response()->json($this->shape($row->refresh()));
+    }
+
+    public function revert(string $slug): JsonResponse
+    {
+        $row = $this->find($slug);
+        if ($row === null) {
+            return $this->notFound($slug);
+        }
+
+        $defaults = SmsTemplate::DEFAULT_TEMPLATES[$slug] ?? null;
+        if ($defaults === null) {
+            return response()->json([
+                'errors' => [['code' => 'sms_template_not_seeded', 'message' => 'No seeded default for this slug.', 'long_message' => 'No seeded default for this slug.', 'meta' => []]],
+                'trace_id' => null,
+            ], 422);
+        }
+
+        $row->forceFill([
+            'body' => $defaults['body'],
+            'delivered_by_us' => true,
+            'from_number_override' => null,
+        ])->save();
+
+        return response()->json($this->shape($row->refresh()));
+    }
+
+    private function find(string $slug): ?SmsTemplate
+    {
+        $env = app(Environment::class);
+
+        return SmsTemplate::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('slug', $slug)
+            ->first();
+    }
+
+    private function notFound(string $slug): JsonResponse
+    {
+        return response()->json([
+            'errors' => [['code' => 'sms_template_not_found', 'message' => "Template '{$slug}' not found.", 'long_message' => "Template '{$slug}' not found.", 'meta' => []]],
+            'trace_id' => null,
+        ], 404);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function shape(SmsTemplate $row): array
+    {
+        return [
+            'object' => 'sms_template',
+            'id' => $row->id,
+            'slug' => $row->slug,
+            'body' => $row->body,
+            'delivered_by_us' => (bool) $row->delivered_by_us,
+            'from_number_override' => $row->from_number_override,
+            'created_at' => $row->created_at?->getTimestampMs(),
+            'updated_at' => $row->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/app/Jobs/Sms/SendInvitationSms.php
+++ b/app/Jobs/Sms/SendInvitationSms.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Sms;
+
+use App\Models\Environment;
+use App\Models\SmsTemplate;
+use App\Sms\SmsPipeline;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Sibling of `SendInvitationEmail`. Renders the `invitation` SmsTemplate
+ * + dispatches via the env's driver.
+ */
+final class SendInvitationSms implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function __construct(
+        public readonly string $environmentId,
+        public readonly string $toNumber,
+        public readonly string $organizationName,
+        public readonly string $actionUrl,
+    ) {
+        $this->onQueue('sms');
+    }
+
+    public function backoff(): array
+    {
+        return [10, 60, 300];
+    }
+
+    public function handle(SmsPipeline $pipeline): void
+    {
+        $env = Environment::query()->withoutGlobalScopes()->where('id', $this->environmentId)->first();
+        if ($env === null) {
+            Log::warning('sms_environment_missing', ['environment_id' => $this->environmentId]);
+
+            return;
+        }
+
+        $pipeline->dispatch(
+            environment: $env,
+            templateSlug: SmsTemplate::SLUG_INVITATION,
+            toNumber: $this->toNumber,
+            vars: [
+                'organization' => ['name' => $this->organizationName],
+                'action_url' => $this->actionUrl,
+            ],
+        );
+    }
+}

--- a/app/Jobs/Sms/SendResetPasswordCodeSms.php
+++ b/app/Jobs/Sms/SendResetPasswordCodeSms.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Sms;
+
+use App\Mail\Renderer;
+use App\Models\Environment;
+use App\Models\PhoneNumber;
+use App\Models\SmsTemplate;
+use App\Models\Verification;
+use App\Sms\SmsPipeline;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Sibling of `SendResetPasswordCodeEmail`. Renders the
+ * `reset_password_code` SmsTemplate + dispatches via the env's driver.
+ */
+final class SendResetPasswordCodeSms implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function __construct(
+        public readonly string $environmentId,
+        public readonly string $toNumber,
+        public readonly string $code,
+        public readonly ?string $phoneNumberId = null,
+        public readonly ?string $verificationId = null,
+    ) {
+        $this->onQueue('sms');
+    }
+
+    public function backoff(): array
+    {
+        return [10, 60, 300];
+    }
+
+    public function handle(SmsPipeline $pipeline): void
+    {
+        $env = Environment::query()->withoutGlobalScopes()->where('id', $this->environmentId)->first();
+        if ($env === null) {
+            Log::warning('sms_environment_missing', ['environment_id' => $this->environmentId]);
+
+            return;
+        }
+
+        $phone = $this->phoneNumberId !== null
+            ? PhoneNumber::query()->withoutGlobalScopes()->where('id', $this->phoneNumberId)->first()
+            : null;
+        $verification = $this->verificationId !== null
+            ? Verification::query()->withoutGlobalScopes()->where('id', $this->verificationId)->first()
+            : null;
+
+        $expiryMinutes = $verification !== null
+            ? max(1, (int) round(($verification->expire_at->getTimestamp() - now()->getTimestamp()) / 60))
+            : 10;
+
+        $pipeline->dispatch(
+            environment: $env,
+            templateSlug: SmsTemplate::SLUG_RESET_PASSWORD_CODE,
+            toNumber: $this->toNumber,
+            vars: [
+                'otp_code' => $this->code,
+                'expiry_minutes' => $expiryMinutes,
+                'expires_at_human' => $verification !== null
+                    ? Renderer::humanExpires($verification->expire_at)
+                    : 'in 10 minutes',
+            ],
+            phoneNumber: $phone,
+            verification: $verification,
+        );
+    }
+}

--- a/app/Jobs/Sms/SendSmsTemplate.php
+++ b/app/Jobs/Sms/SendSmsTemplate.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Sms;
+
+use App\Models\Environment;
+use App\Models\PhoneNumber;
+use App\Models\Verification;
+use App\Sms\SmsPipeline;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Generic SMS dispatcher — renders an arbitrary template with a caller-
+ * supplied context bag and ships through the env's resolved driver.
+ *
+ * Carries scalar IDs only so the queue payload survives model deletion;
+ * the handler does the lookups itself.
+ */
+final class SendSmsTemplate implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    /**
+     * @param  array<string, mixed>  $vars
+     */
+    public function __construct(
+        public readonly string $environmentId,
+        public readonly string $templateSlug,
+        public readonly string $toNumber,
+        public readonly array $vars,
+        public readonly ?string $phoneNumberId = null,
+        public readonly ?string $verificationId = null,
+    ) {
+        $this->onQueue('sms');
+    }
+
+    public function backoff(): array
+    {
+        return [10, 60, 300];
+    }
+
+    public function handle(SmsPipeline $pipeline): void
+    {
+        $env = Environment::query()->withoutGlobalScopes()->where('id', $this->environmentId)->first();
+        if ($env === null) {
+            Log::warning('sms_environment_missing', ['environment_id' => $this->environmentId]);
+
+            return;
+        }
+
+        $phone = $this->phoneNumberId !== null
+            ? PhoneNumber::query()->withoutGlobalScopes()->where('id', $this->phoneNumberId)->first()
+            : null;
+        $verification = $this->verificationId !== null
+            ? Verification::query()->withoutGlobalScopes()->where('id', $this->verificationId)->first()
+            : null;
+
+        $pipeline->dispatch(
+            environment: $env,
+            templateSlug: $this->templateSlug,
+            toNumber: $this->toNumber,
+            vars: $this->vars,
+            phoneNumber: $phone,
+            verification: $verification,
+        );
+    }
+}

--- a/app/Jobs/Sms/SendVerificationSms.php
+++ b/app/Jobs/Sms/SendVerificationSms.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Sms;
+
+use App\Mail\Renderer;
+use App\Models\Environment;
+use App\Models\PhoneNumber;
+use App\Models\SmsTemplate;
+use App\Models\Verification;
+use App\Sms\SmsPipeline;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * AU-9 phone-code Challenge OTP delivery job. Mirror of
+ * `App\Jobs\Mail\SendVerificationEmail`. Carries scalar IDs so the
+ * payload stays small; handler does the lookups.
+ */
+final class SendVerificationSms implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function __construct(
+        public readonly string $environmentId,
+        public readonly string $toNumber,
+        public readonly string $code,
+        public readonly ?string $phoneNumberId = null,
+        public readonly ?string $verificationId = null,
+    ) {
+        $this->onQueue('sms');
+    }
+
+    public function backoff(): array
+    {
+        return [10, 60, 300];
+    }
+
+    public function handle(SmsPipeline $pipeline): void
+    {
+        $env = Environment::query()->withoutGlobalScopes()->where('id', $this->environmentId)->first();
+        if ($env === null) {
+            Log::warning('sms_environment_missing', ['environment_id' => $this->environmentId]);
+
+            return;
+        }
+
+        $phone = $this->phoneNumberId !== null
+            ? PhoneNumber::query()->withoutGlobalScopes()->where('id', $this->phoneNumberId)->first()
+            : null;
+        $verification = $this->verificationId !== null
+            ? Verification::query()->withoutGlobalScopes()->where('id', $this->verificationId)->first()
+            : null;
+
+        $expiryMinutes = $verification !== null
+            ? max(1, (int) round(($verification->expire_at->getTimestamp() - now()->getTimestamp()) / 60))
+            : 10;
+
+        $pipeline->dispatch(
+            environment: $env,
+            templateSlug: SmsTemplate::SLUG_VERIFICATION_CODE,
+            toNumber: $this->toNumber,
+            vars: [
+                'otp_code' => $this->code,
+                'expiry_minutes' => $expiryMinutes,
+                'expires_at_human' => $verification !== null
+                    ? Renderer::humanExpires($verification->expire_at)
+                    : 'in 10 minutes',
+            ],
+            phoneNumber: $phone,
+            verification: $verification,
+        );
+    }
+}

--- a/app/Sms/DriverManager.php
+++ b/app/Sms/DriverManager.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Sms;
+
+use App\Models\Environment;
+use App\Sms\Drivers\NullDriver;
+use App\Sms\Drivers\SmsDriver;
+use App\Sms\Drivers\TwilioDriver;
+use App\Sms\Drivers\VonageDriver;
+use Closure;
+use InvalidArgumentException;
+
+/**
+ * Resolves the SmsDriver instance for a given Environment. The env's
+ * `user_settings.sms.driver` overrides the global default
+ * (`config('authn-sms.default_driver')`).
+ *
+ * Mirror of `App\Mail\DriverManager`.
+ */
+final class DriverManager
+{
+    /**
+     * @var array<string, class-string<SmsDriver>>
+     */
+    private const NAME_TO_CLASS = [
+        TwilioDriver::NAME => TwilioDriver::class,
+        VonageDriver::NAME => VonageDriver::class,
+        NullDriver::NAME => NullDriver::class,
+    ];
+
+    /**
+     * Operator-supplied factories keyed by driver name. Lets tests +
+     * the Dashboard "Send test SMS" path register one-off drivers
+     * without touching the static map.
+     *
+     * @var array<string, Closure(): SmsDriver>
+     */
+    private array $extensions = [];
+
+    public function for(Environment $environment): SmsDriver
+    {
+        $userSettings = is_array($environment->user_settings) ? $environment->user_settings : [];
+        $smsCfg = is_array($userSettings['sms'] ?? null) ? $userSettings['sms'] : [];
+        $name = (string) ($smsCfg['driver'] ?? config('authn-sms.default_driver'));
+
+        return $this->resolve($name);
+    }
+
+    public function resolve(string $name): SmsDriver
+    {
+        if (isset($this->extensions[$name])) {
+            return ($this->extensions[$name])();
+        }
+
+        if (! isset(self::NAME_TO_CLASS[$name])) {
+            throw new InvalidArgumentException("Unknown SMS driver: {$name}");
+        }
+
+        return app(self::NAME_TO_CLASS[$name]);
+    }
+
+    /**
+     * Register a driver factory under `$name`. Subsequent `resolve()`
+     * calls return the factory's product.
+     *
+     * @param  Closure(): SmsDriver  $factory
+     */
+    public function extend(string $name, Closure $factory): void
+    {
+        $this->extensions[$name] = $factory;
+    }
+}

--- a/app/Sms/Drivers/NullDriver.php
+++ b/app/Sms/Drivers/NullDriver.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Sms\Drivers;
+
+use App\Sms\SmsEnvelope;
+use App\Sms\SmsReceipt;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * No-op driver — logs the rendered body and returns a success Receipt.
+ * Default in dev / CI so workers don't try to hit a live SMS gateway.
+ */
+final class NullDriver implements SmsDriver
+{
+    public const NAME = 'null';
+
+    public function name(): string
+    {
+        return self::NAME;
+    }
+
+    public function send(SmsEnvelope $envelope): SmsReceipt
+    {
+        Log::info('sms.null_driver.send', [
+            'to' => $envelope->toNumber,
+            'from' => $envelope->fromNumber,
+            'template' => $envelope->templateSlug,
+            'body' => $envelope->body,
+        ]);
+
+        return new SmsReceipt(
+            id: null,
+            driver: self::NAME,
+            accepted: true,
+            meta: ['logged' => true],
+        );
+    }
+}

--- a/app/Sms/Drivers/SmsDriver.php
+++ b/app/Sms/Drivers/SmsDriver.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Sms\Drivers;
+
+use App\Sms\SmsEnvelope;
+use App\Sms\SmsReceipt;
+
+interface SmsDriver
+{
+    public function name(): string;
+
+    public function send(SmsEnvelope $envelope): SmsReceipt;
+}

--- a/app/Sms/Drivers/TwilioDriver.php
+++ b/app/Sms/Drivers/TwilioDriver.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Sms\Drivers;
+
+use App\Sms\SmsEnvelope;
+use App\Sms\SmsReceipt;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+/**
+ * Twilio REST driver. Authenticated via HTTP Basic with the
+ * `(account_sid, auth_token)` pair. Endpoint URL contains an
+ * `{AccountSid}` placeholder so config can stay literal.
+ */
+final class TwilioDriver implements SmsDriver
+{
+    public const NAME = 'twilio';
+
+    public function name(): string
+    {
+        return self::NAME;
+    }
+
+    public function send(SmsEnvelope $envelope): SmsReceipt
+    {
+        $sid = (string) config('authn-sms.drivers.twilio.account_sid');
+        $token = (string) config('authn-sms.drivers.twilio.auth_token');
+        if ($sid === '' || $token === '') {
+            throw new RuntimeException('Twilio SMS credentials are not configured.');
+        }
+
+        $endpoint = str_replace(
+            '{AccountSid}',
+            $sid,
+            (string) config('authn-sms.drivers.twilio.endpoint'),
+        );
+
+        $response = Http::withBasicAuth($sid, $token)
+            ->asForm()
+            ->post($endpoint, [
+                'To' => $envelope->toNumber,
+                'From' => $envelope->fromNumber,
+                'Body' => $envelope->body,
+            ]);
+
+        $body = $response->json();
+        $accepted = $response->successful() && is_array($body) && ! isset($body['error_code']);
+
+        return new SmsReceipt(
+            id: is_array($body) ? ($body['sid'] ?? null) : null,
+            driver: self::NAME,
+            accepted: $accepted,
+            meta: ['status' => $response->status()],
+        );
+    }
+}

--- a/app/Sms/Drivers/VonageDriver.php
+++ b/app/Sms/Drivers/VonageDriver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Sms\Drivers;
+
+use App\Sms\SmsEnvelope;
+use App\Sms\SmsReceipt;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+/**
+ * Vonage (formerly Nexmo) HTTP API driver. Authenticated via
+ * `api_key` + `api_secret` form fields per their REST contract.
+ */
+final class VonageDriver implements SmsDriver
+{
+    public const NAME = 'vonage';
+
+    public function name(): string
+    {
+        return self::NAME;
+    }
+
+    public function send(SmsEnvelope $envelope): SmsReceipt
+    {
+        $key = (string) config('authn-sms.drivers.vonage.api_key');
+        $secret = (string) config('authn-sms.drivers.vonage.api_secret');
+        if ($key === '' || $secret === '') {
+            throw new RuntimeException('Vonage SMS credentials are not configured.');
+        }
+
+        $endpoint = (string) config('authn-sms.drivers.vonage.endpoint');
+
+        $response = Http::asForm()->post($endpoint, [
+            'api_key' => $key,
+            'api_secret' => $secret,
+            'to' => $envelope->toNumber,
+            'from' => $envelope->fromNumber,
+            'text' => $envelope->body,
+        ]);
+
+        $body = $response->json();
+        $messages = is_array($body) && is_array($body['messages'] ?? null) ? $body['messages'] : [];
+        $first = $messages[0] ?? null;
+        $statusCode = is_array($first) ? (string) ($first['status'] ?? '') : '';
+        $accepted = $response->successful() && $statusCode === '0';
+
+        return new SmsReceipt(
+            id: is_array($first) ? ($first['message-id'] ?? null) : null,
+            driver: self::NAME,
+            accepted: $accepted,
+            meta: ['status' => $response->status(), 'vonage_status' => $statusCode],
+        );
+    }
+}

--- a/app/Sms/SmsEnvelope.php
+++ b/app/Sms/SmsEnvelope.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Sms;
+
+/**
+ * Immutable struct passed from the pipeline into a `SmsDriver::send()`.
+ * Mirror of `App\Mail\Envelope`.
+ */
+final class SmsEnvelope
+{
+    public function __construct(
+        public readonly string $toNumber,
+        public readonly string $fromNumber,
+        public readonly string $body,
+        public readonly string $templateSlug,
+    ) {}
+}

--- a/app/Sms/SmsPipeline.php
+++ b/app/Sms/SmsPipeline.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Sms;
+
+use App\Mail\Renderer;
+use App\Models\Environment;
+use App\Models\PhoneNumber;
+use App\Models\SmsTemplate;
+use App\Models\Verification;
+use App\Webhooks\Emitter;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Shared dispatch path for every Send*Sms job. Mirror of `EmailPipeline`.
+ *
+ *   1. Test-mode short-circuit — recipient in `+1 (555) 555-0100`–`0199`
+ *      reserved range OR `Environment.user_settings.test_mode = enabled`
+ *      → log + bail, no driver call.
+ *   2. Per-(phone_id, verification_id) debounce.
+ *   3. Template lookup; bail with a log line if not seeded.
+ *   4. Render → if `delivered_by_us = false`, fire `sms.created` for
+ *      AU-15 to ship via webhooks; otherwise hand to the env's driver.
+ *
+ * Returns the `SmsReceipt` (or null when test-mode / debounced).
+ */
+final class SmsPipeline
+{
+    public function __construct(
+        private readonly Renderer $renderer,
+        private readonly DriverManager $drivers,
+        private readonly Emitter $emitter,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $vars
+     */
+    public function dispatch(
+        Environment $environment,
+        string $templateSlug,
+        string $toNumber,
+        array $vars,
+        ?PhoneNumber $phoneNumber = null,
+        ?Verification $verification = null,
+    ): ?SmsReceipt {
+        if ($this->isReservedTestNumber($toNumber) || $this->isEnvTestMode($environment)) {
+            Log::info('sms_skipped_test_mode', [
+                'environment_id' => $environment->id,
+                'template' => $templateSlug,
+                'to' => $toNumber,
+            ]);
+
+            return null;
+        }
+
+        if ($phoneNumber !== null && $verification !== null) {
+            $cacheKey = sprintf('sms:debounce:%s:%s', $phoneNumber->id, $verification->id);
+            if (! Cache::add($cacheKey, 1, (int) config('authn-sms.debounce_seconds', 60))) {
+                Log::info('sms_skipped_debounced', [
+                    'environment_id' => $environment->id,
+                    'template' => $templateSlug,
+                    'phone_id' => $phoneNumber->id,
+                    'verification_id' => $verification->id,
+                ]);
+
+                return null;
+            }
+        }
+
+        $template = SmsTemplate::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $environment->id)
+            ->where('slug', $templateSlug)
+            ->first();
+        if ($template === null) {
+            Log::warning('sms_template_missing', [
+                'environment_id' => $environment->id,
+                'template' => $templateSlug,
+            ]);
+
+            return null;
+        }
+
+        $body = $this->renderer->renderSms($template, $environment, $vars);
+
+        $userSettings = is_array($environment->user_settings) ? $environment->user_settings : [];
+        $smsCfg = is_array($userSettings['sms'] ?? null) ? $userSettings['sms'] : [];
+        $envFromNumber = is_string($smsCfg['from_number'] ?? null) ? (string) $smsCfg['from_number'] : null;
+        $globalFrom = (string) (config('authn-sms.default_from_number') ?? '');
+        $fromNumber = $template->from_number_override ?: ($envFromNumber ?: $globalFrom);
+
+        $envelope = new SmsEnvelope(
+            toNumber: $toNumber,
+            fromNumber: $fromNumber,
+            body: $body,
+            templateSlug: $template->slug,
+        );
+
+        if (! $template->delivered_by_us) {
+            Log::info('sms.created (delivered_by_us=false)', [
+                'environment_id' => $environment->id,
+                'template' => $template->slug,
+                'to' => $toNumber,
+            ]);
+            $this->emitter->emit('sms.created', $this->smsEventPayload($template, $envelope, deliveredByUs: false), $environment);
+
+            return new SmsReceipt(id: null, driver: 'webhook', accepted: true, meta: ['template' => $template->slug]);
+        }
+
+        $receipt = $this->drivers->for($environment)->send($envelope);
+        $this->emitter->emit('sms.created', $this->smsEventPayload($template, $envelope, deliveredByUs: true, receipt: $receipt), $environment);
+
+        return $receipt;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function smsEventPayload(SmsTemplate $template, SmsEnvelope $envelope, bool $deliveredByUs, ?SmsReceipt $receipt = null): array
+    {
+        return [
+            'object' => 'sms',
+            'template_slug' => $template->slug,
+            'to_phone_number' => $envelope->toNumber,
+            'from_phone_number' => $envelope->fromNumber,
+            'body' => $envelope->body,
+            'delivered_by_us' => $deliveredByUs,
+            'driver' => $receipt?->driver,
+            'accepted' => $receipt?->accepted,
+            'provider_message_id' => $receipt?->id,
+        ];
+    }
+
+    /**
+     * Per PLAN §9.11 the `+1 (555) 555-0100`–`0199` E.164 range is
+     * reserved for tests — sending an SMS there short-circuits to a
+     * fixed code so the verification flow is exercisable end-to-end
+     * without standing up a real gateway.
+     */
+    public static function isReservedTestNumber(string $toNumber): bool
+    {
+        // Strip whitespace + dashes the operator might have stored.
+        $normalized = preg_replace('/[\s\-()]/', '', $toNumber) ?? $toNumber;
+
+        // Reserved range: +1 555 555 0100 → +1 555 555 0199.
+        return preg_match('/^\+15555550(1\d{2})$/', $normalized) === 1;
+    }
+
+    private function isEnvTestMode(Environment $environment): bool
+    {
+        $userSettings = is_array($environment->user_settings) ? $environment->user_settings : [];
+
+        return ($userSettings['test_mode'] ?? null) === 'enabled';
+    }
+}

--- a/app/Sms/SmsReceipt.php
+++ b/app/Sms/SmsReceipt.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Sms;
+
+/**
+ * Outcome of a single `SmsDriver::send()`. Mirror of `App\Mail\Receipt`.
+ */
+final class SmsReceipt
+{
+    /**
+     * @param  array<string, mixed>  $meta
+     */
+    public function __construct(
+        public readonly ?string $id,
+        public readonly string $driver,
+        public readonly bool $accepted,
+        public readonly array $meta = [],
+    ) {}
+}

--- a/config/authn-sms.php
+++ b/config/authn-sms.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SMS pipeline configuration (PLAN §15.2). Mirror of `authn-mail.php`.
+ *
+ * The driver applied per request is resolved by `App\Sms\DriverManager` —
+ * `Environment.user_settings.sms.driver` may override the global default.
+ */
+return [
+    'default_driver' => env('AUTHN_SMS_DRIVER', 'null'),
+
+    'default_from_number' => env('AUTHN_DEFAULT_FROM_NUMBER'),
+
+    /**
+     * Per-driver settings. Each driver pulls only its own block.
+     */
+    'drivers' => [
+        'twilio' => [
+            'account_sid' => env('AUTHN_SMS_TWILIO_ACCOUNT_SID'),
+            'auth_token' => env('AUTHN_SMS_TWILIO_AUTH_TOKEN'),
+            'endpoint' => env(
+                'AUTHN_SMS_TWILIO_ENDPOINT',
+                'https://api.twilio.com/2010-04-01/Accounts/{AccountSid}/Messages.json',
+            ),
+        ],
+        'vonage' => [
+            'api_key' => env('AUTHN_SMS_VONAGE_API_KEY'),
+            'api_secret' => env('AUTHN_SMS_VONAGE_API_SECRET'),
+            'endpoint' => env('AUTHN_SMS_VONAGE_ENDPOINT', 'https://rest.nexmo.com/sms/json'),
+        ],
+        'null' => [
+            // Logs the rendered body to the queue worker; useful in dev / CI.
+        ],
+    ],
+
+    'retry_attempts' => 3,
+
+    'debounce_seconds' => 60,
+
+    /**
+     * The `+1 (555) 555-0100`–`0199` reserved E.164 range short-circuits
+     * to a fixed test code (PLAN §9.11). The fixed code lets pest assert
+     * the whole sign-up / sign-in flow without standing up a real SMS
+     * gateway.
+     */
+    'test_code' => env('AUTHN_SMS_TEST_CODE', '424242'),
+];

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Bapi\PingController;
 use App\Http\Controllers\Bapi\RedirectUrlsController;
 use App\Http\Controllers\Bapi\RoleController;
 use App\Http\Controllers\Bapi\SessionsController;
+use App\Http\Controllers\Bapi\SmsTemplatesController;
 use App\Http\Controllers\Bapi\UsersController;
 use App\Http\Controllers\Bapi\WebhookDeliveriesController;
 use App\Http\Controllers\Bapi\WebhookEndpointsController;
@@ -95,6 +96,12 @@ Route::post('/webhooks/endpoints/{id}/rotate-secret', [WebhookEndpointsControlle
 Route::get('/webhooks/deliveries', [WebhookDeliveriesController::class, 'index'])->middleware(RateLimit::class.':webhooks.list,300,60');
 Route::get('/webhooks/deliveries/{id}', [WebhookDeliveriesController::class, 'show'])->middleware(RateLimit::class.':webhooks.read,300,60');
 Route::post('/webhooks/deliveries/{id}/replay', [WebhookDeliveriesController::class, 'replay'])->middleware(RateLimit::class.':webhooks.replay,30,60');
+
+// SMS templates
+Route::get('/sms-templates', [SmsTemplatesController::class, 'index'])->middleware(RateLimit::class.':sms_templates.list,300,60')->name('bapi.sms_templates.index');
+Route::get('/sms-templates/{slug}', [SmsTemplatesController::class, 'show'])->middleware(RateLimit::class.':sms_templates.read,300,60')->name('bapi.sms_templates.show');
+Route::patch('/sms-templates/{slug}', [SmsTemplatesController::class, 'update'])->middleware(RateLimit::class.':sms_templates.update,60,60')->name('bapi.sms_templates.update');
+Route::post('/sms-templates/{slug}/revert', [SmsTemplatesController::class, 'revert'])->middleware(RateLimit::class.':sms_templates.update,30,60')->name('bapi.sms_templates.revert');
 
 // Organizations
 Route::get('/organizations', [OrganizationController::class, 'index'])->middleware(RateLimit::class.':orgs.list,300,60')->name('bapi.organizations.index');

--- a/tests/Feature/Http/Bapi/SmsTemplatesTest.php
+++ b/tests/Feature/Http/Bapi/SmsTemplatesTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Bapi;
+
+use App\Models\Environment;
+use App\Models\SmsTemplate;
+use Tests\TestCase;
+
+final class SmsTemplatesTest extends TestCase
+{
+    public function test_index_returns_the_three_seeded_templates(): void
+    {
+        $boot = BapiTestSupport::bootEnv('smslist');
+        app()->instance(Environment::class, $boot['env']);
+
+        $resp = $this->withoutOpenApiAssertions()
+            ->getJson(BapiTestSupport::url('/sms-templates'), BapiTestSupport::headers($boot['token']));
+
+        $resp->assertOk();
+        $resp->assertJsonCount(3, 'data');
+        $slugs = collect($resp->json('data'))->pluck('slug')->sort()->values()->all();
+        $this->assertSame(['invitation', 'reset_password_code', 'verification_code'], $slugs);
+    }
+
+    public function test_show_returns_one_template(): void
+    {
+        $boot = BapiTestSupport::bootEnv('smsshow');
+        app()->instance(Environment::class, $boot['env']);
+
+        $resp = $this->withoutOpenApiAssertions()
+            ->getJson(BapiTestSupport::url('/sms-templates/verification_code'), BapiTestSupport::headers($boot['token']));
+
+        $resp->assertOk();
+        $resp->assertJson([
+            'object' => 'sms_template',
+            'slug' => 'verification_code',
+            'delivered_by_us' => true,
+        ]);
+    }
+
+    public function test_show_404s_for_unseeded_slugs(): void
+    {
+        $boot = BapiTestSupport::bootEnv('smsmiss');
+        app()->instance(Environment::class, $boot['env']);
+
+        $resp = $this->withoutOpenApiAssertions()
+            ->getJson(BapiTestSupport::url('/sms-templates/never_seeded'), BapiTestSupport::headers($boot['token']));
+
+        $resp->assertNotFound();
+        $this->assertSame('sms_template_not_found', $resp->json('errors.0.code'));
+    }
+
+    public function test_update_writes_through_body_and_delivered_by_us(): void
+    {
+        $boot = BapiTestSupport::bootEnv('smsedit');
+        app()->instance(Environment::class, $boot['env']);
+
+        $resp = $this->withoutOpenApiAssertions()->patchJson(
+            BapiTestSupport::url('/sms-templates/verification_code'),
+            ['body' => 'Custom body {{otp_code}}', 'delivered_by_us' => false],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $resp->assertJson(['body' => 'Custom body {{otp_code}}', 'delivered_by_us' => false]);
+
+        $row = SmsTemplate::query()->withoutGlobalScopes()
+            ->where('environment_id', $boot['env']->id)
+            ->where('slug', 'verification_code')
+            ->firstOrFail();
+        $this->assertSame('Custom body {{otp_code}}', $row->body);
+        $this->assertFalse((bool) $row->delivered_by_us);
+    }
+
+    public function test_revert_restores_the_seeded_default_body(): void
+    {
+        $boot = BapiTestSupport::bootEnv('smsrevert');
+        app()->instance(Environment::class, $boot['env']);
+
+        SmsTemplate::query()->withoutGlobalScopes()
+            ->where('environment_id', $boot['env']->id)
+            ->where('slug', 'verification_code')
+            ->update(['body' => 'edited', 'delivered_by_us' => false, 'from_number_override' => '+15550000000']);
+
+        $resp = $this->withoutOpenApiAssertions()->postJson(
+            BapiTestSupport::url('/sms-templates/verification_code/revert'),
+            [],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $row = SmsTemplate::query()->withoutGlobalScopes()
+            ->where('environment_id', $boot['env']->id)
+            ->where('slug', 'verification_code')
+            ->firstOrFail();
+        $this->assertSame(SmsTemplate::DEFAULT_TEMPLATES['verification_code']['body'], $row->body);
+        $this->assertTrue((bool) $row->delivered_by_us);
+        $this->assertNull($row->from_number_override);
+    }
+}

--- a/tests/Feature/Sms/DriversTest.php
+++ b/tests/Feature/Sms/DriversTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Sms\Drivers\NullDriver;
+use App\Sms\Drivers\TwilioDriver;
+use App\Sms\Drivers\VonageDriver;
+use App\Sms\SmsEnvelope;
+use Illuminate\Support\Facades\Http;
+
+function envelopeForDrivers(): SmsEnvelope
+{
+    return new SmsEnvelope(
+        toNumber: '+15551231234',
+        fromNumber: '+15550009999',
+        body: 'Hello',
+        templateSlug: 'verification_code',
+    );
+}
+
+it('TwilioDriver POSTs form-encoded to the configured endpoint with basic auth', function (): void {
+    config()->set('authn-sms.drivers.twilio.account_sid', 'AC123');
+    config()->set('authn-sms.drivers.twilio.auth_token', 'tok456');
+    config()->set('authn-sms.drivers.twilio.endpoint', 'https://api.twilio.com/Accounts/{AccountSid}/Messages.json');
+
+    Http::fake([
+        'api.twilio.com/*' => Http::response(['sid' => 'SM-001'], 201),
+    ]);
+
+    $receipt = app(TwilioDriver::class)->send(envelopeForDrivers());
+
+    expect($receipt->driver)->toBe('twilio');
+    expect($receipt->accepted)->toBeTrue();
+    expect($receipt->id)->toBe('SM-001');
+
+    Http::assertSent(function ($request): bool {
+        return str_contains($request->url(), 'api.twilio.com/Accounts/AC123/Messages.json')
+            && $request['To'] === '+15551231234'
+            && $request['Body'] === 'Hello'
+            && $request->hasHeader('Authorization');
+    });
+});
+
+it('TwilioDriver throws when credentials are missing', function (): void {
+    config()->set('authn-sms.drivers.twilio.account_sid', '');
+    config()->set('authn-sms.drivers.twilio.auth_token', '');
+
+    expect(fn () => app(TwilioDriver::class)->send(envelopeForDrivers()))
+        ->toThrow(RuntimeException::class, 'Twilio SMS credentials');
+});
+
+it('VonageDriver POSTs form-encoded with api_key/api_secret', function (): void {
+    config()->set('authn-sms.drivers.vonage.api_key', 'k1');
+    config()->set('authn-sms.drivers.vonage.api_secret', 's1');
+    config()->set('authn-sms.drivers.vonage.endpoint', 'https://rest.nexmo.com/sms/json');
+
+    Http::fake([
+        'rest.nexmo.com/sms/json' => Http::response([
+            'messages' => [['status' => '0', 'message-id' => 'V-001']],
+        ], 200),
+    ]);
+
+    $receipt = app(VonageDriver::class)->send(envelopeForDrivers());
+
+    expect($receipt->driver)->toBe('vonage');
+    expect($receipt->accepted)->toBeTrue();
+    expect($receipt->id)->toBe('V-001');
+
+    Http::assertSent(function ($request): bool {
+        return $request['api_key'] === 'k1'
+            && $request['api_secret'] === 's1'
+            && $request['to'] === '+15551231234'
+            && $request['text'] === 'Hello';
+    });
+});
+
+it('VonageDriver flips accepted=false when status is non-zero', function (): void {
+    config()->set('authn-sms.drivers.vonage.api_key', 'k');
+    config()->set('authn-sms.drivers.vonage.api_secret', 's');
+
+    Http::fake([
+        'rest.nexmo.com/*' => Http::response([
+            'messages' => [['status' => '4', 'error-text' => 'bad credentials']],
+        ], 200),
+    ]);
+
+    $receipt = app(VonageDriver::class)->send(envelopeForDrivers());
+
+    expect($receipt->accepted)->toBeFalse();
+    expect($receipt->meta['vonage_status'] ?? null)->toBe('4');
+});
+
+it('NullDriver short-circuits + returns an accepted Receipt', function (): void {
+    Http::fake();
+
+    $receipt = app(NullDriver::class)->send(envelopeForDrivers());
+
+    expect($receipt->driver)->toBe('null');
+    expect($receipt->accepted)->toBeTrue();
+    Http::assertNothingSent();
+});

--- a/tests/Feature/Sms/SmsPipelineTest.php
+++ b/tests/Feature/Sms/SmsPipelineTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\SmsTemplate;
+use App\Sms\DriverManager;
+use App\Sms\Drivers\NullDriver;
+use App\Sms\SmsEnvelope;
+use App\Sms\SmsPipeline;
+use App\Sms\SmsReceipt;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+function envForPipeline(): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-pipe']);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'pipe',
+        'routing_label' => 'pipe',
+    ]);
+}
+
+it('short-circuits the reserved +1 555 555 0100-0199 range without hitting any driver', function (): void {
+    config()->set('authn-sms.default_driver', 'null');
+    Http::fake();
+    $env = envForPipeline();
+
+    $receipt = app(SmsPipeline::class)->dispatch(
+        environment: $env,
+        templateSlug: SmsTemplate::SLUG_VERIFICATION_CODE,
+        toNumber: '+15555550100',
+        vars: ['otp_code' => '424242'],
+    );
+
+    expect($receipt)->toBeNull();
+    Http::assertNothingSent();
+});
+
+it('treats env user_settings.test_mode = enabled as a global short-circuit', function (): void {
+    Http::fake();
+    $env = envForPipeline();
+    $env->forceFill(['user_settings' => ['test_mode' => 'enabled']])->save();
+
+    $receipt = app(SmsPipeline::class)->dispatch(
+        environment: $env->refresh(),
+        templateSlug: SmsTemplate::SLUG_VERIFICATION_CODE,
+        toNumber: '+14155551212',
+        vars: ['otp_code' => '424242'],
+    );
+
+    expect($receipt)->toBeNull();
+});
+
+it('renders the body and dispatches via the env driver', function (): void {
+    config()->set('authn-sms.default_driver', 'null');
+    Cache::flush();
+    $env = envForPipeline();
+
+    $receipt = app(SmsPipeline::class)->dispatch(
+        environment: $env,
+        templateSlug: SmsTemplate::SLUG_VERIFICATION_CODE,
+        toNumber: '+14155551212',
+        vars: ['otp_code' => '424242', 'expiry_minutes' => 10],
+    );
+
+    expect($receipt)->not->toBeNull();
+    expect($receipt->driver)->toBe('null');
+    expect($receipt->accepted)->toBeTrue();
+});
+
+it('webhook-only delivery emits sms.created without calling a driver', function (): void {
+    Http::fake();
+    Cache::flush();
+    $env = envForPipeline();
+    SmsTemplate::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('slug', SmsTemplate::SLUG_VERIFICATION_CODE)
+        ->update(['delivered_by_us' => false]);
+
+    // Substitute a driver that fails the test if called.
+    app(DriverManager::class)->extend('null', fn () => new class extends NullDriver
+    {
+        public function send(SmsEnvelope $envelope): SmsReceipt
+        {
+            throw new RuntimeException('driver should not be reached when delivered_by_us=false');
+        }
+    });
+    config()->set('authn-sms.default_driver', 'null');
+
+    $receipt = app(SmsPipeline::class)->dispatch(
+        environment: $env,
+        templateSlug: SmsTemplate::SLUG_VERIFICATION_CODE,
+        toNumber: '+14155551212',
+        vars: ['otp_code' => '424242', 'expiry_minutes' => 10],
+    );
+
+    expect($receipt)->not->toBeNull();
+    expect($receipt->driver)->toBe('webhook');
+});
+
+it('isReservedTestNumber matches only the 0100-0199 range', function (): void {
+    expect(SmsPipeline::isReservedTestNumber('+15555550100'))->toBeTrue();
+    expect(SmsPipeline::isReservedTestNumber('+15555550199'))->toBeTrue();
+    expect(SmsPipeline::isReservedTestNumber('+1 (555) 555-0142'))->toBeTrue();
+    expect(SmsPipeline::isReservedTestNumber('+15555550200'))->toBeFalse();
+    expect(SmsPipeline::isReservedTestNumber('+14155551212'))->toBeFalse();
+});


### PR DESCRIPTION
Closes #131.

## Summary

- `App\Sms\DriverManager` resolves a driver per Environment (mirror of `MailDriverManager`); ships **TwilioDriver** (basic-auth Messages.json POST), **VonageDriver** (api_key/api_secret form POST), **NullDriver** (logs only). `extend($name, $factory)` registers operator factories at runtime.
- `App\Sms\SmsPipeline` is the shared dispatch path: test-mode short-circuit (reserved `+1 555 555 0100`–`0199` E.164 range or `test_mode = enabled`), debounce per `(phone_id, verification_id)`, template lookup, `delivered_by_us = false` webhook-only branching, driver send on the happy path, `sms.created` emit.
- Four queue jobs — `SendVerificationSms` (AU-9 phone_code OTP), `SendResetPasswordCodeSms`, `SendInvitationSms`, `SendSmsTemplate` (generic) — mirror the v0.1 mail-job tree. All carry scalar IDs.
- BAPI `/v1/sms-templates` controller: index / show / patch / revert. Slug-keyed since the send pipeline looks up by slug.
- `config/authn-sms.php` mirrors `authn-mail.php`. Drivers re-use Laravel's Http client; tests use `Http::fake()` per the issue's AC.

## Test plan

- [x] `vendor/bin/pest --filter Sms` — 19 / 19 passing
- [x] `vendor/bin/pest` — 561 / 569 passing; the 8 failures are pre-existing on main (`InstanceTest`'s `multi_factor.phone_code: required` from the OA-7 spec bump — AU-10's scope)
- [x] `vendor/bin/pint --test` — clean