### PR TITLE
AU-14: Dashboard Configure SMS subsection + Phone attribute toggle

### DIFF
--- a/app/Http/Controllers/Dashboard/DashboardController.php
+++ b/app/Http/Controllers/Dashboard/DashboardController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Dashboard;
 
+use App\Jobs\Sms\SendSmsTemplate;
 use App\Models\AllowlistIdentifier;
 use App\Models\ApiKey;
 use App\Models\BlocklistIdentifier;
@@ -19,6 +20,7 @@ use App\Models\Permission;
 use App\Models\Project;
 use App\Models\Role;
 use App\Models\Session;
+use App\Models\SmsTemplate;
 use App\Models\User;
 use App\Models\WebhookDelivery;
 use App\Models\WebhookEndpoint;
@@ -247,13 +249,41 @@ final class DashboardController
             return redirect(Url::dashboardPathPrefix().'/create-project');
         }
 
+        $userSettings = is_array($env->user_settings) ? $env->user_settings : [];
+        $smsCfg = is_array($userSettings['sms'] ?? null) ? $userSettings['sms'] : [];
+        $attributes = is_array($userSettings['attributes'] ?? null) ? $userSettings['attributes'] : [];
+        $smsTemplates = SmsTemplate::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->orderBy('slug')
+            ->get(['id', 'slug', 'body', 'delivered_by_us', 'from_number_override']);
+
         return Inertia::render('Dashboard/Configure', [
             'section' => $section,
-            'user_settings' => is_array($env->user_settings) ? $env->user_settings : [],
+            'user_settings' => $userSettings,
             'allowed_origins' => is_array($env->allowed_origins) ? $env->allowed_origins : [],
             'appearance' => is_array($env->appearance) ? $env->appearance : [],
             'signup_mode' => $env->signup_mode,
-            'multi_factor' => MultiFactorSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : [])->toArray(),
+            'multi_factor' => MultiFactorSettings::fromUserSettings($userSettings)->toArray(),
+            'attributes' => [
+                'phone_number' => is_string($attributes['phone_number'] ?? null)
+                    ? (string) $attributes['phone_number']
+                    : 'off',
+            ],
+            'sms' => [
+                'driver' => $smsCfg['driver'] ?? null,
+                'from_number' => $smsCfg['from_number'] ?? null,
+                'twilio_account_sid' => $smsCfg['twilio']['account_sid'] ?? null,
+                'twilio_auth_token_set' => isset($smsCfg['twilio']['auth_token']) && $smsCfg['twilio']['auth_token'] !== '',
+                'vonage_api_key' => $smsCfg['vonage']['api_key'] ?? null,
+                'vonage_api_secret_set' => isset($smsCfg['vonage']['api_secret']) && $smsCfg['vonage']['api_secret'] !== '',
+            ],
+            'sms_templates' => $smsTemplates->map(fn (SmsTemplate $t) => [
+                'id' => $t->id,
+                'slug' => $t->slug,
+                'body' => $t->body,
+                'delivered_by_us' => (bool) $t->delivered_by_us,
+                'from_number_override' => $t->from_number_override,
+            ])->all(),
         ]);
     }
 
@@ -287,6 +317,131 @@ final class DashboardController
 
         return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/multi-factor")
             ->with('multi_factor_saved', true);
