### PR TITLE
AU-9: phone_code strategy + supportedStrategies narrowing

### DIFF
--- a/app/Auth/Strategies/PhoneCodeStrategy.php
+++ b/app/Auth/Strategies/PhoneCodeStrategy.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Auth\ErrorCodes;
+use App\Jobs\Sms\SendVerificationSms;
+use App\Models\EmailAddress;
+use App\Models\PhoneNumber;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Models\VerificationCode;
+use App\Services\Verification\VerificationManager;
+
+/**
+ * SMS-OTP strategy. Two flows share this implementation:
+ *
+ *   - First-factor sign-in via phone identifier (resolved through the
+ *     attempt's identifier field; symmetric with EmailCodeStrategy).
+ *   - Second-factor MFA via the user's `reserved_for_second_factor`
+ *     PhoneNumber row (resolved off the user inferred from the attempt's
+ *     email identifier — mirror of TotpStrategy).
+ *
+ * `prepare` mints a 6-digit code, persists its sha256 on a VerificationCode
+ * row, and dispatches `SendVerificationSms`. `attempt` consumes the code via
+ * `VerificationManager::attempt`, which handles the Argon2id-style replay
+ * protection (single-use, attempts capped at 5).
+ */
+final class PhoneCodeStrategy implements Strategy
+{
+    public const PURPOSE = 'phone_code';
+
+    public const TTL_SECONDS = 600;
+
+    public function __construct(private readonly VerificationManager $verifications) {}
+
+    public function name(): string
+    {
+        return Verification::STRATEGY_PHONE_CODE;
+    }
+
+    public function requiresPrepare(): bool
+    {
+        return true;
+    }
+
+    public function prepare(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $phone = $this->resolvePhone($attempt, $params);
+        if ($phone instanceof StrategyResult) {
+            return $phone;
+        }
+
+        $verification = $this->verifications->start(
+            $phone,
+            Verification::STRATEGY_PHONE_CODE,
+            self::TTL_SECONDS,
+        );
+        $code = $this->verifications->mintNumericCode($verification, self::PURPOSE, self::TTL_SECONDS);
+
+        SendVerificationSms::dispatch(
+            $attempt->environment_id,
+            $phone->phone_number,
+            $code,
+            $phone->id,
+            $verification->id,
+        );
+
+        return StrategyResult::ok($attempt, verification: $verification);
+    }
+
+    public function attempt(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $code = $params['code'] ?? null;
+        if (! is_string($code) || $code === '') {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'code is required.');
+        }
+        $verification = $params['verification'] ?? null;
+        if (! $verification instanceof Verification) {
+            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, 'No verification is in progress for this attempt.', 422);
+        }
+
+        $ok = $this->verifications->attempt($verification, $code);
+        if (! $ok) {
+            $errCode = match ($verification->fresh()->status) {
+                Verification::STATUS_FAILED => ErrorCodes::VERIFICATION_FAILED,
+                Verification::STATUS_EXPIRED => ErrorCodes::VERIFICATION_EXPIRED,
+                default => ErrorCodes::FORM_CODE_INCORRECT,
+            };
+
+            return StrategyResult::fail($attempt, $errCode, 'Incorrect code.', verification: $verification->fresh() ?? $verification);
+        }
+
+        // The verifiable is the PhoneNumber row. Resolve the owning user.
+        $phone = PhoneNumber::query()->withoutGlobalScopes()->where('id', $verification->verifiable_id)->first();
+        $user = $phone !== null
+            ? User::query()->withoutGlobalScopes()->where('id', $phone->user_id)->first()
+            : null;
+
+        if ($user === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'User not found.', 422);
+        }
+        if ($user->banned) {
+            return StrategyResult::fail($attempt, ErrorCodes::USER_BANNED, 'This user is banned.', 403);
+        }
+        if ($user->locked && $user->lockout_expires_at?->isFuture()) {
+            return StrategyResult::fail($attempt, ErrorCodes::USER_LOCKED, 'This user is temporarily locked.', 403);
+        }
+
+        // First-factor sign-up via phone-attribute path may flip
+        // verified_at when the phone wasn't yet verified; second-factor
+        // MFA never re-verifies (the row was already verified at enroll).
+        if ($phone->verified_at === null) {
+            $phone->markVerified();
+        }
+
+        return StrategyResult::ok($attempt, $user, $verification->fresh() ?? $verification);
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    private function resolvePhone(SignInAttempt $attempt, array $params): PhoneNumber|StrategyResult
+    {
+        $phoneId = $params['phone_number_id'] ?? null;
+        if (is_string($phoneId) && $phoneId !== '') {
+            $row = PhoneNumber::query()
+                ->withoutGlobalScopes()
+                ->where('id', $phoneId)
+                ->where('environment_id', $attempt->environment_id)
+                ->first();
+            if ($row === null) {
+                return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'No phone number matches that id.', 422);
+            }
+
+            return $row;
+        }
+
+        $user = $this->resolveUserFromAttempt($attempt);
+        if ($user === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'Cannot resolve a phone for this attempt; pass phone_number_id.', 422);
+        }
+
+        // Second-factor: prefer the row marked default_second_factor, then
+        // any reserved-for-second-factor row, then primary.
+        $row = PhoneNumber::query()->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->where('reserved_for_second_factor', true)
+            ->orderByDesc('default_second_factor')
+            ->orderByDesc('is_primary')
+            ->first();
+        if ($row === null) {
+            return StrategyResult::fail($attempt, 'phone_not_found', 'User has no phone reserved for second factor.', 422);
+        }
+
+        return $row;
+    }
+
+    private function resolveUserFromAttempt(SignInAttempt $attempt): ?User
+    {
+        if ($attempt->identifier === null) {
+            return null;
+        }
+        $email = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower((string) $attempt->identifier))
+            ->first();
+        if ($email === null) {
+            return null;
+        }
+
+        return User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first();
+    }
+}

