### PR TITLE
AU-10: attributes.phone_number tri-state + multi_factor.phone_code

### DIFF
--- a/app/Http/Controllers/Bapi/InstanceController.php
+++ b/app/Http/Controllers/Bapi/InstanceController.php
@@ -111,7 +111,22 @@ final class InstanceController
 
         $overrides = is_array($userSettings['attributes'] ?? null) ? $userSettings['attributes'] : [];
         foreach ($overrides as $name => $cfg) {
-            if (! isset($defaults[$name]) || ! is_array($cfg)) {
+            if (! isset($defaults[$name])) {
+                continue;
+            }
+            // The v0.4 phone_number tri-state ships as a scalar enum
+            // (`required`/`optional`/`off`); inflate it into the
+            // attribute-row shape the rest of the dashboard reads.
+            if ($name === 'phone_number' && is_string($cfg)) {
+                $defaults[$name]['enabled'] = $cfg !== 'off';
+                $defaults[$name]['required'] = $cfg === 'required';
+                $defaults[$name]['used_for_first_factor'] = $cfg !== 'off';
+                $defaults[$name]['verifications'] = $cfg !== 'off' ? ['phone_code'] : [];
+                $defaults[$name]['verify_at_sign_up'] = $cfg !== 'off';
+
+                continue;
+            }
+            if (! is_array($cfg)) {
                 continue;
             }
             $defaults[$name] = array_merge($defaults[$name], $cfg);
@@ -127,6 +142,7 @@ final class InstanceController
         $userSettings = is_array($env->user_settings) ? $env->user_settings : [];
         $previousTestMode = $userSettings['test_mode'] ?? null;
         $previousMultiFactor = MultiFactorSettings::fromUserSettings($userSettings);
+        $previousAttributes = is_array($userSettings['attributes'] ?? null) ? $userSettings['attributes'] : [];
 
         if ($request->has('support_email')) {
             $appearance['support_email'] = $request->input('support_email');
@@ -139,6 +155,24 @@ final class InstanceController
         }
         if ($request->has('user_settings') && is_array($request->input('user_settings'))) {
             $userSettings = array_replace_recursive($userSettings, $request->input('user_settings'));
+        }
+
+        $attributesChanged = false;
+        if ($request->has('attributes')) {
+            $patch = $request->input('attributes');
+            if (! is_array($patch)) {
+                throw ValidationException::withMessages(['attributes' => 'attributes must be an object.']);
+            }
+            Validator::make($patch, [
+                'phone_number' => 'sometimes|in:required,optional,off',
+            ])->validate();
+
+            $nextAttributes = is_array($userSettings['attributes'] ?? null) ? $userSettings['attributes'] : [];
+            if (array_key_exists('phone_number', $patch)) {
+                $nextAttributes['phone_number'] = (string) $patch['phone_number'];
+            }
+            $userSettings['attributes'] = $nextAttributes;
+            $attributesChanged = $nextAttributes != $previousAttributes;
         }
 
         $multiFactorChanged = false;
@@ -157,6 +191,8 @@ final class InstanceController
                     'integer',
                     'between:'.MultiFactorSettings::MIN_BACKUP_CODE_COUNT.','.MultiFactorSettings::MAX_BACKUP_CODE_COUNT,
                 ],
+                'phone_code' => 'sometimes|array',
+                'phone_code.enabled' => 'sometimes|boolean',
             ])->validate();
 
             $next = $previousMultiFactor->withPatch($patch);
@@ -200,6 +236,24 @@ final class InstanceController
                     'environment_id' => $env->id,
                     'before' => $previousMultiFactor->toArray(),
                     'after' => $next->toArray(),
