### PR TITLE
AU-8: FAPI /v1/me/phone-numbers CRUD

### DIFF
--- a/app/Auth/ErrorCodes.php
+++ b/app/Auth/ErrorCodes.php
@@ -114,4 +114,10 @@ final class ErrorCodes
     public const EMAIL_NOT_VERIFIED = 'email_not_verified';
 
     public const PRIMARY_EMAIL_NOT_REMOVABLE = 'primary_email_not_removable';
+
+    public const PHONE_NOT_FOUND = 'phone_not_found';
+
+    public const PHONE_NOT_VERIFIED = 'phone_not_verified';
+
+    public const PHONE_RESERVED_FOR_SECOND_FACTOR = 'phone_reserved_for_second_factor';
 }

--- a/app/Http/Controllers/Fapi/MePhoneNumberController.php
+++ b/app/Http/Controllers/Fapi/MePhoneNumberController.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Auth\ErrorCodes;
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\PhoneNumberResource;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\PhoneNumber;
+use App\Models\Session;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * `/v1/me/phone-numbers` — end-user phone-number management. Mirror of
+ * the v0.1 `/v1/me/email-addresses` surface; verification reuses the
+ * v0.2 Challenge dance (AU-9 lights up the `phone_code` strategy).
+ *
+ * Hard-deletes (no soft-delete on PhoneNumber); 409 on delete-while-MFA.
+ */
+final class MePhoneNumberController
+{
+    /**
+     * Loose E.164 — leading +, 8-15 digits. We don't try to validate
+     * country code semantics here; the SMS driver returns a clean
+     * error if Twilio / Vonage rejects the number.
+     */
+    private const E164_PATTERN = '/^\+[1-9][0-9]{7,14}$/';
+
+    public function index(): JsonResponse
+    {
+        $user = app(User::class);
+        $rows = $user->phoneNumbers()->withoutGlobalScopes()->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (PhoneNumber $p) => PhoneNumberResource::from($p))->all(),
+            'total_count' => $rows->count(),
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot add phone numbers.');
+        }
+        $env = app(Environment::class);
+        $user = app(User::class);
+
+        $number = $request->input('phone_number');
+        if (! is_string($number) || preg_match(self::E164_PATTERN, $number) !== 1) {
+            return $this->error(422, ErrorCodes::FORM_PARAM_FORMAT_INVALID, 'phone_number must be E.164 (e.g. "+15555550100").');
+        }
+
+        $exists = PhoneNumber::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('phone_number', $number)
+            ->exists();
+        if ($exists) {
+            return $this->error(422, ErrorCodes::FORM_IDENTIFIER_EXISTS, 'That phone number is already registered.');
+        }
+
+        $row = PhoneNumber::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'user_id' => $user->id,
+            'phone_number' => $number,
+            'is_primary' => false,
+        ]);
+
+        return $this->clientEnvelope(PhoneNumberResource::from($row->fresh()), 201);
+    }
+
+    public function show(Request $request): JsonResponse
+    {
+        $row = $this->load($request);
+        if ($row instanceof JsonResponse) {
+            return $row;
+        }
+
+        return response()->json(PhoneNumberResource::from($row))->header('Cache-Control', 'no-store');
+    }
+
+    public function update(Request $request): JsonResponse
+    {
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot mutate phone numbers.');
+        }
+        $row = $this->load($request);
+        if ($row instanceof JsonResponse) {
+            return $row;
+        }
+
+        if ($request->has('is_primary') && $request->boolean('is_primary') === true) {
+            if (! $row->isVerified()) {
+                return $this->error(422, ErrorCodes::PHONE_NOT_VERIFIED, 'Cannot set an unverified phone number as primary.');
+            }
+            $row->forceFill(['is_primary' => true])->save();
+        }
+
+        if ($request->has('reserved_for_second_factor')) {
+            $row->forceFill(['reserved_for_second_factor' => $request->boolean('reserved_for_second_factor')])->save();
+        }
+
+        if ($request->has('default_second_factor') && $request->boolean('default_second_factor') === true) {
+            if (! $row->isVerified()) {
+                return $this->error(422, ErrorCodes::PHONE_NOT_VERIFIED, 'Cannot set an unverified phone number as default second factor.');
+            }
+            $row->forceFill(['default_second_factor' => true])->save();
+        }
+
+        return $this->clientEnvelope(PhoneNumberResource::from($row->fresh()));
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot delete phone numbers.');
+        }
+        $row = $this->load($request);
+        if ($row instanceof JsonResponse) {
+            return $row;
+        }
+
+        if ($row->reserved_for_second_factor) {
+            return $this->error(409, ErrorCodes::PHONE_RESERVED_FOR_SECOND_FACTOR, 'Phone is reserved for second-factor MFA. Toggle reserved_for_second_factor off first.');
+        }
+
+        $row->delete();
+
+        return response()->json(null, 204);
+    }
+
+    private function load(Request $request): PhoneNumber|JsonResponse
+    {
+        $id = (string) $request->route('phone_number_id');
+        $user = app(User::class);
+        $row = PhoneNumber::query()
+            ->withoutGlobalScopes()
+            ->where('id', $id)
+            ->where('user_id', $user->id)
+            ->first();
+        if ($row === null) {
+            return $this->error(404, ErrorCodes::PHONE_NOT_FOUND, 'Phone number not found on this user.');
+        }
+
+        return $row;
+    }
+
+    private function clientEnvelope(mixed $body, int $status = 200): JsonResponse
+    {
+        $client = app()->bound(Client::class) ? app(Client::class) : null;
+
+        return response()->json([
+            'response' => $body,
+            'client' => ClientResource::from($client?->fresh()),
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [['code' => $code, 'message' => $message, 'long_message' => $message, 'meta' => []]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Resources/PhoneNumberResource.php
+++ b/app/Http/Resources/PhoneNumberResource.php
@@ -19,9 +19,7 @@ final class PhoneNumberResource
             'is_primary' => (bool) $phone->is_primary,
             'reserved_for_second_factor' => (bool) $phone->reserved_for_second_factor,
             'default_second_factor' => (bool) $phone->default_second_factor,
-            'linked_to' => $phone->linked_to_external_account_id !== null
-                ? [['id' => $phone->linked_to_external_account_id, 'type' => 'external_account']]
-                : [],
+            'linked_to_external_account_id' => $phone->linked_to_external_account_id,
             'created_at' => $phone->created_at?->getTimestampMs(),
             'updated_at' => $phone->updated_at?->getTimestampMs(),
         ];

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Fapi\MagicLinkController;
 use App\Http\Controllers\Fapi\MeBackupCodesController;
 use App\Http\Controllers\Fapi\MeController;
 use App\Http\Controllers\Fapi\MeOrganizationController;
+use App\Http\Controllers\Fapi\MePhoneNumberController;
 use App\Http\Controllers\Fapi\MeTotpController;
 use App\Http\Controllers\Fapi\OrganizationController as FapiOrganizationController;
 use App\Http\Controllers\Fapi\OrganizationInvitationController as FapiOrganizationInvitationController;
@@ -111,6 +112,12 @@ Route::prefix('v1')->group(function (): void {
         Route::get('/me/email-addresses/{email_address_id}', [MeController::class, 'showEmail'])->name('fapi.me.emails.show');
         Route::patch('/me/email-addresses/{email_address_id}', [MeController::class, 'updateEmail'])->name('fapi.me.emails.update');
         Route::delete('/me/email-addresses/{email_address_id}', [MeController::class, 'deleteEmail'])->name('fapi.me.emails.destroy');
+
+        Route::get('/me/phone-numbers', [MePhoneNumberController::class, 'index'])->name('fapi.me.phones.list');
+        Route::post('/me/phone-numbers', [MePhoneNumberController::class, 'store'])->name('fapi.me.phones.create');
+        Route::get('/me/phone-numbers/{phone_number_id}', [MePhoneNumberController::class, 'show'])->name('fapi.me.phones.show');
+        Route::patch('/me/phone-numbers/{phone_number_id}', [MePhoneNumberController::class, 'update'])->name('fapi.me.phones.update');
+        Route::delete('/me/phone-numbers/{phone_number_id}', [MePhoneNumberController::class, 'destroy'])->name('fapi.me.phones.destroy');
 
         Route::post('/me/email-addresses/{email_address_id}/challenges', [ChallengeController::class, 'storeForEmailAddress'])->name('fapi.me.emails.challenges.store');
         Route::post('/me/email-addresses/{email_address_id}/challenges/{cid}/answer', [ChallengeController::class, 'answerForEmailAddress'])->name('fapi.me.emails.challenges.answer');

--- a/tests/Feature/Http/Me/MePhoneNumberTest.php
+++ b/tests/Feature/Http/Me/MePhoneNumberTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\PhoneNumber;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function mePhoneReq(string $method, string $path, string $jwt, array $body = []): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+it('GET /v1/me/phone-numbers returns the empty list for a fresh user', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = mePhoneReq('GET', '/me/phone-numbers', $auth['jwt']);
+    $r->assertOk()
+        ->assertJsonPath('total_count', 0)
+        ->assertJsonPath('data', []);
+});
+
+it('POST /v1/me/phone-numbers creates an unverified row', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = mePhoneReq('POST', '/me/phone-numbers', $auth['jwt'], ['phone_number' => '+15555550100']);
+    $r->assertCreated()
+        ->assertJsonPath('response.object', 'phone_number')
+        ->assertJsonPath('response.phone_number', '+15555550100')
+        ->assertJsonPath('response.verified', false)
+        ->assertJsonPath('response.is_primary', false);
+});
+
+it('POST /v1/me/phone-numbers 422s on non-E.164 input', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = mePhoneReq('POST', '/me/phone-numbers', $auth['jwt'], ['phone_number' => '555-555-0100']);
+    $r->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'form_param_format_invalid');
+});
+
+it('POST /v1/me/phone-numbers 422s on duplicate within env', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    mePhoneReq('POST', '/me/phone-numbers', $auth['jwt'], ['phone_number' => '+15555550100'])->assertCreated();
+
+    $r = mePhoneReq('POST', '/me/phone-numbers', $auth['jwt'], ['phone_number' => '+15555550100']);
+    $r->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'form_identifier_exists');
+});
+
+it('GET /v1/me/phone-numbers/{id} returns one row', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $row = PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'phone_number' => '+15555550101',
+    ]);
+
+    mePhoneReq('GET', '/me/phone-numbers/'.$row->id, $auth['jwt'])
+        ->assertOk()
+        ->assertJsonPath('id', $row->id)
+        ->assertJsonPath('phone_number', '+15555550101');
+});
+
+it('PATCH /v1/me/phone-numbers/{id} 422s when promoting an unverified phone to primary', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $row = PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'phone_number' => '+15555550102',
+    ]);
+
+    mePhoneReq('PATCH', '/me/phone-numbers/'.$row->id, $auth['jwt'], ['is_primary' => true])
+        ->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'phone_not_verified');
+});
+
+it('PATCH /v1/me/phone-numbers/{id} promotes a verified row + flips reserved_for_second_factor', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $row = PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'phone_number' => '+15555550103',
+    ]);
+    $row->markVerified();
+
+    mePhoneReq('PATCH', '/me/phone-numbers/'.$row->id, $auth['jwt'], [
+        'is_primary' => true,
+        'reserved_for_second_factor' => true,
+    ])->assertOk()
+        ->assertJsonPath('response.is_primary', true)
+        ->assertJsonPath('response.reserved_for_second_factor', true);
+});
+
+it('DELETE /v1/me/phone-numbers/{id} 409s when reserved_for_second_factor is on', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $row = PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'phone_number' => '+15555550104',
+        'reserved_for_second_factor' => true,
+    ]);
+
+    mePhoneReq('DELETE', '/me/phone-numbers/'.$row->id, $auth['jwt'])
+        ->assertStatus(409)
+        ->assertJsonPath('errors.0.code', 'phone_reserved_for_second_factor');
+});
+
+it('DELETE /v1/me/phone-numbers/{id} hard-deletes when not reserved', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $row = PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'phone_number' => '+15555550105',
+    ]);
+
+    mePhoneReq('DELETE', '/me/phone-numbers/'.$row->id, $auth['jwt'])
+        ->assertStatus(204);
+
+    expect(PhoneNumber::query()->withoutGlobalScopes()->where('id', $row->id)->exists())->toBeFalse();
+});
+
+it('GET /v1/me/phone-numbers/{id} 404 when not on this user', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    mePhoneReq('GET', '/me/phone-numbers/phn_nope', $auth['jwt'])
+        ->assertStatus(404)
+        ->assertJsonPath('errors.0.code', 'phone_not_found');
+});
+
+it('UserResource.phone_numbers reflects the row immediately after create', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    mePhoneReq('POST', '/me/phone-numbers', $auth['jwt'], ['phone_number' => '+15555550106'])->assertCreated();
+
+    $r = mePhoneReq('GET', '/me', $auth['jwt']);
+    $r->assertOk();
+    $phones = $r->json('phone_numbers');
+    expect(count($phones))->toBe(1);
+    expect($phones[0]['phone_number'])->toBe('+15555550106');
+});