--- a/app/Auth/StrategyResolver.php
+++ b/app/Auth/StrategyResolver.php
@@ -8,6 +8,7 @@ use App\Auth\Strategies\BackupCodeStrategy;
 use App\Auth\Strategies\EmailCodeStrategy;
 use App\Auth\Strategies\EmailLinkStrategy;
 use App\Auth\Strategies\PasswordStrategy;
+use App\Auth\Strategies\PhoneCodeStrategy;
 use App\Auth\Strategies\ResetPasswordEmailCodeStrategy;
 use App\Auth\Strategies\Strategy;
 use App\Auth\Strategies\TicketStrategy;
@@ -29,6 +30,7 @@ final class StrategyResolver
         private readonly TicketStrategy $ticket,
         private readonly TotpStrategy $totp,
         private readonly BackupCodeStrategy $backupCode,
+        private readonly PhoneCodeStrategy $phoneCode,
     ) {}
 
     public function resolve(string $name): Strategy
@@ -41,6 +43,7 @@ final class StrategyResolver
             Verification::STRATEGY_TICKET => $this->ticket,
             Verification::STRATEGY_TOTP => $this->totp,
             Verification::STRATEGY_BACKUP_CODE => $this->backupCode,
+            Verification::STRATEGY_PHONE_CODE => $this->phoneCode,
             default => throw new InvalidArgumentException("Strategy {$name} is not supported."),
         };
     }

--- a/app/Http/Controllers/Fapi/ChallengeController.php
+++ b/app/Http/Controllers/Fapi/ChallengeController.php
@@ -19,6 +19,7 @@ use App\Models\Client;
 use App\Models\EmailAddress;
 use App\Models\EmailTemplate;
 use App\Models\Environment;
+use App\Models\PhoneNumber;
 use App\Models\Session;
 use App\Models\SignInAttempt;
 use App\Models\SignUpAttempt;
@@ -839,6 +840,16 @@ final class ChallengeController
             ->exists();
         if ($hasUnspent) {
             $strategies[] = Verification::STRATEGY_BACKUP_CODE;
+        }
+
+        $hasReservedPhone = PhoneNumber::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->where('reserved_for_second_factor', true)
+            ->exists();
+        if ($hasReservedPhone) {
+            $strategies[] = Verification::STRATEGY_PHONE_CODE;
         }
 
         return $strategies;

--- a/app/Http/Resources/SignInResource.php
+++ b/app/Http/Resources/SignInResource.php
@@ -6,6 +6,7 @@ namespace App\Http\Resources;
 
 use App\Models\BackupCode;
 use App\Models\EmailAddress;
+use App\Models\PhoneNumber;
 use App\Models\SignInAttempt;
 use App\Models\TotpSecret;
 use App\Models\User;
@@ -106,6 +107,16 @@ final class SignInResource
             ->exists();
         if ($hasUnspent) {
             $strategies[] = Verification::STRATEGY_BACKUP_CODE;
+        }
+
+        $hasReservedPhone = PhoneNumber::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->where('reserved_for_second_factor', true)
+            ->exists();
+        if ($hasReservedPhone) {
+            $strategies[] = Verification::STRATEGY_PHONE_CODE;
         }
 
         return $strategies;

