### PR TITLE
AU-13: Dashboard Configure → Social providers subsection

### DIFF
--- a/app/Http/Controllers/Dashboard/DashboardController.php
+++ b/app/Http/Controllers/Dashboard/DashboardController.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Dashboard;
 
+use App\Auth\Oauth\Exceptions\OauthDiscoveryFailedException;
+use App\Auth\Oauth\OauthProviderResolver;
+use App\Auth\Oauth\PresetRegistry;
 use App\Jobs\Sms\SendSmsTemplate;
 use App\Models\AllowlistIdentifier;
 use App\Models\ApiKey;
 use App\Models\BlocklistIdentifier;
 use App\Models\EmailTemplate;
 use App\Models\Environment;
+use App\Models\ExternalAccount;
 use App\Models\Invitation;
+use App\Models\OauthProvider;
 use App\Models\Organization;
 use App\Models\OrganizationDomain;
 use App\Models\OrganizationInvitation;
@@ -28,12 +33,16 @@ use App\Services\Keys\KeyGenerator;
 use App\Settings\MultiFactorSettings;
 use App\Support\RoutingLabel;
 use App\Support\Url;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
+use Throwable;
 
 /**
  * Dashboard pages — Inertia + React, server-side data prep without proxying
@@ -46,7 +55,11 @@ use Inertia\Response as InertiaResponse;
  */
 final class DashboardController
 {
-    public function __construct(private readonly KeyGenerator $keyGenerator) {}
+    public function __construct(
+        private readonly KeyGenerator $keyGenerator,
+        private readonly OauthProviderResolver $oauthResolver,
+        private readonly PresetRegistry $oauthPresets,
+    ) {}
 
     public function home(): InertiaResponse|RedirectResponse
     {
@@ -256,6 +269,11 @@ final class DashboardController
             ->where('environment_id', $env->id)
             ->orderBy('slug')
             ->get(['id', 'slug', 'body', 'delivered_by_us', 'from_number_override']);
+        $oauthRows = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->orderBy('provider_kind')
+            ->orderBy('provider_key')
+            ->get();
 
         return Inertia::render('Dashboard/Configure', [
             'section' => $section,
@@ -284,6 +302,8 @@ final class DashboardController
                 'delivered_by_us' => (bool) $t->delivered_by_us,
                 'from_number_override' => $t->from_number_override,
             ])->all(),
+            'oauth_providers' => $oauthRows->map(fn (OauthProvider $p) => $this->oauthRowShape($p))->all(),
+            'oauth_preset_keys' => $this->oauthPresets->keys(),
         ]);
     }
 
@@ -442,6 +462,250 @@ final class DashboardController
 
         return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/sms")
             ->with('sms_template_saved', true);