+    }
+
+    public function updateAttributes(Request $request, string $project_slug, string $env_slug): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+
+        $request->validate([
+            'phone_number' => ['required', 'in:required,optional,off'],
+        ]);
+
+        $userSettings = is_array($env->user_settings) ? $env->user_settings : [];
+        $attributes = is_array($userSettings['attributes'] ?? null) ? $userSettings['attributes'] : [];
+        $attributes['phone_number'] = (string) $request->input('phone_number');
+        $userSettings['attributes'] = $attributes;
+        $env->forceFill(['user_settings' => $userSettings])->save();
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/attributes")
+            ->with('attributes_saved', true);
+    }
+
+    public function updateSms(Request $request, string $project_slug, string $env_slug): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+
+        $request->validate([
+            'driver' => ['nullable', 'in:twilio,vonage'],
+            'from_number' => ['nullable', 'string', 'max:32'],
+            'twilio.account_sid' => ['nullable', 'string', 'max:255'],
+            'twilio.auth_token' => ['nullable', 'string', 'max:255'],
+            'vonage.api_key' => ['nullable', 'string', 'max:255'],
+            'vonage.api_secret' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $userSettings = is_array($env->user_settings) ? $env->user_settings : [];
+        $sms = is_array($userSettings['sms'] ?? null) ? $userSettings['sms'] : [];
+
+        $sms['driver'] = $request->input('driver');
+        $sms['from_number'] = $request->input('from_number');
+
+        // Credential write-only semantics: empty / null leaves the stored value
+        // untouched (so the UI can render `•••• rotate` placeholders without
+        // wiping the secret on every save). Operators that need to clear a
+        // secret should rotate via the BAPI `Environment` patch.
+        foreach (['twilio' => ['account_sid', 'auth_token'], 'vonage' => ['api_key', 'api_secret']] as $vendor => $keys) {
+            $vendorBlock = is_array($sms[$vendor] ?? null) ? $sms[$vendor] : [];
+            foreach ($keys as $field) {
+                if (! $request->has("{$vendor}.{$field}")) {
+                    continue;
+                }
+                $value = $request->input("{$vendor}.{$field}");
+                if ($value === '' || $value === null) {
+                    continue;
+                }
+                $vendorBlock[$field] = $value;
+            }
+            if ($vendorBlock !== []) {
+                $sms[$vendor] = $vendorBlock;
+            }
+        }
+
+        $userSettings['sms'] = $sms;
+        $env->forceFill(['user_settings' => $userSettings])->save();
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/sms")
+            ->with('sms_saved', true);
+    }
+
+    public function sendTestSms(Request $request, string $project_slug, string $env_slug): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+
+        $request->validate([
+            'to_number' => ['required', 'string', 'regex:/^\+[1-9][0-9]{7,14}$/'],
+        ]);
+
+        SendSmsTemplate::dispatch(
+            $env->id,
+            SmsTemplate::SLUG_VERIFICATION_CODE,
+            (string) $request->input('to_number'),
+            ['otp_code' => '424242', 'expiry_minutes' => 10],
+        );
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/sms")
+            ->with('sms_test_dispatched', true);
+    }
+
+    public function updateSmsTemplate(Request $request, string $project_slug, string $env_slug, string $slug): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+
+        $request->validate([
+            'body' => ['nullable', 'string', 'max:1600'],
+            'delivered_by_us' => ['nullable', 'boolean'],
+            'from_number_override' => ['nullable', 'string', 'max:32'],
+        ]);
+
+        $row = SmsTemplate::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('slug', $slug)
+            ->first();
+        if ($row === null) {
+            return redirect()->back()->withErrors(['slug' => 'Template not found.']);
+        }
+
+        $patch = array_filter([
+            'body' => $request->input('body'),
+            'delivered_by_us' => $request->has('delivered_by_us') ? $request->boolean('delivered_by_us') : null,
+            'from_number_override' => $request->input('from_number_override'),
+        ], static fn ($v) => $v !== null);
+        $row->forceFill($patch)->save();
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/sms")
+            ->with('sms_template_saved', true);
     }
 
     public function emailTemplates(string $project_slug, string $env_slug): InertiaResponse|RedirectResponse

