### PR TITLE
AU-5: BAPI /v1/oauth-providers CRUD + dry-run test

### DIFF
--- a/app/Http/Controllers/Bapi/OauthProviderController.php
+++ b/app/Http/Controllers/Bapi/OauthProviderController.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Auth\Oauth\Exceptions\OauthDiscoveryFailedException;
+use App\Auth\Oauth\OauthProviderResolver;
+use App\Auth\Oauth\PresetRegistry;
+use App\Http\Requests\Bapi\OauthProviders\OauthProviderStoreRequest;
+use App\Http\Requests\Bapi\OauthProviders\OauthProviderUpdateRequest;
+use App\Http\Resources\OauthProviderResource;
+use App\Models\Environment;
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * BAPI OAuth providers surface (PLAN §4.6, OA-4).
+ *
+ *   GET    /v1/oauth-providers
+ *   POST   /v1/oauth-providers
+ *   GET    /v1/oauth-providers/{oauth_provider_id}
+ *   PATCH  /v1/oauth-providers/{oauth_provider_id}
+ *   DELETE /v1/oauth-providers/{oauth_provider_id}   — 409 when ExternalAccounts present
+ *   POST   /v1/oauth-providers/{oauth_provider_id}/test
+ */
+final class OauthProviderController
+{
+    public function __construct(
+        private readonly OauthProviderResolver $resolver,
+        private readonly PresetRegistry $presets,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $query = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->orderBy('provider_key');
+
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (OauthProvider $r) => OauthProviderResource::from($r))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(OauthProviderStoreRequest $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        $providerKey = (string) $request->input('provider_key');
+        $duplicate = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('provider_key', $providerKey)
+            ->exists();
+        if ($duplicate) {
+            return $this->error(409, 'oauth_provider_exists', 'A provider with that provider_key already exists in this environment.');
+        }
+
+        $payload = $this->buildCreatePayload($env, $request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
+        }
+
+        $provider = OauthProvider::query()->withoutGlobalScopes()->create($payload);
+
+        Log::info('audit:bapi.oauth_provider.created', [
+            'environment_id' => $env->id,
+            'oauth_provider_id' => $provider->id,
+            'provider_kind' => $provider->provider_kind,
+            'provider_key' => $provider->provider_key,
+        ]);
+
+        return response()->json(OauthProviderResource::from($provider), 201);
+    }
+
+    public function show(string $oauthProviderId): JsonResponse
+    {
+        $row = $this->find($oauthProviderId);
+        if ($row === null) {
+            return $this->error(404, 'oauth_provider_not_found', 'No OAuth provider matches that id in this environment.');
+        }
+
+        return response()->json(OauthProviderResource::from($row))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function update(OauthProviderUpdateRequest $request, string $oauthProviderId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $row = $this->find($oauthProviderId);
+        if ($row === null) {
+            return $this->error(404, 'oauth_provider_not_found', 'No OAuth provider matches that id in this environment.');
+        }
+
+        $payload = $request->validated();
+
+        // client_secret semantics: omitted → unchanged; null → clear; string → re-encrypt.
+        if (array_key_exists('client_secret', $payload)) {
+            $secret = $payload['client_secret'];
+            $payload['encrypted_client_secret'] = $secret === null ? '' : (string) $secret;
+            unset($payload['client_secret']);
+        }
+
+        // Refresh discovery when issuer changes for custom_oidc.
+        if ($row->provider_kind === OauthProvider::KIND_CUSTOM_OIDC
+            && array_key_exists('issuer', $payload)
+            && (string) $payload['issuer'] !== (string) $row->issuer
+        ) {
+            try {
+                $endpoints = $this->resolver->discoverEndpoints((string) $payload['issuer']);
+                $payload = array_merge($payload, [
+                    'authorization_endpoint' => $endpoints['authorization_endpoint'],
+                    'token_endpoint' => $endpoints['token_endpoint'],
+                    'userinfo_endpoint' => $endpoints['userinfo_endpoint'],
+                    'jwks_uri' => $endpoints['jwks_uri'],
+                    'id_token_signing_algs' => $endpoints['id_token_signing_algs'],
+                    'discovery_cached_at' => now(),
+                ]);
+            } catch (OauthDiscoveryFailedException $e) {
+                return $this->error(422, 'oauth_discovery_failed', $e->getMessage());
+            }
+        }
+
+        $row->forceFill($payload)->save();
+
+        Log::info('audit:bapi.oauth_provider.updated', [
+            'environment_id' => $env->id,
+            'oauth_provider_id' => $row->id,
+        ]);
+
+        return response()->json(OauthProviderResource::from($row->refresh()));
+    }
+
+    public function destroy(string $oauthProviderId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $row = $this->find($oauthProviderId);
+        if ($row === null) {
+            return $this->error(404, 'oauth_provider_not_found', 'No OAuth provider matches that id in this environment.');
+        }
+
+        $linked = ExternalAccount::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('oauth_provider_id', $row->id)
+            ->exists();
+        if ($linked) {
+            return $this->error(409, 'oauth_provider_in_use', 'Cannot delete: ExternalAccount rows still link to this provider.');
+        }
+
+        $row->delete();
+
+        Log::info('audit:bapi.oauth_provider.deleted', [
+            'environment_id' => $env->id,
+            'oauth_provider_id' => $row->id,
+        ]);
+
+        return response()->json([
+            'object' => 'deleted_object',
+            'id' => $oauthProviderId,
+            'deleted' => true,
+        ]);
+    }
+
+    public function test(string $oauthProviderId): JsonResponse
+    {
+        $row = $this->find($oauthProviderId);
+        if ($row === null) {
+            return $this->error(404, 'oauth_provider_not_found', 'No OAuth provider matches that id in this environment.');
+        }
+
+        $errors = [];
+        $authorizeUrl = '';
+        $userinfoStatus = null;
+
+        try {
+            $resolved = $this->resolver->resolve($row);
+        } catch (OauthDiscoveryFailedException $e) {
+            $errors[] = ['code' => 'oauth_discovery_failed', 'message' => $e->getMessage(), 'long_message' => $e->getMessage(), 'meta' => []];
+            $resolved = null;
+        }
+
+        if ($resolved !== null) {
+            $authorizeUrl = $this->buildAuthorizeUrl($resolved->authorizationEndpoint, $row, $resolved->scopes, $resolved->additionalAuthorizationParams);
+            if ($resolved->userinfoEndpoint !== '' && $resolved->userinfoEndpoint !== $resolved->tokenEndpoint) {
+                try {
+                    $response = Http::timeout(5)->get($resolved->userinfoEndpoint);
+                    $userinfoStatus = $response->status();
+                } catch (ConnectionException|RequestException|Throwable $e) {
+                    $errors[] = ['code' => 'userinfo_unreachable', 'message' => $e->getMessage(), 'long_message' => $e->getMessage(), 'meta' => []];
+                }
+            }
+        }
+
+        return response()->json([
+            'authorize_url' => $authorizeUrl,
+            'userinfo_status' => $userinfoStatus,
+            'errors' => $errors,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>|JsonResponse
+     */
+    private function buildCreatePayload(Environment $env, OauthProviderStoreRequest $request): array|JsonResponse
+    {
+        $kind = (string) $request->input('provider_kind');
+        $base = [
+            'environment_id' => $env->id,
+            'provider_kind' => $kind,
+            'provider_key' => (string) $request->input('provider_key'),
+            'name' => (string) $request->input('name'),
+            'enabled' => $request->boolean('enabled', false),
+            'allow_sign_in' => $request->boolean('allow_sign_in', true),
+            'allow_sign_up' => $request->boolean('allow_sign_up', true),
+            'block_email_subaddresses' => $request->boolean('block_email_subaddresses', false),
+            'client_id' => (string) $request->input('client_id'),
+            'encrypted_client_secret' => (string) $request->input('client_secret', ''),
+            'scopes' => $this->arrayInput($request, 'scopes'),
+            'additional_authorization_params' => $this->arrayInput($request, 'additional_authorization_params'),
+            'attribute_mapping' => $this->arrayInput($request, 'attribute_mapping'),
+        ];
+
+        if ($kind === OauthProvider::KIND_PRESET) {
+            $preset = $this->presets->get($base['provider_key']);
+            if ($preset !== null) {
+                $base['authorization_endpoint'] = $preset->authorizationEndpoint();
+                $base['token_endpoint'] = $preset->tokenEndpoint();
+                $base['userinfo_endpoint'] = $preset->userinfoEndpoint();
+                $base['jwks_uri'] = $preset->jwksUri();
+                $base['id_token_signing_algs'] = $preset->idTokenSigningAlgs();
+                $base['userinfo_method'] = $preset->userinfoMethod();
+                $base['userinfo_auth'] = $preset->userinfoAuth();
+                if ($base['scopes'] === []) {
+                    $base['scopes'] = $preset->defaultScopes();
+                }
+                if ($base['attribute_mapping'] === []) {
+                    $base['attribute_mapping'] = $preset->defaultAttributeMapping();
+                }
+                if ($base['additional_authorization_params'] === []) {
+                    $base['additional_authorization_params'] = $preset->additionalAuthorizationParams();
+                }
+            }
+        }
+
+        if ($kind === OauthProvider::KIND_CUSTOM_OIDC) {
+            $base['issuer'] = (string) $request->input('issuer');
+            try {
+                $endpoints = $this->resolver->discoverEndpoints($base['issuer']);
+                $base = array_merge($base, [
+                    'authorization_endpoint' => $endpoints['authorization_endpoint'],
+                    'token_endpoint' => $endpoints['token_endpoint'],
+                    'userinfo_endpoint' => $endpoints['userinfo_endpoint'],
+                    'jwks_uri' => $endpoints['jwks_uri'],
+                    'id_token_signing_algs' => $endpoints['id_token_signing_algs'],
+                    'discovery_cached_at' => now(),
+                ]);
+            } catch (OauthDiscoveryFailedException $e) {
+                return $this->error(422, 'oauth_discovery_failed', $e->getMessage());
+            }
+        }
+
+        if ($kind === OauthProvider::KIND_CUSTOM_OAUTH2) {
+            $base['authorization_endpoint'] = (string) $request->input('authorization_endpoint');
+            $base['token_endpoint'] = (string) $request->input('token_endpoint');
+            $base['userinfo_endpoint'] = (string) $request->input('userinfo_endpoint');
+            $base['userinfo_method'] = (string) $request->input('userinfo_method');
+            $base['userinfo_auth'] = (string) $request->input('userinfo_auth');
+        }
+
+        return $base;
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    private function arrayInput(Request $request, string $key): array
+    {
+        $value = $request->input($key);
+
+        return is_array($value) ? $value : [];
+    }
+
+    /**
+     * @param  array<int, string>  $scopes
+     * @param  array<string, mixed>  $extraParams
+     */
+    private function buildAuthorizeUrl(string $authEndpoint, OauthProvider $row, array $scopes, array $extraParams): string
+    {
+        if ($authEndpoint === '') {
+            return '';
+        }
+
+        $params = array_merge([
+            'response_type' => 'code',
+            'client_id' => $row->client_id,
+            'redirect_uri' => $row->computeRedirectUri(),
+            'scope' => implode(' ', $scopes),
+            'state' => 'test_'.bin2hex(random_bytes(8)),
+        ], $extraParams);
+
+        $separator = str_contains($authEndpoint, '?') ? '&' : '?';
+
+        return $authEndpoint.$separator.http_build_query($params);
+    }
+
+    private function find(string $oauthProviderId): ?OauthProvider
+    {
+        $env = app(Environment::class);
+
+        return OauthProvider::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $oauthProviderId)
+            ->first();
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [['code' => $code, 'message' => $message, 'long_message' => $message, 'meta' => []]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Requests/Bapi/OauthProviders/OauthProviderStoreRequest.php
+++ b/app/Http/Requests/Bapi/OauthProviders/OauthProviderStoreRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\OauthProviders;
+
+use App\Models\OauthProvider;
+use Illuminate\Foundation\Http\FormRequest;
+
+final class OauthProviderStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $kind = (string) $this->input('provider_kind', '');
+
+        $rules = [
+            'provider_kind' => ['required', 'string', 'in:'.implode(',', OauthProvider::KINDS)],
+            'provider_key' => ['required', 'string', 'regex:/^[a-z][a-z0-9_]{1,63}$/'],
+            'name' => ['required', 'string', 'max:255'],
+            'enabled' => ['nullable', 'boolean'],
+            'allow_sign_in' => ['nullable', 'boolean'],
+            'allow_sign_up' => ['nullable', 'boolean'],
+            'block_email_subaddresses' => ['nullable', 'boolean'],
+            'client_id' => ['required', 'string', 'max:255'],
+            'client_secret' => ['nullable', 'string', 'max:1024'],
+            'scopes' => ['nullable', 'array'],
+            'scopes.*' => ['string'],
+            'additional_authorization_params' => ['nullable', 'array'],
+            'attribute_mapping' => ['nullable', 'array'],
+            'attribute_mapping.*' => ['string'],
+        ];
+
+        if ($kind === OauthProvider::KIND_CUSTOM_OIDC) {
+            $rules['issuer'] = ['required', 'url', 'max:512'];
+        }
+        if ($kind === OauthProvider::KIND_CUSTOM_OAUTH2) {
+            $rules['authorization_endpoint'] = ['required', 'url', 'max:512'];
+            $rules['token_endpoint'] = ['required', 'url', 'max:512'];
+            $rules['userinfo_endpoint'] = ['required', 'url', 'max:512'];
+            $rules['userinfo_method'] = ['required', 'in:GET,POST'];
+            $rules['userinfo_auth'] = ['required', 'in:bearer,basic,query'];
+        }
+
+        return $rules;
+    }
+}

--- a/app/Http/Requests/Bapi/OauthProviders/OauthProviderUpdateRequest.php
+++ b/app/Http/Requests/Bapi/OauthProviders/OauthProviderUpdateRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Bapi\OauthProviders;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class OauthProviderUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'string', 'max:255'],
+            'enabled' => ['sometimes', 'boolean'],
+            'allow_sign_in' => ['sometimes', 'boolean'],
+            'allow_sign_up' => ['sometimes', 'boolean'],
+            'block_email_subaddresses' => ['sometimes', 'boolean'],
+            'client_id' => ['sometimes', 'string', 'max:255'],
+            'client_secret' => ['nullable', 'string', 'max:1024'],
+            'scopes' => ['sometimes', 'array'],
+            'scopes.*' => ['string'],
+            'additional_authorization_params' => ['sometimes', 'array'],
+            'attribute_mapping' => ['sometimes', 'array'],
+            'attribute_mapping.*' => ['string'],
+            'issuer' => ['sometimes', 'url', 'max:512'],
+            'authorization_endpoint' => ['sometimes', 'url', 'max:512'],
+            'token_endpoint' => ['sometimes', 'url', 'max:512'],
+            'userinfo_endpoint' => ['sometimes', 'url', 'max:512'],
+            'jwks_uri' => ['sometimes', 'nullable', 'url', 'max:512'],
+            'id_token_signing_algs' => ['sometimes', 'array'],
+            'id_token_signing_algs.*' => ['string'],
+            'userinfo_method' => ['sometimes', 'in:GET,POST'],
+            'userinfo_auth' => ['sometimes', 'in:bearer,basic,query'],
+            'provider_kind' => ['prohibited'],
+            'provider_key' => ['prohibited'],
+        ];
+    }
+}

--- a/app/Http/Resources/OauthProviderResource.php
+++ b/app/Http/Resources/OauthProviderResource.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\OauthProvider;
+
+/**
+ * Public OauthProvider shape per OA-1. `client_secret` never appears in
+ * any response (the model `$hidden`s it; this resource just doesn't emit
+ * it). `redirect_uri` is always emitted — the operator must register it
+ * with the IdP.
+ */
+final class OauthProviderResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function from(OauthProvider $provider): array
+    {
+        return [
+            'object' => 'oauth_provider',
+            'id' => $provider->id,
+            'provider_kind' => $provider->provider_kind,
+            'provider_key' => $provider->provider_key,
+            'name' => $provider->name,
+            'enabled' => (bool) $provider->enabled,
+            'allow_sign_in' => (bool) $provider->allow_sign_in,
+            'allow_sign_up' => (bool) $provider->allow_sign_up,
+            'block_email_subaddresses' => (bool) $provider->block_email_subaddresses,
+            'client_id' => (string) $provider->client_id,
+            'scopes' => is_array($provider->scopes) ? array_values($provider->scopes) : [],
+            'additional_authorization_params' => is_array($provider->additional_authorization_params)
+                ? $provider->additional_authorization_params
+                : [],
+            'attribute_mapping' => is_array($provider->attribute_mapping)
+                ? $provider->attribute_mapping
+                : [],
+            'issuer' => $provider->issuer,
+            'discovery_endpoint' => $provider->discovery_endpoint,
+            'authorization_endpoint' => $provider->authorization_endpoint,
+            'token_endpoint' => $provider->token_endpoint,
+            'userinfo_endpoint' => $provider->userinfo_endpoint,
+            'jwks_uri' => $provider->jwks_uri,
+            'id_token_signing_algs' => is_array($provider->id_token_signing_algs)
+                ? array_values($provider->id_token_signing_algs)
+                : [],
+            'userinfo_method' => $provider->userinfo_method,
+            'userinfo_auth' => $provider->userinfo_auth,
+            'redirect_uri' => $provider->computeRedirectUri(),
+            'created_at' => $provider->created_at?->getTimestampMs(),
+            'updated_at' => $provider->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Bapi\AllowlistIdentifiersController;
 use App\Http\Controllers\Bapi\BlocklistIdentifiersController;
 use App\Http\Controllers\Bapi\InstanceController;
 use App\Http\Controllers\Bapi\InvitationsController;
+use App\Http\Controllers\Bapi\OauthProviderController;
 use App\Http\Controllers\Bapi\OrganizationController;
 use App\Http\Controllers\Bapi\OrganizationDomainChallengeController;
 use App\Http\Controllers\Bapi\OrganizationDomainController;
@@ -102,6 +103,14 @@ Route::get('/sms-templates', [SmsTemplatesController::class, 'index'])->middlewa
 Route::get('/sms-templates/{slug}', [SmsTemplatesController::class, 'show'])->middleware(RateLimit::class.':sms_templates.read,300,60')->name('bapi.sms_templates.show');
 Route::patch('/sms-templates/{slug}', [SmsTemplatesController::class, 'update'])->middleware(RateLimit::class.':sms_templates.update,60,60')->name('bapi.sms_templates.update');
 Route::post('/sms-templates/{slug}/revert', [SmsTemplatesController::class, 'revert'])->middleware(RateLimit::class.':sms_templates.update,30,60')->name('bapi.sms_templates.revert');
+
+// OAuth providers
+Route::get('/oauth-providers', [OauthProviderController::class, 'index'])->middleware(RateLimit::class.':oauth_providers.list,300,60')->name('bapi.oauth_providers.index');
+Route::post('/oauth-providers', [OauthProviderController::class, 'store'])->middleware(RateLimit::class.':oauth_providers.create,30,60')->name('bapi.oauth_providers.store');
+Route::get('/oauth-providers/{oauth_provider_id}', [OauthProviderController::class, 'show'])->middleware(RateLimit::class.':oauth_providers.read,300,60')->name('bapi.oauth_providers.show');
+Route::patch('/oauth-providers/{oauth_provider_id}', [OauthProviderController::class, 'update'])->middleware(RateLimit::class.':oauth_providers.update,60,60')->name('bapi.oauth_providers.update');
+Route::delete('/oauth-providers/{oauth_provider_id}', [OauthProviderController::class, 'destroy'])->middleware(RateLimit::class.':oauth_providers.destroy,30,60')->name('bapi.oauth_providers.destroy');
+Route::post('/oauth-providers/{oauth_provider_id}/test', [OauthProviderController::class, 'test'])->middleware(RateLimit::class.':oauth_providers.test,30,60')->name('bapi.oauth_providers.test');
 
 // Organizations
 Route::get('/organizations', [OrganizationController::class, 'index'])->middleware(RateLimit::class.':orgs.list,300,60')->name('bapi.organizations.index');

--- a/tests/Feature/Http/Bapi/OauthProvidersTest.php
+++ b/tests/Feature/Http/Bapi/OauthProvidersTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Bapi;
+
+use App\Models\Environment;
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+final class OauthProvidersTest extends TestCase
+{
+    public function test_index_returns_the_seeded_preset_rows(): void
+    {
+        $boot = BapiTestSupport::bootEnv('oauthlist');
+        app()->instance(Environment::class, $boot['env']);
+
+        $resp = $this->getJson(BapiTestSupport::url('/oauth-providers'), BapiTestSupport::headers($boot['token']));
+
+        $resp->assertOk();
+        $keys = collect($resp->json('data'))->pluck('provider_key')->sort()->values()->all();
+        $this->assertSame(['apple', 'github', 'google', 'microsoft'], $keys);
+    }
+
+    public function test_show_returns_one_provider_with_redirect_uri(): void
+    {
+        $boot = BapiTestSupport::bootEnv('oauthshow');
+        app()->instance(Environment::class, $boot['env']);
+        $row = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $boot['env']->id)
+            ->where('provider_key', 'google')
+            ->firstOrFail();
+
+        $resp = $this->getJson(
+            BapiTestSupport::url('/oauth-providers/'.$row->id),
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $resp->assertJson([
+            'object' => 'oauth_provider',
+            'provider_kind' => 'preset',
+            'provider_key' => 'google',
+        ]);
+        $this->assertStringContainsString('/v1/oauth-callback/google', $resp->json('redirect_uri'));
+    }
+
+    public function test_store_creates_a_custom_oauth2_provider(): void
+    {
+        $boot = BapiTestSupport::bootEnv('oauthcreate');
+        app()->instance(Environment::class, $boot['env']);
+
+        $resp = $this->postJson(
+            BapiTestSupport::url('/oauth-providers'),
+            [
+                'provider_kind' => 'custom_oauth2',
+                'provider_key' => 'acmecorp',
+                'name' => 'Acme Corp',
+                'enabled' => true,
+                'client_id' => 'cid-1',
+                'client_secret' => 'sec-1',
+                'authorization_endpoint' => 'https://acme.test/authorize',
+                'token_endpoint' => 'https://acme.test/token',
+                'userinfo_endpoint' => 'https://acme.test/userinfo',
+                'userinfo_method' => 'GET',
+                'userinfo_auth' => 'bearer',
+            ],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertCreated();
+        $resp->assertJson([
+            'object' => 'oauth_provider',
+            'provider_kind' => 'custom_oauth2',
+            'provider_key' => 'acmecorp',
+            'name' => 'Acme Corp',
+            'enabled' => true,
+        ]);
+        $this->assertArrayNotHasKey('client_secret', $resp->json());
+    }
+
+    public function test_store_runs_oid_c_discovery_on_custom_oidc(): void
+    {
+        Http::fake([
+            'https://idp.acme.test/.well-known/openid-configuration' => Http::response([
+                'authorization_endpoint' => 'https://idp.acme.test/authorize',
+                'token_endpoint' => 'https://idp.acme.test/token',
+                'userinfo_endpoint' => 'https://idp.acme.test/userinfo',
+                'jwks_uri' => 'https://idp.acme.test/jwks',
+                'id_token_signing_alg_values_supported' => ['RS256'],
+            ], 200),
+        ]);
+
+        $boot = BapiTestSupport::bootEnv('oauthoidc');
+        app()->instance(Environment::class, $boot['env']);
+
+        $resp = $this->postJson(
+            BapiTestSupport::url('/oauth-providers'),
+            [
+                'provider_kind' => 'custom_oidc',
+                'provider_key' => 'acmeoidc',
+                'name' => 'Acme OIDC',
+                'client_id' => 'cid',
+                'client_secret' => 'sec',
+                'issuer' => 'https://idp.acme.test',
+            ],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertCreated();
+        $resp->assertJson([
+            'authorization_endpoint' => 'https://idp.acme.test/authorize',
+            'jwks_uri' => 'https://idp.acme.test/jwks',
+        ]);
+    }
+
+    public function test_store_422s_on_custom_oidc_without_issuer(): void
+    {
+        $boot = BapiTestSupport::bootEnv('oauth422');
+        app()->instance(Environment::class, $boot['env']);
+
+        $resp = $this->postJson(
+            BapiTestSupport::url('/oauth-providers'),
+            [
+                'provider_kind' => 'custom_oidc',
+                'provider_key' => 'noissuer',
+                'name' => 'X',
+                'client_id' => 'c',
+                'client_secret' => 's',
+            ],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertStatus(422);
+    }
+
+    public function test_store_409_on_duplicate_provider_key(): void
+    {
+        $boot = BapiTestSupport::bootEnv('oauthdup');
+        app()->instance(Environment::class, $boot['env']);
+
+        $resp = $this->postJson(
+            BapiTestSupport::url('/oauth-providers'),
+            [
+                'provider_kind' => 'preset',
+                'provider_key' => 'google',
+                'name' => 'Dup Google',
+                'client_id' => 'a',
+                'client_secret' => 'b',
+            ],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertStatus(409);
+        $this->assertSame('oauth_provider_exists', $resp->json('errors.0.code'));
+    }
+
+    public function test_update_writes_through_with_partial_patch(): void
+    {
+        $boot = BapiTestSupport::bootEnv('oauthpatch');
+        app()->instance(Environment::class, $boot['env']);
+        $row = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $boot['env']->id)
+            ->where('provider_key', 'google')
+            ->firstOrFail();
+
+        $resp = $this->patchJson(
+            BapiTestSupport::url('/oauth-providers/'.$row->id),
+            ['enabled' => true, 'client_id' => 'real-client', 'client_secret' => 'rotated'],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $resp->assertJson(['enabled' => true, 'client_id' => 'real-client']);
+
+        $row->refresh();
+        $this->assertSame('rotated', $row->encrypted_client_secret);
+    }
+
+    public function test_update_rejects_provider_kind_changes(): void
+    {
+        $boot = BapiTestSupport::bootEnv('oauthimm');
+        app()->instance(Environment::class, $boot['env']);
+        $row = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $boot['env']->id)
+            ->where('provider_key', 'google')
+            ->firstOrFail();
+
+        $resp = $this->patchJson(
+            BapiTestSupport::url('/oauth-providers/'.$row->id),
+            ['provider_kind' => 'custom_oidc'],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertStatus(422);
+    }
+
+    public function test_destroy_409s_when_external_accounts_link_to_the_provider(): void
+    {
+        $boot = BapiTestSupport::bootEnv('oauthdel');
+        app()->instance(Environment::class, $boot['env']);
+        $row = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $boot['env']->id)
+            ->where('provider_key', 'google')
+            ->firstOrFail();
+        $user = User::query()->withoutGlobalScopes()->create(['environment_id' => $boot['env']->id]);
+        ExternalAccount::query()->withoutGlobalScopes()->create([
+            'environment_id' => $boot['env']->id,
+            'user_id' => $user->id,
+            'oauth_provider_id' => $row->id,
+            'provider_user_id' => 'pid',
+            'encrypted_access_token' => 't',
+            'linked_at' => now(),
+        ]);
+
+        $resp = $this->deleteJson(
+            BapiTestSupport::url('/oauth-providers/'.$row->id),
+            [],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertStatus(409);
+        $this->assertSame('oauth_provider_in_use', $resp->json('errors.0.code'));
+    }
+
+    public function test_destroy_soft_deletes_when_no_links(): void
+    {
+        $boot = BapiTestSupport::bootEnv('oauthdel2');
+        app()->instance(Environment::class, $boot['env']);
+        $row = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $boot['env']->id)
+            ->where('provider_key', 'google')
+            ->firstOrFail();
+
+        $resp = $this->deleteJson(
+            BapiTestSupport::url('/oauth-providers/'.$row->id),
+            [],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $resp->assertJson(['object' => 'deleted_object', 'deleted' => true]);
+    }
+
+    public function test_test_action_returns_authorize_url_and_userinfo_status(): void
+    {
+        Http::fake([
+            'openidconnect.googleapis.com/*' => Http::response('', 401),
+        ]);
+
+        $boot = BapiTestSupport::bootEnv('oauthtest');
+        app()->instance(Environment::class, $boot['env']);
+        $row = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $boot['env']->id)
+            ->where('provider_key', 'google')
+            ->firstOrFail();
+        $row->forceFill(['client_id' => 'real-client'])->save();
+
+        $resp = $this->postJson(
+            BapiTestSupport::url('/oauth-providers/'.$row->id.'/test'),
+            [],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $this->assertStringContainsString('accounts.google.com/o/oauth2/v2/auth', $resp->json('authorize_url'));
+        $this->assertSame(401, $resp->json('userinfo_status'));
+        $this->assertSame([], $resp->json('errors'));
+    }
+}


### PR DESCRIPTION
Closes #124.

## Summary

- Mounts six operations under `/v1/oauth-providers`: index, store, show, update, destroy, test.
- `OauthProviderStoreRequest` enforces kind-specific required fields per OA-1 (`custom_oidc` → `issuer`; `custom_oauth2` → endpoints + method + auth). `OauthProviderUpdateRequest` makes `provider_kind` / `provider_key` `prohibited` (spec calls them immutable).
- `store()` runs OIDC discovery via `OauthProviderResolver` for `custom_oidc` rows; for `preset` rows the registry's defaults flow into endpoints / scopes / attribute_mapping when the operator omits them.
- `update()` partial-patch semantics: omitted fields untouched; `client_secret: null` clears the stored value; an `issuer` change triggers fresh discovery.
- `destroy()` soft-deletes; returns `409 oauth_provider_in_use` when any `ExternalAccount` still links to the provider.
- `test()` builds the authorize URL the SDK would emit (synthetic `state`, registered `redirect_uri`) and unauthenticated-probes `userinfo_endpoint`. Always `200`; failures land in `errors[]` per the OA-4 contract.
- `OauthProviderResource` mirrors the OA-1 shape (no `client_secret`, computed `redirect_uri`).
- Audit breadcrumbs via `Log::info` — webhook events land in AU-15.

## Test plan

- [x] `vendor/bin/pest --filter OauthProviders` — 11 / 11 passing
- [x] `vendor/bin/pest` — 585 / 585 passing
- [x] `vendor/bin/pint --test` — clean
- [x] OpenAPI contract validation (auto-applied) passes for every response