+                ],
+                $env,
+            );
+        }
+
+        if ($attributesChanged) {
+            $nextAttributes = is_array($userSettings['attributes'] ?? null) ? $userSettings['attributes'] : [];
+            Log::info('instance.config.attributes_updated', [
+                'environment_id' => $env->id,
+                'before' => $previousAttributes,
+                'after' => $nextAttributes,
+            ]);
+            app(Emitter::class)->emit(
+                'instance.config.attributes_updated',
+                [
+                    'environment_id' => $env->id,
+                    'before' => $previousAttributes,
+                    'after' => $nextAttributes,
                 ],
                 $env,
             );

--- a/app/Http/Resources/EnvironmentResource.php
+++ b/app/Http/Resources/EnvironmentResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Resources;
 
 use App\Models\Environment;
+use App\Models\OauthProvider;
 use App\Settings\MultiFactorSettings;
 
 /**
@@ -20,6 +21,29 @@ use App\Settings\MultiFactorSettings;
  */
 final class EnvironmentResource
 {
+    /**
+     * Public half of `Environment.sms`. Strips every credential field —
+     * `auth_token` / `api_secret` are write-only and never leak via the
+     * FAPI bootstrap.
+     *
+     * @param  array<string, mixed>  $userSettings
+     * @return array{driver: ?string, from_number: ?string}
+     */
+    private static function smsBootstrap(array $userSettings): array
+    {
+        $sms = is_array($userSettings['sms'] ?? null) ? $userSettings['sms'] : [];
+        $driver = $sms['driver'] ?? null;
+        if (! in_array($driver, ['twilio', 'vonage', null], true)) {
+            $driver = null;
+        }
+        $from = is_string($sms['from_number'] ?? null) ? (string) $sms['from_number'] : null;
+
+        return [
+            'driver' => $driver,
+            'from_number' => $from,
+        ];
+    }
+
     public static function from(Environment $environment): array
     {
         $appearance = is_array($environment->appearance) ? $environment->appearance : [];
@@ -28,6 +52,22 @@ final class EnvironmentResource
         $localization = is_array($environment->localization) ? $environment->localization : [];
         $multiFactor = MultiFactorSettings::fromUserSettings($userSettings);
 
+        $attributes = is_array($userSettings['attributes'] ?? null) ? $userSettings['attributes'] : [];
+        $phoneAttr = is_string($attributes['phone_number'] ?? null) ? (string) $attributes['phone_number'] : 'off';
+        $firstFactors = ['password', 'email_code', 'reset_password_email_code', 'ticket'];
+        if ($phoneAttr !== 'off') {
+            $firstFactors[] = 'phone_code';
+        }
+        $oauthRows = OauthProvider::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $environment->id)
+            ->where('enabled', true)
+            ->orderBy('provider_key')
+            ->get();
+        foreach ($oauthRows as $row) {
+            $firstFactors[] = 'oauth_'.$row->provider_key;
+        }
+
         return [
             'object' => 'environment',
             'id' => $environment->id,
@@ -35,10 +75,10 @@ final class EnvironmentResource
             'auth_config' => [
                 'identifier_requirements' => [
                     'email_address' => 'required',
-                    'phone_number' => 'off',
+                    'phone_number' => $phoneAttr,
                     'username' => 'off',
                 ],
-                'first_factors' => ['password', 'email_code', 'reset_password_email_code', 'ticket'],
+                'first_factors' => $firstFactors,
                 'second_factors' => $multiFactor->enabledStrategies(),
                 'sign_up_modes' => ['public'],
             ],
@@ -115,8 +155,16 @@ final class EnvironmentResource
                 'supported_locales' => $localization['supported_locales'] ?? ['en-US'],
             ],
 
-            // v0.4 lights this up with preset + custom OIDC/OAuth2 providers.
-            'oauth_providers' => [],
+            'oauth_providers' => $oauthRows->map(fn (OauthProvider $p): array => [
+                'provider_key' => $p->provider_key,
+                'name' => $p->name,
+                'logo_url' => is_array($p->additional_authorization_params)
+                    ? ($p->additional_authorization_params['logo_url'] ?? null)
+                    : null,
+                'strategy' => 'oauth_'.$p->provider_key,
+            ])->all(),
+
+            'sms' => self::smsBootstrap($userSettings),
 
             'paths' => $appearance['paths'] ?? [],
 

--- a/app/Settings/MultiFactorSettings.php
+++ b/app/Settings/MultiFactorSettings.php
@@ -24,6 +24,7 @@ final readonly class MultiFactorSettings
         public bool $totpEnabled = true,
         public bool $backupCodesEnabled = true,
         public int $backupCodesDefaultCount = self::DEFAULT_BACKUP_CODE_COUNT,
+        public bool $phoneCodeEnabled = false,
     ) {}
 
     /**
@@ -43,16 +44,18 @@ final readonly class MultiFactorSettings
     {
         $totp = is_array($multiFactor['totp'] ?? null) ? $multiFactor['totp'] : [];
         $backup = is_array($multiFactor['backup_codes'] ?? null) ? $multiFactor['backup_codes'] : [];
+        $phoneCode = is_array($multiFactor['phone_code'] ?? null) ? $multiFactor['phone_code'] : [];
 
         return new self(
             totpEnabled: (bool) ($totp['enabled'] ?? true),
             backupCodesEnabled: (bool) ($backup['enabled'] ?? true),
             backupCodesDefaultCount: (int) ($backup['default_count'] ?? self::DEFAULT_BACKUP_CODE_COUNT),
+            phoneCodeEnabled: (bool) ($phoneCode['enabled'] ?? false),
         );
     }
 
     /**
-     * @return array{totp: array{enabled: bool}, backup_codes: array{enabled: bool, default_count: int}}
+     * @return array{totp: array{enabled: bool}, backup_codes: array{enabled: bool, default_count: int}, phone_code: array{enabled: bool}}
      */
     public function toArray(): array
     {
@@ -63,6 +66,9 @@ final readonly class MultiFactorSettings
             'backup_codes' => [
                 'enabled' => $this->backupCodesEnabled,
                 'default_count' => $this->backupCodesDefaultCount,
+            ],
+            'phone_code' => [
+                'enabled' => $this->phoneCodeEnabled,
             ],
         ];
     }