--- a/resources/js/dashboard/pages/Configure.tsx
+++ b/resources/js/dashboard/pages/Configure.tsx
@@ -4,6 +4,28 @@ import { useDashboard, useDashboardUrl } from '../shared'
 type MultiFactorSettings = {
     totp: { enabled: boolean }
     backup_codes: { enabled: boolean; default_count: number }
+    phone_code?: { enabled: boolean }
+}
+
+type AttributesSettings = {
+    phone_number: 'required' | 'optional' | 'off'
+}
+
+type SmsSettings = {
+    driver: 'twilio' | 'vonage' | null
+    from_number: string | null
+    twilio_account_sid: string | null
+    twilio_auth_token_set: boolean
+    vonage_api_key: string | null
+    vonage_api_secret_set: boolean
+}
+
+type SmsTemplate = {
+    id: string
+    slug: string
+    body: string
+    delivered_by_us: boolean
+    from_number_override: string | null
 }
 
 type Props = {
@@ -13,11 +35,15 @@ type Props = {
     appearance: Record<string, unknown>
     signup_mode: string
     multi_factor: MultiFactorSettings
+    attributes: AttributesSettings
+    sms: SmsSettings
+    sms_templates: SmsTemplate[]
 }
 
 const SECTIONS = [
     { slug: 'attributes', label: 'Attributes' },
     { slug: 'multi-factor', label: 'Multi-factor' },
+    { slug: 'sms', label: 'SMS' },
 ] as const
 
 export default function Configure(props: Props) {
@@ -47,22 +73,63 @@ export default function Configure(props: Props) {
                     </Link>
                 ))}
             </nav>
-            {props.section === 'multi-factor'
-                ? <MultiFactorSection multiFactor={props.multi_factor} />
-                : <AttributesPlaceholder section={props.section} userSettings={props.user_settings} signupMode={props.signup_mode} />}
+            {props.section === 'multi-factor' && <MultiFactorSection multiFactor={props.multi_factor} />}
+            {props.section === 'sms' && <SmsSection sms={props.sms} smsTemplates={props.sms_templates} />}
+            {props.section === 'attributes' && <AttributesSection attributes={props.attributes} signupMode={props.signup_mode} />}
+            {!['multi-factor', 'sms', 'attributes'].includes(props.section) && (
+                <pre style={{ background: '#f1f5f9', padding: 12, borderRadius: 6 }}>
+                    {JSON.stringify(props.user_settings, null, 2)}
+                </pre>
+            )}
         </div>
     )
 }
 