--- a/tests/Feature/Models/PhoneNumberTest.php
+++ b/tests/Feature/Models/PhoneNumberTest.php
@@ -160,5 +160,5 @@ it('serialises phone_numbers on UserResource with the flat shape', function (): 
     expect($entry['reserved_for_second_factor'])->toBeTrue();
     expect($entry['default_second_factor'])->toBeFalse();
     expect($entry)->toHaveKey('current_challenge_id');
-    expect($entry['linked_to'])->toBe([]);
+    expect($entry['linked_to_external_account_id'])->toBeNull();
 });


### PR DESCRIPTION
Closes #127.

## Summary

- Adds `MePhoneNumberController` with index / store / show / update / destroy under `/v1/me/phone-numbers`.
- E.164 validation (loose: `+` then 8–15 digits); per-env uniqueness via the existing unique index.
- `update()` partial-patch for `is_primary`, `reserved_for_second_factor`, `default_second_factor`. Promoting an unverified row → 422 `phone_not_verified`.
- `destroy()` is hard delete; 409 `phone_reserved_for_second_factor` when MFA-committed.
- Impersonation sessions → 403 `actor_session_forbidden` on mutations.
- `PhoneNumberResource.linked_to_external_account_id` switched from a `linked_to[]` envelope to a flat scalar id per OA-3 spec.

## Test plan

- [x] `vendor/bin/pest --filter "MePhoneNumber|PhoneNumberTest"` — 18 / 18 passing
- [x] `vendor/bin/pest` — 607 / 607 passing
- [x] `vendor/bin/pint --test` — clean
- [x] OpenAPI contract validation passes for every response