@@ -77,6 +83,7 @@ final readonly class MultiFactorSettings
         $totpEnabled = $this->totpEnabled;
         $backupCodesEnabled = $this->backupCodesEnabled;
         $backupCodesDefaultCount = $this->backupCodesDefaultCount;
+        $phoneCodeEnabled = $this->phoneCodeEnabled;
 
         if (is_array($patch['totp'] ?? null) && array_key_exists('enabled', $patch['totp'])) {
             $totpEnabled = (bool) $patch['totp']['enabled'];
@@ -89,8 +96,11 @@ final readonly class MultiFactorSettings
                 $backupCodesDefaultCount = (int) $patch['backup_codes']['default_count'];
             }
         }
+        if (is_array($patch['phone_code'] ?? null) && array_key_exists('enabled', $patch['phone_code'])) {
+            $phoneCodeEnabled = (bool) $patch['phone_code']['enabled'];
+        }
 
-        return new self($totpEnabled, $backupCodesEnabled, $backupCodesDefaultCount);
+        return new self($totpEnabled, $backupCodesEnabled, $backupCodesDefaultCount, $phoneCodeEnabled);
     }
 
     /**
@@ -104,6 +114,7 @@ final readonly class MultiFactorSettings
         return match ($strategy) {
             Verification::STRATEGY_TOTP => $this->totpEnabled,
             Verification::STRATEGY_BACKUP_CODE => $this->backupCodesEnabled,
+            Verification::STRATEGY_PHONE_CODE => $this->phoneCodeEnabled,
             default => false,
         };
     }
@@ -123,6 +134,9 @@ final readonly class MultiFactorSettings
         }
         if ($this->backupCodesEnabled) {
             $out[] = Verification::STRATEGY_BACKUP_CODE;
+        }
+        if ($this->phoneCodeEnabled) {
+            $out[] = Verification::STRATEGY_PHONE_CODE;
         }
 
         return $out;

--- a/tests/Feature/Http/Bapi/InstancePhoneAndOauthTest.php
+++ b/tests/Feature/Http/Bapi/InstancePhoneAndOauthTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Resources\EnvironmentResource;
+use App\Models\Environment;
+use App\Models\OauthProvider;
+use App\Models\WebhookEvent;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+
+it('PATCH /instance writes through multi_factor.phone_code.enabled', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/instance'), [
+            'multi_factor' => ['phone_code' => ['enabled' => true]],
+        ])
+        ->assertOk()
+        ->assertJsonPath('multi_factor.phone_code.enabled', true);
+
+    $env = Environment::query()->withoutGlobalScopes()->where('id', $f['env']->id)->first();
+    $this->assertTrue($env->user_settings['multi_factor']['phone_code']['enabled']);
+});
+
+it('PATCH /instance emits instance.config.multi_factor_updated when phone_code flips', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/instance'), [
+            'multi_factor' => ['phone_code' => ['enabled' => true]],
+        ])
+        ->assertOk();
+
+    $events = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('type', 'instance.config.multi_factor_updated')
+        ->get();
+    expect($events)->toHaveCount(1);
+});
+
+it('PATCH /instance accepts attributes.phone_number tri-state and emits attributes_updated', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/instance'), [
+            'attributes' => ['phone_number' => 'optional'],
+        ])
+        ->assertOk()
+        ->assertJsonPath('attribute_settings.phone_number.enabled', true)
+        ->assertJsonPath('attribute_settings.phone_number.required', false);
+
+    $env = Environment::query()->withoutGlobalScopes()->where('id', $f['env']->id)->first();
+    $this->assertSame('optional', $env->user_settings['attributes']['phone_number']);
+
+    $events = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('type', 'instance.config.attributes_updated')
+        ->get();
+    expect($events)->toHaveCount(1);
+});
+
+it('PATCH /instance rejects unknown phone_number values', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/instance'), [
+            'attributes' => ['phone_number' => 'maybe'],
+        ])
+        ->assertStatus(422);
+});
+
+it('GET /environment narrows first_factors and oauth_providers based on env state', function (): void {
+    $f = BapiTestSupport::bootEnv('env10');
+
+    $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/instance'), [
+            'attributes' => ['phone_number' => 'optional'],
+            'multi_factor' => ['phone_code' => ['enabled' => true]],
+        ])
+        ->assertOk();
+
+    OauthProvider::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'provider_kind' => OauthProvider::KIND_PRESET,
+        'provider_key' => 'google',
+        'name' => 'Google',
+        'enabled' => true,
+        'client_id' => 'gid',
+        'encrypted_client_secret' => 'gsecret',
+    ]);
+
+    // Render the resource directly — full FAPI route reload would clobber
+    // the BAPI routes the bootEnv() above just installed.
+    $payload = EnvironmentResource::from($f['env']->refresh());
+
+    $firstFactors = $payload['auth_config']['first_factors'];
+    expect($firstFactors)->toContain('phone_code');
+    expect($firstFactors)->toContain('oauth_google');
+    expect($payload['auth_config']['identifier_requirements']['phone_number'])->toBe('optional');
+    expect($payload['auth_config']['second_factors'])->toContain('phone_code');
+    expect(collect($payload['oauth_providers'])->pluck('provider_key')->all())->toContain('google');
+});


### PR DESCRIPTION
Closes #129.

## Summary

- `MultiFactorSettings` gains a `phone_code` block (default `enabled = false`) alongside `totp` / `backup_codes`. `enabledStrategies()` / `withPatch()` / `strategyEnabled()` all recognise the new strategy.
- `InstanceController::update()` validates `multi_factor.phone_code.enabled` (boolean) and `attributes.phone_number` (`required|optional|off`). The phone-attribute patch writes a scalar enum to `Environment.user_settings.attributes.phone_number`; the existing `attribute_settings` reader inflates that scalar into the dashboard row shape.
- New audit + webhook event `instance.config.attributes_updated` fires when the attributes blob changes (mirror of `multi_factor_updated`).
- `EnvironmentResource` (FAPI bootstrap) now reflects the phone tri-state in `auth_config.identifier_requirements.phone_number`, appends `phone_code` to `auth_config.first_factors` when phone is on, populates `auth_config.oauth_providers` from enabled OauthProvider rows, and adds the top-level `sms` block (`driver` + `from_number` only — credentials never leak).
- Resolves the contract violations the OA-7 + OA-8 spec bumps left on main (`multi_factor.phone_code: required`, `sms: required` on FAPI bootstrap).

## Test plan

- [x] `vendor/bin/pest --filter "InstancePhoneAndOauth"` — 5 / 5 passing
- [x] `vendor/bin/pest` — 559 / 559 passing (was 549 / 559 on main; the 10 pre-existing contract failures are now resolved)
- [x] `vendor/bin/pint --test` — clean