-function AttributesPlaceholder({ section, userSettings, signupMode }: { section: string; userSettings: Record<string, unknown>; signupMode: string }) {
+function AttributesSection({ attributes, signupMode }: { attributes: AttributesSettings; signupMode: string }) {
+    const url = useDashboardUrl()
+    const { active_project, active_environment } = useDashboard()
+    const { props: pageProps } = usePage<{ flash?: { attributes_saved?: boolean } }>()
+    const form = useForm({ phone_number: attributes.phone_number })
+
+    if (!active_project || !active_environment) {
+        return <p>No active environment.</p>
+    }
+    const action = url(`/${active_project.slug}/${active_environment.slug}/configure/attributes`)
+
     return (
-        <>
-            <h2>{section}</h2>
+        <section>
+            <h2>Attributes</h2>
             <p>Sign-up mode: <strong>{signupMode}</strong></p>
-            <pre style={{ background: '#f1f5f9', padding: 12, borderRadius: 6 }}>
-                {JSON.stringify(userSettings, null, 2)}
-            </pre>
-        </>
+            {pageProps.flash?.attributes_saved && (
+                <div style={{ padding: 12, background: '#dcfce7', borderRadius: 6, marginBottom: 16 }}>Saved.</div>
+            )}
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault()
+                    form.patch(action, { preserveScroll: true })
+                }}
+            >
+                <fieldset style={{ marginBottom: 16, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+                    <legend><strong>Phone number</strong></legend>
+                    {(['required', 'optional', 'off'] as const).map(opt => (
+                        <label key={opt} style={{ display: 'block', marginBottom: 4 }}>
+                            <input
+                                type="radio"
+                                name="phone_number"
+                                value={opt}
+                                checked={form.data.phone_number === opt}
+                                onChange={() => form.setData('phone_number', opt)}
+                                style={{ marginRight: 6 }}
+                            />
+                            {opt}
+                        </label>
+                    ))}
+                </fieldset>
+                <button type="submit" disabled={form.processing}>
+                    {form.processing ? 'Saving…' : 'Save'}
+                </button>
+            </form>
+        </section>
     )
 }
 
@@ -138,5 +205,221 @@ function MultiFactorSection({ multiFactor }: { multiFactor: MultiFactorSettings 
                 </button>
             </form>
         </section>
+    )
+}
+
+function SmsSection({ sms, smsTemplates }: { sms: SmsSettings; smsTemplates: SmsTemplate[] }) {
+    const url = useDashboardUrl()
+    const { active_project, active_environment } = useDashboard()
+    const { props: pageProps } = usePage<{ flash?: { sms_saved?: boolean; sms_test_dispatched?: boolean; sms_template_saved?: boolean } }>()
+
+    const settingsForm = useForm({
+        driver: sms.driver ?? '',
+        from_number: sms.from_number ?? '',
+        twilio: {
+            account_sid: sms.twilio_account_sid ?? '',
+            auth_token: '',
+        },
+        vonage: {
+            api_key: sms.vonage_api_key ?? '',
+            api_secret: '',
+        },
+    })
+
+    const testForm = useForm({ to_number: '' })
+
+    if (!active_project || !active_environment) {
+        return <p>No active environment.</p>
+    }
+    const base = `/${active_project.slug}/${active_environment.slug}/configure`
+
+    return (
+        <section>
+            <h2>SMS</h2>
+            <p>Outbound SMS provider for phone-number verification + phone-MFA codes.</p>
+            {pageProps.flash?.sms_saved && (
+                <div style={{ padding: 12, background: '#dcfce7', borderRadius: 6, marginBottom: 16 }}>Saved.</div>
+            )}
+            {pageProps.flash?.sms_test_dispatched && (
+                <div style={{ padding: 12, background: '#dbeafe', borderRadius: 6, marginBottom: 16 }}>Test SMS dispatched.</div>
+            )}
+
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault()
+                    settingsForm.patch(url(`${base}/sms`), { preserveScroll: true })
+                }}
+            >
+                <fieldset style={{ marginBottom: 16, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+                    <legend><strong>Driver</strong></legend>
+                    {(['', 'twilio', 'vonage'] as const).map(opt => (
+                        <label key={opt || 'null'} style={{ display: 'block', marginBottom: 4 }}>
+                            <input
+                                type="radio"
+                                name="driver"
+                                value={opt}
+                                checked={settingsForm.data.driver === opt}
+                                onChange={() => settingsForm.setData('driver', opt)}
+                                style={{ marginRight: 6 }}
+                            />
+                            {opt === '' ? 'Disabled (no-op)' : opt}
+                        </label>
+                    ))}
+                </fieldset>
+
+                <label style={{ display: 'block', marginBottom: 16 }}>
+                    From number (E.164)
+                    <input
+                        type="text"
+                        value={settingsForm.data.from_number}
+                        onChange={(e) => settingsForm.setData('from_number', e.target.value)}
+                        placeholder="+15555550100"
+                        style={{ display: 'block', marginTop: 4, padding: 6, width: 240 }}
+                    />
+                </label>
+
+                {settingsForm.data.driver === 'twilio' && (
+                    <fieldset style={{ marginBottom: 16, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+                        <legend><strong>Twilio</strong></legend>
+                        <label style={{ display: 'block', marginBottom: 8 }}>
+                            Account SID
+                            <input
+                                type="text"
+                                value={settingsForm.data.twilio.account_sid}
+                                onChange={(e) => settingsForm.setData('twilio', { ...settingsForm.data.twilio, account_sid: e.target.value })}
+                                style={{ display: 'block', marginTop: 4, padding: 6, width: 360 }}
+                            />
+                        </label>
+                        <label style={{ display: 'block' }}>
+                            Auth token {sms.twilio_auth_token_set && <span style={{ color: '#64748b', fontSize: 12 }}>(••••, leave blank to keep)</span>}
+                            <input
+                                type="password"
+                                value={settingsForm.data.twilio.auth_token}
+                                onChange={(e) => settingsForm.setData('twilio', { ...settingsForm.data.twilio, auth_token: e.target.value })}
+                                placeholder={sms.twilio_auth_token_set ? '•••• rotate' : 'auth token'}
+                                style={{ display: 'block', marginTop: 4, padding: 6, width: 360 }}
+                            />
+                        </label>
+                    </fieldset>
+                )}
+
+                {settingsForm.data.driver === 'vonage' && (
+                    <fieldset style={{ marginBottom: 16, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+                        <legend><strong>Vonage</strong></legend>
+                        <label style={{ display: 'block', marginBottom: 8 }}>
+                            API key
+                            <input
+                                type="text"
+                                value={settingsForm.data.vonage.api_key}
+                                onChange={(e) => settingsForm.setData('vonage', { ...settingsForm.data.vonage, api_key: e.target.value })}
+                                style={{ display: 'block', marginTop: 4, padding: 6, width: 360 }}
+                            />
+                        </label>
+                        <label style={{ display: 'block' }}>
+                            API secret {sms.vonage_api_secret_set && <span style={{ color: '#64748b', fontSize: 12 }}>(••••, leave blank to keep)</span>}
+                            <input
+                                type="password"
+                                value={settingsForm.data.vonage.api_secret}
+                                onChange={(e) => settingsForm.setData('vonage', { ...settingsForm.data.vonage, api_secret: e.target.value })}
+                                placeholder={sms.vonage_api_secret_set ? '•••• rotate' : 'api secret'}
+                                style={{ display: 'block', marginTop: 4, padding: 6, width: 360 }}
+                            />
+                        </label>
+                    </fieldset>
+                )}
+
+                <button type="submit" disabled={settingsForm.processing}>
+                    {settingsForm.processing ? 'Saving…' : 'Save'}
+                </button>
+            </form>
+
+            <fieldset style={{ marginTop: 24, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+                <legend><strong>Send test SMS</strong></legend>
+                <form
+                    onSubmit={(e) => {
+                        e.preventDefault()
+                        testForm.post(url(`${base}/sms/test`), { preserveScroll: true, onSuccess: () => testForm.reset() })
+                    }}
+                >
+                    <label style={{ display: 'block', marginBottom: 8 }}>
+                        Recipient (E.164)
+                        <input
+                            type="text"
+                            value={testForm.data.to_number}
+                            onChange={(e) => testForm.setData('to_number', e.target.value)}
+                            placeholder="+15555550100"
+                            style={{ display: 'block', marginTop: 4, padding: 6, width: 240 }}
+                        />
+                    </label>
+                    <button type="submit" disabled={testForm.processing}>
+                        {testForm.processing ? 'Sending…' : 'Send test'}
+                    </button>
+                </form>
+            </fieldset>
+
+            <h3 style={{ marginTop: 24 }}>Templates</h3>
+            {smsTemplates.map(t => (
+                <SmsTemplateRow key={t.id} template={t} />
+            ))}
+        </section>
+    )
+}
+
+function SmsTemplateRow({ template }: { template: SmsTemplate }) {
+    const url = useDashboardUrl()
+    const { active_project, active_environment } = useDashboard()
+    const form = useForm({
+        body: template.body,
+        delivered_by_us: template.delivered_by_us,
+        from_number_override: template.from_number_override ?? '',
+    })
+
+    if (!active_project || !active_environment) {
+        return null
+    }
+    const action = url(`/${active_project.slug}/${active_environment.slug}/configure/sms-templates/${template.slug}`)
+
+    return (
+        <details style={{ marginBottom: 12, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+            <summary><strong>{template.slug}</strong></summary>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault()
+                    form.patch(action, { preserveScroll: true })
+                }}
+                style={{ marginTop: 8 }}
+            >
+                <label style={{ display: 'block', marginBottom: 8 }}>
+                    Body (Liquid)
+                    <textarea
+                        value={form.data.body}
+                        onChange={(e) => form.setData('body', e.target.value)}
+                        rows={4}
+                        style={{ display: 'block', marginTop: 4, padding: 6, width: '100%' }}
+                    />
+                </label>
+                <label style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 8 }}>
+                    <input
+                        type="checkbox"
+                        checked={form.data.delivered_by_us}
+                        onChange={(e) => form.setData('delivered_by_us', e.target.checked)}
+                    />
+                    Send via the configured driver (otherwise emit `sms.created` webhook only).
+                </label>
+                <label style={{ display: 'block', marginBottom: 8 }}>
+                    From number override
+                    <input
+                        type="text"
+                        value={form.data.from_number_override}
+                        onChange={(e) => form.setData('from_number_override', e.target.value)}
+                        placeholder="+1…"
+                        style={{ display: 'block', marginTop: 4, padding: 6, width: 240 }}
+                    />
+                </label>
+                <button type="submit" disabled={form.processing}>
+                    {form.processing ? 'Saving…' : 'Save'}
+                </button>
+            </form>
+        </details>
     )
 }

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -40,6 +40,10 @@ Route::prefix('{project_slug}/{env_slug}')->group(function (): void {
     Route::get('/blocklist', [DashboardController::class, 'blocklist'])->name('dashboard.blocklist');
     Route::get('/configure/{section?}', [DashboardController::class, 'configure'])->name('dashboard.configure');
     Route::patch('/configure/multi-factor', [DashboardController::class, 'updateMultiFactor'])->name('dashboard.configure.multi_factor.update');
+    Route::patch('/configure/attributes', [DashboardController::class, 'updateAttributes'])->name('dashboard.configure.attributes.update');
+    Route::patch('/configure/sms', [DashboardController::class, 'updateSms'])->name('dashboard.configure.sms.update');
+    Route::post('/configure/sms/test', [DashboardController::class, 'sendTestSms'])->name('dashboard.configure.sms.test');
+    Route::patch('/configure/sms-templates/{slug}', [DashboardController::class, 'updateSmsTemplate'])->name('dashboard.configure.sms_templates.update');
     Route::get('/email-templates', [DashboardController::class, 'emailTemplates'])->name('dashboard.email_templates');
 
     Route::get('/api-keys', [DashboardController::class, 'apiKeys'])->name('dashboard.api_keys');

--- a/tests/Feature/Http/Dashboard/DashboardTest.php
+++ b/tests/Feature/Http/Dashboard/DashboardTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Jobs\Sms\SendSmsTemplate;
 use App\Models\ApiKey;
 use App\Models\Client;
 use App\Models\EmailAddress;
@@ -11,11 +12,13 @@ use App\Models\OrganizationMembership;
 use App\Models\Project;
 use App\Models\Role;
 use App\Models\Session;
+use App\Models\SmsTemplate;
 use App\Models\User;
 use App\Models\WebhookEndpoint;
 use App\Services\Keys\SigningKeyGenerator;
 use App\Services\Sessions\SessionTokenIssuer;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Route;
 
 function reloadDashboardRoutes(): void
@@ -391,4 +394,172 @@ it('PATCH /configure/multi-factor rejects default_count outside 4..24 with valid
     $r->assertStatus(422);
     $errors = $r->json('errors');
     expect($errors)->toHaveKey('backup_codes.default_count');
+});
+
+it('PATCH /configure/attributes writes phone_number tri-state through to user_settings.attributes', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->patch('http://dashboard.authn.local/acme/production/configure/attributes', [
+            'phone_number' => 'optional',
+        ]);
+
+    $r->assertRedirect();
+    expect($env->fresh()->user_settings['attributes']['phone_number'])->toBe('optional');
+});
+
+it('PATCH /configure/attributes rejects unknown phone_number values', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->patch('http://dashboard.authn.local/acme/production/configure/attributes', [
+            'phone_number' => 'maybe',
+        ]);
+
+    $r->assertStatus(422);
+});
+
+it('PATCH /configure/sms writes driver + from_number + credentials through with rotate semantics', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->patch('http://dashboard.authn.local/acme/production/configure/sms', [
+            'driver' => 'twilio',
+            'from_number' => '+15555550100',
+            'twilio' => ['account_sid' => 'AC123', 'auth_token' => 'tok-1'],
+        ]);
+
+    $r->assertRedirect();
+    $sms = $env->fresh()->user_settings['sms'];
+    expect($sms['driver'])->toBe('twilio');
+    expect($sms['from_number'])->toBe('+15555550100');
+    expect($sms['twilio']['account_sid'])->toBe('AC123');
+    expect($sms['twilio']['auth_token'])->toBe('tok-1');
+
+    // Empty auth_token leaves the stored value untouched.
+    $r2 = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->patch('http://dashboard.authn.local/acme/production/configure/sms', [
+            'driver' => 'twilio',
+            'from_number' => '+15555550100',
+            'twilio' => ['account_sid' => 'AC123', 'auth_token' => ''],
+        ]);
+    $r2->assertRedirect();
+    expect($env->fresh()->user_settings['sms']['twilio']['auth_token'])->toBe('tok-1');
+});
+
+it('POST /configure/sms/test dispatches a SendSmsTemplate job', function (): void {
+    Queue::fake();
+
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->post('http://dashboard.authn.local/acme/production/configure/sms/test', [
+            'to_number' => '+15555550100',
+        ]);
+
+    $r->assertRedirect();
+    Queue::assertPushed(SendSmsTemplate::class);
+});
+
+it('POST /configure/sms/test 422s on non-E.164 input', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->post('http://dashboard.authn.local/acme/production/configure/sms/test', [
+            'to_number' => 'bad',
+        ]);
+
+    $r->assertStatus(422);
+});
+
+it('PATCH /configure/sms-templates/{slug} updates the template body', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->patch('http://dashboard.authn.local/acme/production/configure/sms-templates/verification_code', [
+            'body' => 'Custom: {{otp_code}}',
+        ]);
+
+    $r->assertRedirect();
+    $row = SmsTemplate::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('slug', 'verification_code')
+        ->firstOrFail();
+    expect($row->body)->toBe('Custom: {{otp_code}}');
+});
+
+it('Configure renders the sms section with seeded templates + null driver default', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->get('http://dashboard.authn.local/acme/production/configure/sms');
+
+    $r->assertOk()
+        ->assertJsonPath('component', 'Dashboard/Configure')
+        ->assertJsonPath('props.section', 'sms')
+        ->assertJsonPath('props.sms.driver', null)
+        ->assertJsonCount(3, 'props.sms_templates');
 });


### PR DESCRIPTION
Closes #133.

## Summary

- Four new `DashboardController` handlers:
  - `updateAttributes` writes the phone-number tri-state (`required` / `optional` / `off`) to `Environment.user_settings.attributes.phone_number`.
  - `updateSms` writes the `Environment.sms` block — driver picker (twilio / vonage / null), `from_number`, per-driver credentials with write-only rotate semantics (empty/null leaves the stored secret untouched).
  - `sendTestSms` dispatches a one-off `SendSmsTemplate` job; UI shows a toast on dispatch.
  - `updateSmsTemplate` patches a single `SmsTemplate` row by slug.
- Routes registered under `/configure/{attributes,sms,sms-templates/{slug}}` in `routes/dashboard.php`, plus `/configure/sms/test`.
- `Configure.tsx` extended with new SMS + Attributes sections, tab nav appended.

## Test plan

- [x] `vendor/bin/pest tests/Feature/Http/Dashboard/DashboardTest.php` — 19 / 19 passing
- [x] `vendor/bin/pest` — 614 / 614 passing
- [x] `vendor/bin/pint --test` — clean
- [x] `npm run build` — clean (Configure-*.js 11.00 kB / gzip 2.62 kB)