--- a/tests/Feature/Auth/Strategies/PhoneCodeStrategyTest.php
+++ b/tests/Feature/Auth/Strategies/PhoneCodeStrategyTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Strategies\PhoneCodeStrategy;
+use App\Http\Resources\SignInResource;
+use App\Jobs\Sms\SendVerificationSms;
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\PhoneNumber;
+use App\Models\Project;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Models\VerificationCode;
+use Illuminate\Support\Facades\Queue;
+
+function makeClientForPhoneCode(Environment $env): string
+{
+    return Client::create(['environment_id' => $env->id])->id;
+}
+
+function envForPhoneCode(): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-pcs']);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'pcs',
+        'routing_label' => 'pcs',
+    ]);
+}
+
+function makeUserWithVerifiedPhone(Environment $env, string $phoneNumber, bool $reservedForSecondFactor = true): array
+{
+    $user = User::create(['environment_id' => $env->id]);
+    EmailAddress::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'email_address' => 'u-'.uniqid().'@example.com',
+        'is_primary' => true,
+    ]);
+    $phone = PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => $phoneNumber,
+        'reserved_for_second_factor' => $reservedForSecondFactor,
+    ]);
+    $phone->markVerified();
+
+    return ['user' => $user, 'phone' => $phone->fresh()];
+}
+
+it('prepare() dispatches SendVerificationSms and returns the verification', function (): void {
+    Queue::fake();
+    $env = envForPhoneCode();
+    $f = makeUserWithVerifiedPhone($env, '+15551230001');
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => makeClientForPhoneCode($env),
+        'identifier' => $f['user']->emailAddresses()->first()->email_address,
+        'status' => SignInAttempt::STATUS_NEEDS_SECOND_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+
+    $result = app(PhoneCodeStrategy::class)->prepare($attempt, []);
+
+    expect($result->success)->toBeTrue();
+    expect($result->verification)->not->toBeNull();
+    expect($result->verification->strategy)->toBe(Verification::STRATEGY_PHONE_CODE);
+    Queue::assertPushed(SendVerificationSms::class);
+});
+
+it('attempt() succeeds with the right code and verifies the verification', function (): void {
+    $env = envForPhoneCode();
+    $f = makeUserWithVerifiedPhone($env, '+15551230002');
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => makeClientForPhoneCode($env),
+        'identifier' => $f['user']->emailAddresses()->first()->email_address,
+        'status' => SignInAttempt::STATUS_NEEDS_SECOND_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+    $verification = Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'verifiable_type' => $f['phone']->getMorphClass(),
+        'verifiable_id' => $f['phone']->id,
+        'strategy' => Verification::STRATEGY_PHONE_CODE,
+        'status' => Verification::STATUS_UNVERIFIED,
+        'attempts' => 0,
+        'expire_at' => now()->addMinutes(10),
+    ]);
+    $known = '424242';
+    VerificationCode::query()->create([
+        'verification_id' => $verification->id,
+        'code_hash' => hash('sha256', $known),
+        'purpose' => PhoneCodeStrategy::PURPOSE,
+        'expires_at' => now()->addMinutes(10),
+    ]);
+
+    $result = app(PhoneCodeStrategy::class)->attempt($attempt, ['code' => $known, 'verification' => $verification]);
+
+    expect($result->success)->toBeTrue();
+    expect($result->user?->id)->toBe($f['user']->id);
+    expect($verification->fresh()->status)->toBe(Verification::STATUS_VERIFIED);
+});
+
+it('attempt() returns form_code_incorrect on the wrong code', function (): void {
+    $env = envForPhoneCode();
+    $f = makeUserWithVerifiedPhone($env, '+15551230003');
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => makeClientForPhoneCode($env),
+        'identifier' => $f['user']->emailAddresses()->first()->email_address,
+        'status' => SignInAttempt::STATUS_NEEDS_SECOND_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+    $verification = Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'verifiable_type' => $f['phone']->getMorphClass(),
+        'verifiable_id' => $f['phone']->id,
+        'strategy' => Verification::STRATEGY_PHONE_CODE,
+        'status' => Verification::STATUS_UNVERIFIED,
+        'attempts' => 0,
+        'expire_at' => now()->addMinutes(10),
+    ]);
+    VerificationCode::query()->create([
+        'verification_id' => $verification->id,
+        'code_hash' => hash('sha256', 'right-code'),
+        'purpose' => PhoneCodeStrategy::PURPOSE,
+        'expires_at' => now()->addMinutes(10),
+    ]);
+
+    $result = app(PhoneCodeStrategy::class)->attempt($attempt, ['code' => 'wrong', 'verification' => $verification]);
+
+    expect($result->success)->toBeFalse();
+    expect($result->errorCode)->toBe('form_code_incorrect');
+});
+
+it('prepare() falls back to the user-resolved reserved phone when phone_number_id is omitted', function (): void {
+    Queue::fake();
+    $env = envForPhoneCode();
+    $f = makeUserWithVerifiedPhone($env, '+15551230004');
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => makeClientForPhoneCode($env),
+        'identifier' => $f['user']->emailAddresses()->first()->email_address,
+        'status' => SignInAttempt::STATUS_NEEDS_SECOND_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+
+    $result = app(PhoneCodeStrategy::class)->prepare($attempt, []);
+
+    expect($result->success)->toBeTrue();
+    expect($result->verification?->verifiable_id)->toBe($f['phone']->id);
+});
+
+it('prepare() returns phone_not_found when the user has no reserved-for-second-factor phone', function (): void {
+    $env = envForPhoneCode();
+    $f = makeUserWithVerifiedPhone($env, '+15551230005', reservedForSecondFactor: false);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => makeClientForPhoneCode($env),
+        'identifier' => $f['user']->emailAddresses()->first()->email_address,
+        'status' => SignInAttempt::STATUS_NEEDS_SECOND_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+
+    $result = app(PhoneCodeStrategy::class)->prepare($attempt, []);
+
+    expect($result->success)->toBeFalse();
+    expect($result->errorCode)->toBe('phone_not_found');
+});
+
+it('prepare() with phone_number_id targets a specific row (sign-up flow)', function (): void {
+    Queue::fake();
+    $env = envForPhoneCode();
+    $user = User::create(['environment_id' => $env->id]);
+    $phone = PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15551230006',
+    ]);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => makeClientForPhoneCode($env),
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+
+    $result = app(PhoneCodeStrategy::class)->prepare($attempt, ['phone_number_id' => $phone->id]);
+
+    expect($result->success)->toBeTrue();
+    expect($result->verification?->verifiable_id)->toBe($phone->id);
+});
+
+it('attempt() flips an unverified phone to verified on first-factor success', function (): void {
+    $env = envForPhoneCode();
+    $user = User::create(['environment_id' => $env->id]);
+    $phone = PhoneNumber::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15551230007',
+    ]);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => makeClientForPhoneCode($env),
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+    $verification = Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'verifiable_type' => $phone->getMorphClass(),
+        'verifiable_id' => $phone->id,
+        'strategy' => Verification::STRATEGY_PHONE_CODE,
+        'status' => Verification::STATUS_UNVERIFIED,
+        'attempts' => 0,
+        'expire_at' => now()->addMinutes(10),
+    ]);
+    $known = '424242';
+    VerificationCode::query()->create([
+        'verification_id' => $verification->id,
+        'code_hash' => hash('sha256', $known),
+        'purpose' => PhoneCodeStrategy::PURPOSE,
+        'expires_at' => now()->addMinutes(10),
+    ]);
+
+    $result = app(PhoneCodeStrategy::class)->attempt($attempt, ['code' => $known, 'verification' => $verification]);
+
+    expect($result->success)->toBeTrue();
+    expect($phone->fresh()->verified_at)->not->toBeNull();
+});
+
+it('SignInResource exposes phone_code as a second factor when the user has a reserved phone', function (): void {
+    $env = envForPhoneCode();
+    $f = makeUserWithVerifiedPhone($env, '+15551230008');
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => makeClientForPhoneCode($env),
+        'identifier' => $f['user']->emailAddresses()->first()->email_address,
+        'status' => SignInAttempt::STATUS_NEEDS_SECOND_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+
+    $shape = SignInResource::from($attempt);
+
+    expect($shape['supported_strategies'])->toContain('phone_code');
+});


### PR DESCRIPTION
Closes #128.

## Summary

- New `PhoneCodeStrategy`: `prepare()` resolves the target phone (explicit `phone_number_id` for sign-up flows, or the user's reserved-for-second-factor verified phone for MFA), starts a `Verification`, mints a 6-digit code, dispatches `SendVerificationSms`. `attempt()` consumes the code via `VerificationManager::attempt` (replay-protected, 5-attempt cap, 10-minute TTL); first-factor success on an unverified phone flips `verified_at` so the row counts going forward.
- Wired into `StrategyResolver::resolve('phone_code')`.
- `SignInResource::supportedStrategies()` and `ChallengeController::signInSecondFactorStrategies()` append `phone_code` when the user has a verified `reserved_for_second_factor` PhoneNumber. Strict-semantic — env-level `multi_factor.phone_code.enabled` gates *enrolment*, not enforcement (mirrors v0.3 MFA precedent).

## Test plan

- [x] `vendor/bin/pest --filter PhoneCodeStrategy` — 8 / 8 passing
- [x] `vendor/bin/pest` — 604 / 604 passing
- [x] `vendor/bin/pint --test` — clean
- [x] OpenAPI contract validation passes