+    }
+
+    public function storeOauthProvider(Request $request, string $project_slug, string $env_slug): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+
+        $request->validate([
+            'provider_kind' => ['required', Rule::in(OauthProvider::KINDS)],
+            'provider_key' => ['required', 'string', 'regex:/^[a-z][a-z0-9_]{1,63}$/'],
+            'name' => ['required', 'string', 'max:255'],
+            'client_id' => ['required', 'string', 'max:255'],
+            'client_secret' => ['nullable', 'string', 'max:1024'],
+            'issuer' => ['nullable', 'url', 'max:512'],
+            'authorization_endpoint' => ['nullable', 'url', 'max:512'],
+            'token_endpoint' => ['nullable', 'url', 'max:512'],
+            'userinfo_endpoint' => ['nullable', 'url', 'max:512'],
+            'userinfo_method' => ['nullable', 'in:GET,POST'],
+            'userinfo_auth' => ['nullable', 'in:bearer,basic,query'],
+            'scopes' => ['nullable', 'array'],
+            'attribute_mapping' => ['nullable', 'array'],
+            'additional_authorization_params' => ['nullable', 'array'],
+            'enabled' => ['nullable', 'boolean'],
+        ]);
+
+        $kind = (string) $request->input('provider_kind');
+        $providerKey = (string) $request->input('provider_key');
+
+        $duplicate = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('provider_key', $providerKey)
+            ->exists();
+        if ($duplicate) {
+            return redirect()->back()->withErrors(['provider_key' => 'A provider with that key already exists.']);
+        }
+
+        $payload = [
+            'environment_id' => $env->id,
+            'provider_kind' => $kind,
+            'provider_key' => $providerKey,
+            'name' => (string) $request->input('name'),
+            'enabled' => $request->boolean('enabled', false),
+            'client_id' => (string) $request->input('client_id'),
+            'encrypted_client_secret' => (string) $request->input('client_secret', ''),
+            'scopes' => is_array($request->input('scopes')) ? $request->input('scopes') : [],
+            'attribute_mapping' => is_array($request->input('attribute_mapping')) ? $request->input('attribute_mapping') : [],
+            'additional_authorization_params' => is_array($request->input('additional_authorization_params')) ? $request->input('additional_authorization_params') : [],
+        ];
+
+        if ($kind === OauthProvider::KIND_PRESET) {
+            $preset = $this->oauthPresets->get($providerKey);
+            if ($preset !== null) {
+                $payload['authorization_endpoint'] = $preset->authorizationEndpoint();
+                $payload['token_endpoint'] = $preset->tokenEndpoint();
+                $payload['userinfo_endpoint'] = $preset->userinfoEndpoint();
+                $payload['jwks_uri'] = $preset->jwksUri();
+                $payload['id_token_signing_algs'] = $preset->idTokenSigningAlgs();
+                $payload['userinfo_method'] = $preset->userinfoMethod();
+                $payload['userinfo_auth'] = $preset->userinfoAuth();
+                if ($payload['scopes'] === []) {
+                    $payload['scopes'] = $preset->defaultScopes();
+                }
+                if ($payload['attribute_mapping'] === []) {
+                    $payload['attribute_mapping'] = $preset->defaultAttributeMapping();
+                }
+                if ($payload['additional_authorization_params'] === []) {
+                    $payload['additional_authorization_params'] = $preset->additionalAuthorizationParams();
+                }
+            }
+        }
+
+        if ($kind === OauthProvider::KIND_CUSTOM_OIDC) {
+            $issuer = (string) $request->input('issuer');
+            if ($issuer === '') {
+                return redirect()->back()->withErrors(['issuer' => 'issuer is required for custom OIDC.']);
+            }
+            try {
+                $endpoints = $this->oauthResolver->discoverEndpoints($issuer);
+                $payload = array_merge($payload, [
+                    'issuer' => $issuer,
+                    'authorization_endpoint' => $endpoints['authorization_endpoint'],
+                    'token_endpoint' => $endpoints['token_endpoint'],
+                    'userinfo_endpoint' => $endpoints['userinfo_endpoint'],
+                    'jwks_uri' => $endpoints['jwks_uri'],
+                    'id_token_signing_algs' => $endpoints['id_token_signing_algs'],
+                    'discovery_cached_at' => now(),
+                ]);
+            } catch (OauthDiscoveryFailedException $e) {
+                return redirect()->back()->withErrors(['issuer' => $e->getMessage()]);
+            }
+        }
+
+        if ($kind === OauthProvider::KIND_CUSTOM_OAUTH2) {
+            foreach (['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint', 'userinfo_method', 'userinfo_auth'] as $field) {
+                if (! $request->filled($field)) {
+                    return redirect()->back()->withErrors([$field => "{$field} is required for custom OAuth2."]);
+                }
+                $payload[$field] = $request->input($field);
+            }
+        }
+
+        OauthProvider::query()->withoutGlobalScopes()->create($payload);
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/social-providers")
+            ->with('oauth_provider_saved', true);
+    }
+
+    public function updateOauthProvider(Request $request, string $project_slug, string $env_slug, string $oauth_provider_id): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+        $row = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $oauth_provider_id)
+            ->first();
+        if ($row === null) {
+            return redirect()->back()->withErrors(['oauth_provider_id' => 'Provider not found.']);
+        }
+
+        $request->validate([
+            'name' => ['sometimes', 'string', 'max:255'],
+            'enabled' => ['sometimes', 'boolean'],
+            'allow_sign_in' => ['sometimes', 'boolean'],
+            'allow_sign_up' => ['sometimes', 'boolean'],
+            'block_email_subaddresses' => ['sometimes', 'boolean'],
+            'client_id' => ['sometimes', 'string', 'max:255'],
+            'client_secret' => ['nullable', 'string', 'max:1024'],
+            'scopes' => ['sometimes', 'array'],
+            'attribute_mapping' => ['sometimes', 'array'],
+            'additional_authorization_params' => ['sometimes', 'array'],
+        ]);
+
+        $patch = [];
+        foreach (['name', 'enabled', 'allow_sign_in', 'allow_sign_up', 'block_email_subaddresses', 'client_id', 'scopes', 'attribute_mapping', 'additional_authorization_params'] as $field) {
+            if ($request->has($field)) {
+                $patch[$field] = $request->input($field);
+            }
+        }
+        // Only rotate the secret on a non-empty value.
+        $secret = $request->input('client_secret');
+        if (is_string($secret) && $secret !== '') {
+            $patch['encrypted_client_secret'] = $secret;
+        }
+
+        $row->forceFill($patch)->save();
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/social-providers")
+            ->with('oauth_provider_saved', true);
+    }
+
+    public function destroyOauthProvider(string $project_slug, string $env_slug, string $oauth_provider_id): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+        $row = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $oauth_provider_id)
+            ->first();
+        if ($row === null) {
+            return redirect()->back()->withErrors(['oauth_provider_id' => 'Provider not found.']);
+        }
+
+        $linked = ExternalAccount::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('oauth_provider_id', $row->id)
+            ->exists();
+        if ($linked) {
+            return redirect()->back()->withErrors(['oauth_provider_id' => 'ExternalAccount rows still link to this provider.']);
+        }
+
+        $row->delete();
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/social-providers")
+            ->with('oauth_provider_saved', true);
+    }
+
+    public function testOauthProvider(string $project_slug, string $env_slug, string $oauth_provider_id): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+        $row = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $oauth_provider_id)
+            ->first();
+        if ($row === null) {
+            return redirect()->back()->withErrors(['oauth_provider_id' => 'Provider not found.']);
+        }
+
+        $errors = [];
+        $userinfoStatus = null;
+        try {
+            $resolved = $this->oauthResolver->resolve($row);
+            if ($resolved->userinfoEndpoint !== '' && $resolved->userinfoEndpoint !== $resolved->tokenEndpoint) {
+                try {
+                    $userinfoStatus = Http::timeout(5)->get($resolved->userinfoEndpoint)->status();
+                } catch (ConnectionException|RequestException|Throwable $e) {
+                    $errors[] = $e->getMessage();
+                }
+            }
+        } catch (OauthDiscoveryFailedException $e) {
+            $errors[] = $e->getMessage();
+        }
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/social-providers")
+            ->with('oauth_provider_test', [
+                'provider_id' => $row->id,
+                'userinfo_status' => $userinfoStatus,
+                'errors' => $errors,
+            ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function oauthRowShape(OauthProvider $row): array
+    {
+        return [
+            'id' => $row->id,
+            'provider_kind' => $row->provider_kind,
+            'provider_key' => $row->provider_key,
+            'name' => $row->name,
+            'enabled' => (bool) $row->enabled,
+            'allow_sign_in' => (bool) $row->allow_sign_in,
+            'allow_sign_up' => (bool) $row->allow_sign_up,
+            'block_email_subaddresses' => (bool) $row->block_email_subaddresses,
+            'client_id' => (string) $row->client_id,
+            'client_secret_set' => $row->encrypted_client_secret !== '',
+            'scopes' => is_array($row->scopes) ? array_values($row->scopes) : [],
+            'attribute_mapping' => is_array($row->attribute_mapping) ? $row->attribute_mapping : [],
+            'additional_authorization_params' => is_array($row->additional_authorization_params) ? $row->additional_authorization_params : [],
+            'issuer' => $row->issuer,
+            'authorization_endpoint' => $row->authorization_endpoint,
+            'token_endpoint' => $row->token_endpoint,
+            'userinfo_endpoint' => $row->userinfo_endpoint,
+            'redirect_uri' => $row->computeRedirectUri(),
+        ];
     }
 
     public function emailTemplates(string $project_slug, string $env_slug): InertiaResponse|RedirectResponse

--- a/resources/js/dashboard/pages/Configure.tsx
+++ b/resources/js/dashboard/pages/Configure.tsx
@@ -28,6 +28,27 @@ type SmsTemplate = {
     from_number_override: string | null
 }
 
+type OauthProvider = {
+    id: string
+    provider_kind: 'preset' | 'custom_oidc' | 'custom_oauth2'
+    provider_key: string
+    name: string
+    enabled: boolean
+    allow_sign_in: boolean
+    allow_sign_up: boolean
+    block_email_subaddresses: boolean
+    client_id: string
+    client_secret_set: boolean
+    scopes: string[]
+    attribute_mapping: Record<string, string>
+    additional_authorization_params: Record<string, unknown>
+    issuer: string | null
+    authorization_endpoint: string | null
+    token_endpoint: string | null
+    userinfo_endpoint: string | null
+    redirect_uri: string
+}
+
 type Props = {
     section: string
     user_settings: Record<string, unknown>
@@ -38,12 +59,15 @@ type Props = {
     attributes: AttributesSettings
     sms: SmsSettings
     sms_templates: SmsTemplate[]
+    oauth_providers: OauthProvider[]
+    oauth_preset_keys: string[]
 }
 
 const SECTIONS = [
     { slug: 'attributes', label: 'Attributes' },
     { slug: 'multi-factor', label: 'Multi-factor' },
     { slug: 'sms', label: 'SMS' },
+    { slug: 'social-providers', label: 'Social providers' },
 ] as const
 
 export default function Configure(props: Props) {
@@ -73,10 +97,11 @@ export default function Configure(props: Props) {
                     </Link>
                 ))}
             </nav>
+            {props.section === 'attributes' && <AttributesSection attributes={props.attributes} signupMode={props.signup_mode} />}
             {props.section === 'multi-factor' && <MultiFactorSection multiFactor={props.multi_factor} />}
             {props.section === 'sms' && <SmsSection sms={props.sms} smsTemplates={props.sms_templates} />}
-            {props.section === 'attributes' && <AttributesSection attributes={props.attributes} signupMode={props.signup_mode} />}
-            {!['multi-factor', 'sms', 'attributes'].includes(props.section) && (
+            {props.section === 'social-providers' && <SocialProvidersSection providers={props.oauth_providers} presetKeys={props.oauth_preset_keys} />}
+            {!['attributes', 'multi-factor', 'sms', 'social-providers'].includes(props.section) && (
                 <pre style={{ background: '#f1f5f9', padding: 12, borderRadius: 6 }}>
                     {JSON.stringify(props.user_settings, null, 2)}
                 </pre>
@@ -418,6 +443,302 @@ function SmsTemplateRow({ template }: { template: SmsTemplate }) {
                 </label>
                 <button type="submit" disabled={form.processing}>
                     {form.processing ? 'Saving…' : 'Save'}
+                </button>
+            </form>
+        </details>
+    )
+}
+
+function SocialProvidersSection({ providers, presetKeys }: { providers: OauthProvider[]; presetKeys: string[] }) {
+    const url = useDashboardUrl()
+    const { active_project, active_environment } = useDashboard()
+    const { props: pageProps } = usePage<{ flash?: { oauth_provider_saved?: boolean; oauth_provider_test?: { provider_id: string; userinfo_status: number | null; errors: string[] } } }>()
+
+    if (!active_project || !active_environment) {
+        return <p>No active environment.</p>
+    }
+    const base = `/${active_project.slug}/${active_environment.slug}/configure`
+
+    const presetsConfigured = new Set(providers.filter(p => p.provider_kind === 'preset').map(p => p.provider_key))
+    const presetsMissing = presetKeys.filter(k => !presetsConfigured.has(k))
+
+    return (
+        <section>
+            <h2>Social providers</h2>
+            <p>Per-environment OAuth IdPs. Toggle a preset on/off, or add a custom OIDC / OAuth2 IdP.</p>
+            {pageProps.flash?.oauth_provider_saved && (
+                <div style={{ padding: 12, background: '#dcfce7', borderRadius: 6, marginBottom: 16 }}>Saved.</div>
+            )}
+            {pageProps.flash?.oauth_provider_test && (
+                <div style={{ padding: 12, background: '#dbeafe', borderRadius: 6, marginBottom: 16 }}>
+                    Test result for {pageProps.flash.oauth_provider_test.provider_id}: userinfo status {pageProps.flash.oauth_provider_test.userinfo_status ?? 'n/a'}
+                    {pageProps.flash.oauth_provider_test.errors.length > 0 && (
+                        <ul>{pageProps.flash.oauth_provider_test.errors.map((e, i) => <li key={i}>{e}</li>)}</ul>
+                    )}
+                </div>
+            )}
+
+            {providers.length === 0 && presetsMissing.length === presetKeys.length && (
+                <p style={{ color: '#64748b' }}>No social providers configured. Pick a preset below or add a custom IdP.</p>
+            )}
+
+            {providers.map(p => <ProviderRow key={p.id} provider={p} base={base} url={url} />)}
+
+            {presetsMissing.length > 0 && (
+                <fieldset style={{ marginTop: 16, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+                    <legend><strong>Add preset</strong></legend>
+                    {presetsMissing.map(k => <PresetCreateForm key={k} providerKey={k} base={base} url={url} />)}
+                </fieldset>
+            )}
+
+            <CustomOidcWizard base={base} url={url} />
+            <CustomOauth2Wizard base={base} url={url} />
+        </section>
+    )
+}
+
+function ProviderRow({ provider, base, url }: { provider: OauthProvider; base: string; url: (s: string) => string }) {
+    const form = useForm({
+        name: provider.name,
+        enabled: provider.enabled,
+        allow_sign_in: provider.allow_sign_in,
+        allow_sign_up: provider.allow_sign_up,
+        block_email_subaddresses: provider.block_email_subaddresses,
+        client_id: provider.client_id,
+        client_secret: '',
+        scopes: provider.scopes.join(' '),
+    })
+    const action = url(`${base}/oauth-providers/${provider.id}`)
+
+    return (
+        <details style={{ marginBottom: 12, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+            <summary>
+                <strong>{provider.name}</strong> — <code>{provider.provider_key}</code> ({provider.provider_kind})
+                {provider.enabled ? ' · enabled' : ' · disabled'}
+            </summary>
+            <p style={{ marginTop: 8, fontSize: 13, color: '#64748b' }}>
+                Redirect URL (paste into the IdP's allow-list): <code>{provider.redirect_uri}</code>
+            </p>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault()
+                    const payload: Record<string, unknown> = {
+                        name: form.data.name,
+                        enabled: form.data.enabled,
+                        allow_sign_in: form.data.allow_sign_in,
+                        allow_sign_up: form.data.allow_sign_up,
+                        block_email_subaddresses: form.data.block_email_subaddresses,
+                        client_id: form.data.client_id,
+                        scopes: form.data.scopes.trim() === '' ? [] : form.data.scopes.trim().split(/\s+/),
+                    }
+                    if (form.data.client_secret !== '') {
+                        payload.client_secret = form.data.client_secret
+                    }
+                    form.transform(() => payload).patch(action, { preserveScroll: true })
+                }}
+            >
+                <label style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
+                    <input type="checkbox" checked={form.data.enabled} onChange={e => form.setData('enabled', e.target.checked)} />
+                    Enabled
+                </label>
+                <label style={{ display: 'block', marginBottom: 8 }}>
+                    Display name
+                    <input
+                        type="text"
+                        value={form.data.name}
+                        onChange={e => form.setData('name', e.target.value)}
+                        style={{ display: 'block', marginTop: 4, padding: 6, width: 320 }}
+                    />
+                </label>
+                <label style={{ display: 'block', marginBottom: 8 }}>
+                    client_id
+                    <input
+                        type="text"
+                        value={form.data.client_id}
+                        onChange={e => form.setData('client_id', e.target.value)}
+                        style={{ display: 'block', marginTop: 4, padding: 6, width: 360 }}
+                    />
+                </label>
+                <label style={{ display: 'block', marginBottom: 8 }}>
+                    client_secret {provider.client_secret_set && <span style={{ color: '#64748b', fontSize: 12 }}>(••••, leave blank to keep)</span>}
+                    <input
+                        type="password"
+                        value={form.data.client_secret}
+                        onChange={e => form.setData('client_secret', e.target.value)}
+                        placeholder={provider.client_secret_set ? '•••• rotate' : ''}
+                        style={{ display: 'block', marginTop: 4, padding: 6, width: 360 }}
+                    />
+                </label>
+                <label style={{ display: 'block', marginBottom: 8 }}>
+                    Scopes (space-separated)
+                    <input
+                        type="text"
+                        value={form.data.scopes}
+                        onChange={e => form.setData('scopes', e.target.value)}
+                        style={{ display: 'block', marginTop: 4, padding: 6, width: 360 }}
+                    />
+                </label>
+                <label style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
+                    <input type="checkbox" checked={form.data.allow_sign_in} onChange={e => form.setData('allow_sign_in', e.target.checked)} />
+                    Allow sign-in
+                </label>
+                <label style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
+                    <input type="checkbox" checked={form.data.allow_sign_up} onChange={e => form.setData('allow_sign_up', e.target.checked)} />
+                    Allow sign-up
+                </label>
+                <button type="submit" disabled={form.processing} style={{ marginRight: 8 }}>
+                    {form.processing ? 'Saving…' : 'Save'}
+                </button>
+                <TestButton providerId={provider.id} base={base} url={url} />
+                <DeleteButton providerId={provider.id} base={base} url={url} />
+            </form>
+        </details>
+    )
+}
+
+function TestButton({ providerId, base, url }: { providerId: string; base: string; url: (s: string) => string }) {
+    const form = useForm({})
+    return (
+        <button
+            type="button"
+            disabled={form.processing}
+            onClick={() => form.post(url(`${base}/oauth-providers/${providerId}/test`), { preserveScroll: true })}
+            style={{ marginRight: 8 }}
+        >
+            Test
+        </button>
+    )
+}
+
+function DeleteButton({ providerId, base, url }: { providerId: string; base: string; url: (s: string) => string }) {
+    const form = useForm({})
+    return (
+        <button
+            type="button"
+            disabled={form.processing}
+            onClick={() => {
+                if (!confirm('Delete this OAuth provider?')) return
+                form.delete(url(`${base}/oauth-providers/${providerId}`), { preserveScroll: true })
+            }}
+        >
+            Delete
+        </button>
+    )
+}
+
+function PresetCreateForm({ providerKey, base, url }: { providerKey: string; base: string; url: (s: string) => string }) {
+    const form = useForm({
+        provider_kind: 'preset',
+        provider_key: providerKey,
+        name: providerKey.charAt(0).toUpperCase() + providerKey.slice(1),
+        client_id: '',
+        client_secret: '',
+        enabled: true,
+    })
+
+    return (
+        <form
+            onSubmit={(e) => {
+                e.preventDefault()
+                form.post(url(`${base}/oauth-providers`), { preserveScroll: true })
+            }}
+            style={{ marginBottom: 8 }}
+        >
+            <strong>{providerKey}</strong>
+            <input
+                type="text"
+                value={form.data.client_id}
+                onChange={e => form.setData('client_id', e.target.value)}
+                placeholder="client_id"
+                style={{ marginLeft: 8, padding: 4, width: 240 }}
+            />
+            <input
+                type="password"
+                value={form.data.client_secret}
+                onChange={e => form.setData('client_secret', e.target.value)}
+                placeholder="client_secret"
+                style={{ marginLeft: 8, padding: 4, width: 240 }}
+            />
+            <button type="submit" disabled={form.processing} style={{ marginLeft: 8 }}>
+                {form.processing ? 'Adding…' : 'Add'}
+            </button>
+        </form>
+    )
+}
+
+function CustomOidcWizard({ base, url }: { base: string; url: (s: string) => string }) {
+    const form = useForm({
+        provider_kind: 'custom_oidc',
+        provider_key: '',
+        name: '',
+        client_id: '',
+        client_secret: '',
+        issuer: '',
+    })
+    return (
+        <details style={{ marginTop: 16, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+            <summary><strong>Add custom OIDC</strong></summary>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault()
+                    form.post(url(`${base}/oauth-providers`), { preserveScroll: true })
+                }}
+                style={{ marginTop: 8 }}
+            >
+                <input type="text" placeholder="provider_key" value={form.data.provider_key} onChange={e => form.setData('provider_key', e.target.value)} style={{ display: 'block', marginBottom: 8, padding: 6, width: 240 }} />
+                <input type="text" placeholder="display name" value={form.data.name} onChange={e => form.setData('name', e.target.value)} style={{ display: 'block', marginBottom: 8, padding: 6, width: 320 }} />
+                <input type="url" placeholder="https://idp.example.com (issuer)" value={form.data.issuer} onChange={e => form.setData('issuer', e.target.value)} style={{ display: 'block', marginBottom: 8, padding: 6, width: 360 }} />
+                <input type="text" placeholder="client_id" value={form.data.client_id} onChange={e => form.setData('client_id', e.target.value)} style={{ display: 'block', marginBottom: 8, padding: 6, width: 360 }} />
+                <input type="password" placeholder="client_secret" value={form.data.client_secret} onChange={e => form.setData('client_secret', e.target.value)} style={{ display: 'block', marginBottom: 8, padding: 6, width: 360 }} />
+                <button type="submit" disabled={form.processing}>
+                    {form.processing ? 'Adding…' : 'Discover + add'}
+                </button>
+            </form>
+        </details>
+    )
+}
+
+function CustomOauth2Wizard({ base, url }: { base: string; url: (s: string) => string }) {
+    const form = useForm({
+        provider_kind: 'custom_oauth2',
+        provider_key: '',
+        name: '',
+        client_id: '',
+        client_secret: '',
+        authorization_endpoint: '',
+        token_endpoint: '',
+        userinfo_endpoint: '',
+        userinfo_method: 'GET',
+        userinfo_auth: 'bearer',
+    })
+    return (
+        <details style={{ marginTop: 16, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+            <summary><strong>Add custom OAuth2</strong></summary>
+            <form
+                onSubmit={(e) => {
+                    e.preventDefault()
+                    form.post(url(`${base}/oauth-providers`), { preserveScroll: true })
+                }}
+                style={{ marginTop: 8 }}
+            >
+                <input type="text" placeholder="provider_key" value={form.data.provider_key} onChange={e => form.setData('provider_key', e.target.value)} style={{ display: 'block', marginBottom: 8, padding: 6, width: 240 }} />
+                <input type="text" placeholder="display name" value={form.data.name} onChange={e => form.setData('name', e.target.value)} style={{ display: 'block', marginBottom: 8, padding: 6, width: 320 }} />
+                <input type="text" placeholder="client_id" value={form.data.client_id} onChange={e => form.setData('client_id', e.target.value)} style={{ display: 'block', marginBottom: 8, padding: 6, width: 360 }} />
+                <input type="password" placeholder="client_secret" value={form.data.client_secret} onChange={e => form.setData('client_secret', e.target.value)} style={{ display: 'block', marginBottom: 8, padding: 6, width: 360 }} />
+                <input type="url" placeholder="authorization_endpoint" value={form.data.authorization_endpoint} onChange={e => form.setData('authorization_endpoint', e.target.value)} style={{ display: 'block', marginBottom: 8, padding: 6, width: 360 }} />
+                <input type="url" placeholder="token_endpoint" value={form.data.token_endpoint} onChange={e => form.setData('token_endpoint', e.target.value)} style={{ display: 'block', marginBottom: 8, padding: 6, width: 360 }} />
+                <input type="url" placeholder="userinfo_endpoint" value={form.data.userinfo_endpoint} onChange={e => form.setData('userinfo_endpoint', e.target.value)} style={{ display: 'block', marginBottom: 8, padding: 6, width: 360 }} />
+                <select value={form.data.userinfo_method} onChange={e => form.setData('userinfo_method', e.target.value)} style={{ marginRight: 8, padding: 6 }}>
+                    <option value="GET">GET</option>
+                    <option value="POST">POST</option>
+                </select>
+                <select value={form.data.userinfo_auth} onChange={e => form.setData('userinfo_auth', e.target.value)} style={{ marginRight: 8, padding: 6 }}>
+                    <option value="bearer">bearer</option>
+                    <option value="basic">basic</option>
+                    <option value="query">query</option>
+                </select>
+                <button type="submit" disabled={form.processing}>
+                    {form.processing ? 'Adding…' : 'Add'}
                 </button>
             </form>
         </details>

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -44,6 +44,10 @@ Route::prefix('{project_slug}/{env_slug}')->group(function (): void {
     Route::patch('/configure/sms', [DashboardController::class, 'updateSms'])->name('dashboard.configure.sms.update');
     Route::post('/configure/sms/test', [DashboardController::class, 'sendTestSms'])->name('dashboard.configure.sms.test');
     Route::patch('/configure/sms-templates/{slug}', [DashboardController::class, 'updateSmsTemplate'])->name('dashboard.configure.sms_templates.update');
+    Route::post('/configure/oauth-providers', [DashboardController::class, 'storeOauthProvider'])->name('dashboard.configure.oauth_providers.store');
+    Route::patch('/configure/oauth-providers/{oauth_provider_id}', [DashboardController::class, 'updateOauthProvider'])->name('dashboard.configure.oauth_providers.update');
+    Route::delete('/configure/oauth-providers/{oauth_provider_id}', [DashboardController::class, 'destroyOauthProvider'])->name('dashboard.configure.oauth_providers.destroy');
+    Route::post('/configure/oauth-providers/{oauth_provider_id}/test', [DashboardController::class, 'testOauthProvider'])->name('dashboard.configure.oauth_providers.test');
     Route::get('/email-templates', [DashboardController::class, 'emailTemplates'])->name('dashboard.email_templates');
 
     Route::get('/api-keys', [DashboardController::class, 'apiKeys'])->name('dashboard.api_keys');

--- a/tests/Feature/Http/Dashboard/DashboardTest.php
+++ b/tests/Feature/Http/Dashboard/DashboardTest.php
@@ -7,6 +7,7 @@ use App\Models\ApiKey;
 use App\Models\Client;
 use App\Models\EmailAddress;
 use App\Models\Environment;
+use App\Models\OauthProvider;
 use App\Models\Organization;
 use App\Models\OrganizationMembership;
 use App\Models\Project;
@@ -18,6 +19,7 @@ use App\Models\WebhookEndpoint;
 use App\Services\Keys\SigningKeyGenerator;
 use App\Services\Sessions\SessionTokenIssuer;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Route;
 
@@ -562,4 +564,173 @@ it('Configure renders the sms section with seeded templates + null driver defaul
         ->assertJsonPath('props.section', 'sms')
         ->assertJsonPath('props.sms.driver', null)
         ->assertJsonCount(3, 'props.sms_templates');
+});
+
+it('Configure renders the social-providers section with the seeded preset rows + preset keys', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->get('http://dashboard.authn.local/acme/production/configure/social-providers');
+
+    $r->assertOk()
+        ->assertJsonPath('component', 'Dashboard/Configure')
+        ->assertJsonPath('props.section', 'social-providers');
+    $keys = collect($r->json('props.oauth_providers'))->pluck('provider_key')->sort()->values()->all();
+    expect($keys)->toBe(['apple', 'github', 'google', 'microsoft']);
+    expect($r->json('props.oauth_preset_keys'))->toBe(['google', 'github', 'apple', 'microsoft']);
+});
+
+it('PATCH /configure/oauth-providers/{id} flips enabled + rotates client_secret', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+    $row = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)->where('provider_key', 'google')->firstOrFail();
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->patch('http://dashboard.authn.local/acme/production/configure/oauth-providers/'.$row->id, [
+            'enabled' => true,
+            'client_id' => 'gid-real',
+            'client_secret' => 'rotated',
+        ]);
+
+    $r->assertRedirect();
+    $row->refresh();
+    expect($row->enabled)->toBeTrue();
+    expect($row->client_id)->toBe('gid-real');
+    expect($row->encrypted_client_secret)->toBe('rotated');
+});
+
+it('PATCH /configure/oauth-providers/{id} leaves client_secret untouched on empty input', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+    $row = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)->where('provider_key', 'google')->firstOrFail();
+    $row->forceFill(['encrypted_client_secret' => 'kept'])->save();
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->patch('http://dashboard.authn.local/acme/production/configure/oauth-providers/'.$row->id, [
+            'enabled' => true,
+            'client_secret' => '',
+        ]);
+
+    $r->assertRedirect();
+    expect($row->fresh()->encrypted_client_secret)->toBe('kept');
+});
+
+it('POST /configure/oauth-providers creates a custom OAuth2 row', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->post('http://dashboard.authn.local/acme/production/configure/oauth-providers', [
+            'provider_kind' => 'custom_oauth2',
+            'provider_key' => 'acmecorp',
+            'name' => 'Acme Corp',
+            'client_id' => 'cid',
+            'client_secret' => 'sec',
+            'authorization_endpoint' => 'https://acme.test/authorize',
+            'token_endpoint' => 'https://acme.test/token',
+            'userinfo_endpoint' => 'https://acme.test/userinfo',
+            'userinfo_method' => 'GET',
+            'userinfo_auth' => 'bearer',
+        ]);
+
+    $r->assertRedirect();
+    $row = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)->where('provider_key', 'acmecorp')->first();
+    expect($row)->not->toBeNull();
+    expect($row->authorization_endpoint)->toBe('https://acme.test/authorize');
+});
+
+it('POST /configure/oauth-providers runs OIDC discovery for custom_oidc', function (): void {
+    Http::fake([
+        'https://idp.acme.test/.well-known/openid-configuration' => Http::response([
+            'authorization_endpoint' => 'https://idp.acme.test/authorize',
+            'token_endpoint' => 'https://idp.acme.test/token',
+            'userinfo_endpoint' => 'https://idp.acme.test/userinfo',
+            'jwks_uri' => 'https://idp.acme.test/jwks',
+            'id_token_signing_alg_values_supported' => ['RS256'],
+        ], 200),
+    ]);
+
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->post('http://dashboard.authn.local/acme/production/configure/oauth-providers', [
+            'provider_kind' => 'custom_oidc',
+            'provider_key' => 'acmeoidc',
+            'name' => 'Acme OIDC',
+            'client_id' => 'cid',
+            'client_secret' => 'sec',
+            'issuer' => 'https://idp.acme.test',
+        ]);
+
+    $r->assertRedirect();
+    $row = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)->where('provider_key', 'acmeoidc')->first();
+    expect($row)->not->toBeNull();
+    expect($row->authorization_endpoint)->toBe('https://idp.acme.test/authorize');
+});
+
+it('DELETE /configure/oauth-providers/{id} removes the row when no ExternalAccounts link', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+    $row = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)->where('provider_key', 'google')->firstOrFail();
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->delete('http://dashboard.authn.local/acme/production/configure/oauth-providers/'.$row->id);
+
+    $r->assertRedirect();
+    expect(OauthProvider::query()->withoutGlobalScopes()->where('id', $row->id)->whereNull('deleted_at')->exists())->toBeFalse();
 });


### PR DESCRIPTION
Closes #132.

## Summary

- Four new `DashboardController` handlers for OauthProvider CRUD + test, mounted under `/configure/oauth-providers/{...}`:
  - `storeOauthProvider` handles all three `provider_kind`s. Preset rows pick up the registry's defaults when the operator omits them. Custom OIDC runs discovery via `OauthProviderResolver` + persists the resolved endpoints + cache timestamp.
  - `updateOauthProvider` partial-patch with write-only secret rotate semantics (empty `client_secret` leaves the stored value untouched).
  - `destroyOauthProvider` soft-deletes; refuses inline when ExternalAccount rows still link to the provider.
  - `testOauthProvider` resolves the row + unauthenticated-probes `userinfo_endpoint`; result rendered as a flash notification.
- DashboardController constructor gains `OauthProviderResolver` + `PresetRegistry`. `configure()` surfaces `oauth_providers[]` + `oauth_preset_keys[]`.
- `Configure.tsx` new `social-providers` tab: per-provider edit drawer (toggle, scopes, secret rotate, copy redirect URL), test, delete; "Add preset" picker; custom OIDC + OAuth2 wizards.

## Test plan

- [x] `vendor/bin/pest tests/Feature/Http/Dashboard/DashboardTest.php` — 18 / 18 passing
- [x] `vendor/bin/pest` — 632 / 632 passing
- [x] `vendor/bin/pint --test` — clean
- [x] `npm run build` — clean (Configure-*.js 14.37 kB / gzip 3.12 kB)