### PR TITLE
AU-6: FAPI oauth_<provider_key> strategy + OauthCallbackController

### DIFF
--- a/app/Auth/Oauth/StateToken.php
+++ b/app/Auth/Oauth/StateToken.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth;
+
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Support\Facades\Crypt;
+
+/**
+ * Server-issued `state` parameter shipped to the IdP and bounced back on
+ * the callback. Carries enough plumbing to find the originating
+ * SignIn/SignUp attempt without trusting the URL's other parameters.
+ *
+ * Encrypted at rest via Laravel's app-key (Crypt::encrypt). Tamper-proof
+ * on round-trip — any modification breaks decryption and the callback
+ * controller surfaces a uniform `state_invalid` error.
+ */
+final class StateToken
+{
+    public const TTL_SECONDS = 600;
+
+    /**
+     * @param  array<string, mixed>  $extra
+     */
+    public static function mint(
+        string $environmentId,
+        string $providerKey,
+        string $verificationId,
+        string $clientId,
+        string $attemptId,
+        string $attemptKind,
+        ?string $redirectUrl,
+        ?string $redirectUrlComplete,
+        string $nonce,
+        array $extra = [],
+    ): string {
+        $payload = [
+            'env' => $environmentId,
+            'pk' => $providerKey,
+            'v' => $verificationId,
+            'c' => $clientId,
+            'a' => $attemptId,
+            'ak' => $attemptKind,
+            'ru' => $redirectUrl,
+            'ruc' => $redirectUrlComplete,
+            'n' => $nonce,
+            'iat' => time(),
+            'exp' => time() + self::TTL_SECONDS,
+        ] + $extra;
+
+        return Crypt::encryptString(json_encode($payload, JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public static function unwrap(string $token): ?array
+    {
+        try {
+            $raw = Crypt::decryptString($token);
+        } catch (DecryptException) {
+            return null;
+        }
+        $payload = json_decode($raw, true);
+        if (! is_array($payload)) {
+            return null;
+        }
+        if (! isset($payload['exp']) || (int) $payload['exp'] < time()) {
+            return null;
+        }
+
+        return $payload;
+    }
+}

--- a/app/Auth/Strategies/OauthRedirectStrategy.php
+++ b/app/Auth/Strategies/OauthRedirectStrategy.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Auth\ErrorCodes;
+use App\Auth\Oauth\OauthProviderResolver;
+use App\Auth\Oauth\ResolvedProvider;
+use App\Auth\Oauth\StateToken;
+use App\Models\Client;
+use App\Models\OauthProvider;
+use App\Models\SignInAttempt;
+use App\Models\Verification;
+use App\Services\Verification\VerificationManager;
+
+/**
+ * `oauth_<provider_key>` first-factor strategy. The "answer" lives on
+ * the IdP redirect callback — `OauthCallbackController` flips the
+ * Verification + parent attempt to `verified` / `complete` after the
+ * `state` round-trip, code exchange, and userinfo lookup.
+ *
+ * `prepare()` mints the authorize URL the SDK redirects the browser to,
+ * stashes a server-issued `state` token (encrypted via app-key) so the
+ * callback can find the originating attempt, and writes the URL onto
+ * the Verification's `external_verification_redirect_url`.
+ *
+ * Strategy `name()` returns the placeholder `oauth_*`; the dispatcher
+ * resolves any concrete `oauth_<provider_key>` to this single instance.
+ */
+final class OauthRedirectStrategy implements Strategy
+{
+    public function __construct(
+        private readonly OauthProviderResolver $resolver,
+        private readonly VerificationManager $verifications,
+    ) {}
+
+    public function name(): string
+    {
+        return 'oauth_*';
+    }
+
+    public function requiresPrepare(): bool
+    {
+        return true;
+    }
+
+    public function prepare(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $providerKey = $params['provider_key'] ?? null;
+        if (! is_string($providerKey) || $providerKey === '') {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'provider_key is required.', 422);
+        }
+
+        $row = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('provider_key', $providerKey)
+            ->where('enabled', true)
+            ->first();
+        if ($row === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'No enabled OAuth provider matches that key.', 422);
+        }
+
+        $resolved = $this->resolver->resolve($row);
+
+        $verification = $this->verifications->start(
+            $attempt,
+            'oauth_'.$providerKey,
+            StateToken::TTL_SECONDS,
+        );
+
+        $client = $params['client'] ?? null;
+        $clientId = $client instanceof Client ? $client->id : '';
+        $nonce = bin2hex(random_bytes(16));
+
+        $state = StateToken::mint(
+            environmentId: $attempt->environment_id,
+            providerKey: $providerKey,
+            verificationId: $verification->id,
+            clientId: $clientId,
+            attemptId: $attempt->id,
+            attemptKind: 'sign_in',
+            redirectUrl: is_string($params['redirect_url'] ?? null) ? (string) $params['redirect_url'] : null,
+            redirectUrlComplete: is_string($params['redirect_url_complete'] ?? null) ? (string) $params['redirect_url_complete'] : null,
+            nonce: $nonce,
+        );
+
+        $authorizeUrl = $this->buildAuthorizeUrl($resolved, $row, $state, $nonce);
+
+        $verification->forceFill([
+            'external_verification_redirect_url' => $authorizeUrl,
+            'nonce' => $nonce,
+        ])->save();
+
+        return StrategyResult::ok($attempt, verification: $verification);
+    }
+
+    public function attempt(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        return StrategyResult::fail(
+            $attempt,
+            ErrorCodes::PREPARE_NOT_REQUIRED,
+            'oauth_<provider_key> completes via the /v1/oauth-callback/<provider_key> redirect, not the answer endpoint.',
+            422,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $extraParams
+     */
+    private function buildAuthorizeUrl(ResolvedProvider $resolved, OauthProvider $row, string $state, string $nonce): string
+    {
+        $params = array_merge([
+            'response_type' => 'code',
+            'client_id' => $row->client_id,
+            'redirect_uri' => $row->computeRedirectUri(),
+            'scope' => implode(' ', $resolved->scopes),
+            'state' => $state,
+            'nonce' => $nonce,
+        ], $resolved->additionalAuthorizationParams);
+
+        $separator = str_contains($resolved->authorizationEndpoint, '?') ? '&' : '?';
+
+        return $resolved->authorizationEndpoint.$separator.http_build_query($params);
+    }
+}

--- a/app/Auth/StrategyResolver.php
+++ b/app/Auth/StrategyResolver.php
@@ -7,6 +7,7 @@ namespace App\Auth;
 use App\Auth\Strategies\BackupCodeStrategy;
 use App\Auth\Strategies\EmailCodeStrategy;
 use App\Auth\Strategies\EmailLinkStrategy;
+use App\Auth\Strategies\OauthRedirectStrategy;
 use App\Auth\Strategies\PasswordStrategy;
 use App\Auth\Strategies\PhoneCodeStrategy;
 use App\Auth\Strategies\ResetPasswordEmailCodeStrategy;
@@ -31,10 +32,15 @@ final class StrategyResolver
         private readonly TotpStrategy $totp,
         private readonly BackupCodeStrategy $backupCode,
         private readonly PhoneCodeStrategy $phoneCode,
+        private readonly OauthRedirectStrategy $oauth,
     ) {}
 
     public function resolve(string $name): Strategy
     {
+        if (preg_match(Verification::OAUTH_STRATEGY_PATTERN, $name) === 1) {
+            return $this->oauth;
+        }
+
         return match ($name) {
             Verification::STRATEGY_PASSWORD => $this->password,
             Verification::STRATEGY_EMAIL_CODE => $this->emailCode,

--- a/app/Http/Controllers/Fapi/ChallengeController.php
+++ b/app/Http/Controllers/Fapi/ChallengeController.php
@@ -19,6 +19,7 @@ use App\Models\Client;
 use App\Models\EmailAddress;
 use App\Models\EmailTemplate;
 use App\Models\Environment;
+use App\Models\OauthProvider;
 use App\Models\PhoneNumber;
 use App\Models\Session;
 use App\Models\SignInAttempt;
@@ -127,9 +128,15 @@ final class ChallengeController
             return $this->signInEnvelope($client, $attempt->fresh(), $challenge);
         }
 
+        $providerKey = preg_match(Verification::OAUTH_STRATEGY_PATTERN, $strategyName) === 1
+            ? substr($strategyName, strlen('oauth_'))
+            : null;
         $result = $strategy->prepare($attempt, [
             'email_address_id' => $request->input('email_address_id'),
             'redirect_url' => $request->input('redirect_url'),
+            'redirect_url_complete' => $request->input('redirect_url_complete'),
+            'provider_key' => $providerKey,
+            'client' => $client,
         ]);
 
         if (! $result->success || $result->verification === null) {
@@ -794,16 +801,39 @@ final class ChallengeController
     private function signInSupportedStrategies(SignInAttempt $attempt): array
     {
         return match ($attempt->status) {
-            SignInAttempt::STATUS_NEEDS_FIRST_FACTOR => [
-                Verification::STRATEGY_PASSWORD,
-                Verification::STRATEGY_EMAIL_CODE,
-                Verification::STRATEGY_EMAIL_LINK,
-                Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE,
-                Verification::STRATEGY_TICKET,
-            ],
+            SignInAttempt::STATUS_NEEDS_FIRST_FACTOR => array_merge(
+                [
+                    Verification::STRATEGY_PASSWORD,
+                    Verification::STRATEGY_EMAIL_CODE,
+                    Verification::STRATEGY_EMAIL_LINK,
+                    Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE,
+                    Verification::STRATEGY_TICKET,
+                ],
+                $this->enabledOauthStrategies($attempt->environment_id, allowSignIn: true),
+            ),
             SignInAttempt::STATUS_NEEDS_SECOND_FACTOR => $this->signInSecondFactorStrategies($attempt),
             default => [],
         };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function enabledOauthStrategies(string $environmentId, bool $allowSignIn = false, bool $allowSignUp = false): array
+    {
+        $query = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $environmentId)
+            ->where('enabled', true);
+        if ($allowSignIn) {
+            $query->where('allow_sign_in', true);
+        }
+        if ($allowSignUp) {
+            $query->where('allow_sign_up', true);
+        }
+
+        return $query->pluck('provider_key')
+            ->map(fn (string $k): string => 'oauth_'.$k)
+            ->values()->all();
     }
 
     /**

--- a/app/Http/Controllers/Fapi/OauthCallbackController.php
+++ b/app/Http/Controllers/Fapi/OauthCallbackController.php
@@ -1,0 +1,374 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Auth\Oauth\Exceptions\OauthDiscoveryFailedException;
+use App\Auth\Oauth\OauthProviderResolver;
+use App\Auth\Oauth\ResolvedProvider;
+use App\Auth\Oauth\StateToken;
+use App\Models\Challenge;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+use App\Models\Session;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * `GET /v1/oauth-callback/{provider_key}` — landing endpoint the IdP
+ * redirects to after the user has consented. Verifies `state`, exchanges
+ * the authorization code for tokens, fetches userinfo, applies
+ * `attribute_mapping`, finds-or-creates the User + ExternalAccount, and
+ * 302-redirects to `redirect_url_complete`.
+ *
+ * Strict best-effort posture: any unrecoverable failure flips the parent
+ * Verification to `failed` and 302's to `redirect_url?__authn_error=…`
+ * so the SDK can surface the error inline.
+ */
+final class OauthCallbackController
+{
+    public function __construct(
+        private readonly OauthProviderResolver $resolver,
+    ) {}
+
+    public function __invoke(Request $request): RedirectResponse
+    {
+        $provider_key = (string) $request->route('provider_key');
+        $stateToken = (string) $request->query('state', '');
+        $state = StateToken::unwrap($stateToken);
+        if ($state === null) {
+            return $this->fail(null, null, 'state_invalid', 'state token is missing or expired.');
+        }
+        if (($state['pk'] ?? null) !== $provider_key) {
+            return $this->fail($state['ru'] ?? null, null, 'state_provider_mismatch', 'state.provider_key does not match.');
+        }
+
+        $env = app()->bound(Environment::class) ? app(Environment::class) : null;
+        if ($env === null || $env->id !== ($state['env'] ?? null)) {
+            return $this->fail($state['ru'] ?? null, null, 'state_env_mismatch', 'state.environment_id does not match.');
+        }
+
+        $verification = Verification::query()->withoutGlobalScopes()
+            ->where('id', (string) ($state['v'] ?? ''))
+            ->where('environment_id', $env->id)
+            ->first();
+        if ($verification === null) {
+            return $this->fail($state['ru'] ?? null, null, 'verification_not_found', 'verification row missing.');
+        }
+
+        $provider = OauthProvider::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('provider_key', $provider_key)
+            ->first();
+        if ($provider === null) {
+            return $this->fail($state['ru'] ?? null, $verification, 'oauth_provider_not_found', 'OauthProvider row missing.');
+        }
+
+        if ($request->query('error') !== null) {
+            $code = (string) $request->query('error');
+            $description = (string) $request->query('error_description', '');
+
+            return $this->fail($state['ru'] ?? null, $verification, $code, $description !== '' ? $description : 'IdP returned an error.');
+        }
+
+        $code = (string) $request->query('code', '');
+        if ($code === '') {
+            return $this->fail($state['ru'] ?? null, $verification, 'oauth_code_missing', 'IdP did not return a code.');
+        }
+
+        try {
+            $resolved = $this->resolver->resolve($provider);
+        } catch (OauthDiscoveryFailedException $e) {
+            return $this->fail($state['ru'] ?? null, $verification, 'oauth_discovery_failed', $e->getMessage());
+        }
+
+        try {
+            $tokenResponse = Http::asForm()->post($resolved->tokenEndpoint, [
+                'grant_type' => 'authorization_code',
+                'code' => $code,
+                'redirect_uri' => $provider->computeRedirectUri(),
+                'client_id' => $provider->client_id,
+                'client_secret' => $provider->encrypted_client_secret,
+            ]);
+        } catch (ConnectionException|RequestException|Throwable $e) {
+            return $this->fail($state['ru'] ?? null, $verification, 'oauth_token_exchange_failed', $e->getMessage());
+        }
+        if (! $tokenResponse->successful()) {
+            return $this->fail($state['ru'] ?? null, $verification, 'oauth_token_exchange_failed', 'Token endpoint returned HTTP '.$tokenResponse->status());
+        }
+        $tokenBody = $tokenResponse->json();
+        if (! is_array($tokenBody) || ! is_string($tokenBody['access_token'] ?? null)) {
+            return $this->fail($state['ru'] ?? null, $verification, 'oauth_token_exchange_failed', 'Token endpoint returned no access_token.');
+        }
+
+        $userinfo = $this->fetchUserinfo($resolved, $tokenBody);
+        if ($userinfo === null) {
+            return $this->fail($state['ru'] ?? null, $verification, 'oauth_userinfo_failed', 'userinfo lookup returned no data.');
+        }
+
+        $providerUserId = (string) ($userinfo['sub'] ?? $userinfo['id'] ?? '');
+        if ($providerUserId === '') {
+            return $this->fail($state['ru'] ?? null, $verification, 'oauth_provider_user_id_missing', 'userinfo response had no sub/id.');
+        }
+
+        $mapped = $this->applyAttributeMapping($resolved->attributeMapping, $userinfo);
+        $emailAddress = isset($mapped['email']) ? strtolower((string) $mapped['email']) : null;
+        $emailVerified = (bool) ($mapped['email_verified'] ?? false);
+
+        if ($emailAddress !== null && $provider->block_email_subaddresses && str_contains(explode('@', $emailAddress, 2)[0] ?? '', '+')) {
+            return $this->fail($state['ru'] ?? null, $verification, 'email_subaddress_blocked', 'Email subaddresses are blocked on this provider.');
+        }
+
+        $signInAttempt = (string) ($state['ak'] ?? '') === 'sign_in'
+            ? SignInAttempt::query()->withoutGlobalScopes()->where('id', (string) ($state['a'] ?? ''))->first()
+            : null;
+
+        $result = DB::transaction(function () use ($env, $provider, $providerUserId, $emailAddress, $emailVerified, $mapped, $tokenBody): array {
+            $existingExt = ExternalAccount::query()->withoutGlobalScopes()
+                ->where('environment_id', $env->id)
+                ->where('oauth_provider_id', $provider->id)
+                ->where('provider_user_id', $providerUserId)
+                ->first();
+
+            if ($existingExt !== null) {
+                if (! $provider->allow_sign_in) {
+                    return ['error' => 'sign_in_disabled'];
+                }
+                $existingExt->forceFill([
+                    'encrypted_access_token' => (string) $tokenBody['access_token'],
+                    'encrypted_refresh_token' => isset($tokenBody['refresh_token']) ? (string) $tokenBody['refresh_token'] : null,
+                    'encrypted_id_token' => isset($tokenBody['id_token']) ? (string) $tokenBody['id_token'] : null,
+                    'access_token_expires_at' => isset($tokenBody['expires_in']) ? now()->addSeconds((int) $tokenBody['expires_in']) : null,
+                    'last_signed_in_at' => now(),
+                    'public_metadata' => $mapped,
+                ])->save();
+                $user = User::query()->withoutGlobalScopes()->where('id', $existingExt->user_id)->first();
+
+                return ['user' => $user, 'external_account' => $existingExt, 'created' => false];
+            }
+
+            $user = null;
+            if ($emailAddress !== null) {
+                $emailRow = EmailAddress::query()->withoutGlobalScopes()
+                    ->where('environment_id', $env->id)
+                    ->where('email_address', $emailAddress)
+                    ->first();
+                if ($emailRow !== null) {
+                    $user = User::query()->withoutGlobalScopes()->where('id', $emailRow->user_id)->first();
+                }
+            }
+
+            if ($user === null) {
+                if (! $provider->allow_sign_up) {
+                    return ['error' => 'sign_up_disabled'];
+                }
+                $user = User::query()->withoutGlobalScopes()->create([
+                    'environment_id' => $env->id,
+                    'first_name' => $mapped['first_name'] ?? null,
+                    'last_name' => $mapped['last_name'] ?? null,
+                    'image_url' => $mapped['image_url'] ?? null,
+                    'username' => $mapped['username'] ?? null,
+                ]);
+                if ($emailAddress !== null) {
+                    EmailAddress::query()->withoutGlobalScopes()->create([
+                        'environment_id' => $env->id,
+                        'user_id' => $user->id,
+                        'email_address' => $emailAddress,
+                        'verified_at' => $emailVerified ? now() : null,
+                        'is_primary' => true,
+                    ]);
+                }
+            } elseif (! $provider->allow_sign_in) {
+                return ['error' => 'sign_in_disabled'];
+            }
+
+            $external = ExternalAccount::query()->withoutGlobalScopes()->create([
+                'environment_id' => $env->id,
+                'user_id' => $user->id,
+                'oauth_provider_id' => $provider->id,
+                'provider_user_id' => $providerUserId,
+                'email_address' => $emailAddress,
+                'verified' => $emailVerified,
+                'scopes' => isset($tokenBody['scope']) ? explode(' ', (string) $tokenBody['scope']) : [],
+                'public_metadata' => $mapped,
+                'encrypted_access_token' => (string) $tokenBody['access_token'],
+                'encrypted_refresh_token' => isset($tokenBody['refresh_token']) ? (string) $tokenBody['refresh_token'] : null,
+                'encrypted_id_token' => isset($tokenBody['id_token']) ? (string) $tokenBody['id_token'] : null,
+                'access_token_expires_at' => isset($tokenBody['expires_in']) ? now()->addSeconds((int) $tokenBody['expires_in']) : null,
+                'linked_at' => now(),
+                'last_signed_in_at' => now(),
+            ]);
+
+            if ($emailAddress !== null) {
+                EmailAddress::query()->withoutGlobalScopes()
+                    ->where('environment_id', $env->id)
+                    ->where('email_address', $emailAddress)
+                    ->update(['linked_to_external_account_id' => $external->id]);
+            }
+
+            return ['user' => $user, 'external_account' => $external, 'created' => true];
+        });
+
+        if (isset($result['error'])) {
+            return $this->fail($state['ru'] ?? null, $verification, $result['error'], 'OAuth flow rejected by provider policy.');
+        }
+
+        $verification->forceFill([
+            'status' => Verification::STATUS_VERIFIED,
+            'verified_at' => now(),
+        ])->save();
+
+        Challenge::query()->withoutGlobalScopes()
+            ->where('verification_id', $verification->id)
+            ->update(['status' => Challenge::STATUS_VERIFIED]);
+
+        if ($signInAttempt !== null && $result['user'] !== null) {
+            $session = Session::query()->withoutGlobalScopes()->create([
+                'environment_id' => $signInAttempt->environment_id,
+                'client_id' => $signInAttempt->client_id,
+                'user_id' => $result['user']->id,
+                'status' => Session::STATUS_ACTIVE,
+                'was_test' => (bool) $signInAttempt->was_test,
+            ]);
+            $signInAttempt->forceFill([
+                'status' => SignInAttempt::STATUS_COMPLETE,
+                'created_session_id' => $session->id,
+            ])->save();
+        }
+
+        Log::info('audit:fapi.oauth_callback.success', [
+            'environment_id' => $env->id,
+            'oauth_provider_id' => $provider->id,
+            'user_id' => $result['user']?->id,
+            'external_account_id' => $result['external_account']?->id,
+            'created' => $result['created'] ?? false,
+        ]);
+
+        $redirect = (string) ($state['ruc'] ?? $state['ru'] ?? '/');
+
+        return redirect()->away($redirect);
+    }
+
+    /**
+     * @param  array<string, mixed>  $tokenBody
+     * @return array<string, mixed>|null
+     */
+    private function fetchUserinfo(ResolvedProvider $resolved, array $tokenBody): ?array
+    {
+        $accessToken = (string) $tokenBody['access_token'];
+
+        // Apple sends every claim back in the id_token; the userinfo
+        // endpoint is the token endpoint as a sentinel — short-circuit
+        // and parse the id_token if present.
+        if ($resolved->userinfoEndpoint === $resolved->tokenEndpoint && isset($tokenBody['id_token'])) {
+            return $this->decodeIdTokenClaims((string) $tokenBody['id_token']);
+        }
+
+        $request = Http::withHeaders($resolved->userinfoAuth === 'bearer'
+            ? ['Authorization' => 'Bearer '.$accessToken, 'Accept' => 'application/json']
+            : ['Accept' => 'application/json']);
+
+        try {
+            $response = $resolved->userinfoMethod === 'POST'
+                ? $request->asForm()->post($resolved->userinfoEndpoint, $resolved->userinfoAuth === 'query' ? ['access_token' => $accessToken] : [])
+                : $request->get($resolved->userinfoEndpoint, $resolved->userinfoAuth === 'query' ? ['access_token' => $accessToken] : []);
+        } catch (ConnectionException|RequestException|Throwable) {
+            return null;
+        }
+
+        if (! $response->successful()) {
+            return null;
+        }
+        $body = $response->json();
+
+        return is_array($body) ? $body : null;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decodeIdTokenClaims(string $idToken): ?array
+    {
+        $parts = explode('.', $idToken);
+        if (count($parts) !== 3) {
+            return null;
+        }
+        $payload = base64_decode(strtr($parts[1], '-_', '+/'), true);
+        if ($payload === false) {
+            return null;
+        }
+        $decoded = json_decode($payload, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @param  array<string, string>  $mapping  e.g. `{ "email" => "email", "first_name" => "given_name" }`
+     * @param  array<string, mixed>  $userinfo
+     * @return array<string, mixed>
+     */
+    private function applyAttributeMapping(array $mapping, array $userinfo): array
+    {
+        $out = [];
+        foreach ($mapping as $shape => $claim) {
+            if (! is_string($claim) || $claim === '') {
+                continue;
+            }
+            $value = $userinfo;
+            foreach (explode('.', $claim) as $segment) {
+                if (! is_array($value) || ! array_key_exists($segment, $value)) {
+                    $value = null;
+                    break;
+                }
+                $value = $value[$segment];
+            }
+            if ($value !== null) {
+                $out[$shape] = $value;
+            }
+        }
+
+        return $out;
+    }
+
+    private function fail(?string $redirectUrl, ?Verification $verification, string $code, string $message): RedirectResponse
+    {
+        if ($verification !== null) {
+            $verification->forceFill([
+                'status' => Verification::STATUS_FAILED,
+                'error_code' => $code,
+                'error_message' => $message,
+            ])->save();
+            Challenge::query()->withoutGlobalScopes()
+                ->where('verification_id', $verification->id)
+                ->update([
+                    'status' => Challenge::STATUS_FAILED,
+                    'error_code' => $code,
+                    'error_message' => $message,
+                ]);
+        }
+
+        Log::info('audit:fapi.oauth_callback.failed', [
+            'code' => $code,
+            'message' => $message,
+            'verification_id' => $verification?->id,
+        ]);
+
+        $target = $redirectUrl !== null && $redirectUrl !== ''
+            ? $redirectUrl.(str_contains($redirectUrl, '?') ? '&' : '?').'__authn_error='.urlencode($code)
+            : '/?__authn_error='.urlencode($code);
+
+        return redirect()->away($target);
+    }
+}

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Fapi\MeController;
 use App\Http\Controllers\Fapi\MeOrganizationController;
 use App\Http\Controllers\Fapi\MePhoneNumberController;
 use App\Http\Controllers\Fapi\MeTotpController;
+use App\Http\Controllers\Fapi\OauthCallbackController;
 use App\Http\Controllers\Fapi\OrganizationController as FapiOrganizationController;
 use App\Http\Controllers\Fapi\OrganizationInvitationController as FapiOrganizationInvitationController;
 use App\Http\Controllers\Fapi\OrganizationMembershipController as FapiOrganizationMembershipController;
@@ -70,6 +71,12 @@ Route::prefix('v1')->group(function (): void {
         // Magic-link click handler (AU-10). Top-level browser navigation
         // from the email — no Origin header, no Client cookie required.
         Route::get('/client/magic-link/redeem', [MagicLinkController::class, 'redeem'])->name('fapi.magic_link.redeem');
+
+        // OAuth callback — IdP top-level redirect back from the authorize
+        // dance. No Origin / Client cookie required (redirect lands on a
+        // fresh navigation context); state token in the query string is
+        // the integrity check.
+        Route::get('/oauth-callback/{provider_key}', OauthCallbackController::class)->name('fapi.oauth_callback');
     });
 
     // Sign-in: POST creates the attempt (and, if needed, the Client). The

--- a/tests/Feature/Auth/Oauth/OauthCallbackTest.php
+++ b/tests/Feature/Auth/Oauth/OauthCallbackTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Oauth\StateToken;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+use App\Models\Project;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Route;
+
+function reloadOauthFapiRoutes(): void
+{
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+    $appHost = (string) config('authn.app_host');
+    $fapi = Route::middleware('fapi');
+    if ((string) config('authn.routing_mode') === 'subdomain') {
+        $fapi->domain('{env_slug}.'.$appHost);
+    } else {
+        $fapi->prefix('{env_slug}');
+    }
+    $fapi->group(base_path('routes/fapi.php'));
+}
+
+function envForOauthCallback(): Environment
+{
+    config([
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'http',
+        'authn.app_port_suffix' => '',
+        'authn.bapi_host' => 'api.authn.local',
+    ]);
+    reloadOauthFapiRoutesIfNeeded();
+    $project = Project::create(['name' => 'P', 'slug' => 'p-cb']);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'cb',
+        'routing_label' => 'cb',
+    ]);
+}
+
+function reloadOauthFapiRoutesIfNeeded(): void
+{
+    reloadOauthFapiRoutes();
+}
+
+function makeEnabledGoogleProvider(Environment $env): OauthProvider
+{
+    $row = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('provider_key', 'google')
+        ->firstOrFail();
+    $row->forceFill([
+        'enabled' => true,
+        'client_id' => 'gid',
+        'encrypted_client_secret' => 'gsecret',
+    ])->save();
+
+    return $row->refresh();
+}
+
+it('callback rejects invalid state with a 302 + __authn_error', function (): void {
+    $env = envForOauthCallback();
+
+    $r = $this->withHeaders(['Host' => 'cb.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get('http://cb.authn.local/v1/oauth-callback/google?state=garbage&code=abc');
+
+    $r->assertRedirect();
+    expect($r->headers->get('Location'))->toContain('__authn_error=state_invalid');
+});
+
+it('callback succeeds: exchanges code, fetches userinfo, creates User + ExternalAccount', function (): void {
+    $env = envForOauthCallback();
+    app()->instance(Environment::class, $env);
+    $provider = makeEnabledGoogleProvider($env);
+    $client = Client::create(['environment_id' => $env->id]);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => $client->id,
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+    $verification = Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => 'oauth_google',
+        'status' => Verification::STATUS_UNVERIFIED,
+        'attempts' => 0,
+        'expire_at' => now()->addMinutes(10),
+    ]);
+
+    Http::fake([
+        'oauth2.googleapis.com/token' => Http::response([
+            'access_token' => 'at-1', 'refresh_token' => 'rt-1', 'expires_in' => 3600, 'scope' => 'openid email profile',
+        ], 200),
+        'openidconnect.googleapis.com/v1/userinfo' => Http::response([
+            'sub' => 'g-12345', 'email' => 'alice@example.com', 'email_verified' => true,
+            'given_name' => 'Alice', 'family_name' => 'Smith', 'picture' => 'https://example.com/a.png',
+        ], 200),
+    ]);
+
+    $state = StateToken::mint(
+        environmentId: $env->id,
+        providerKey: 'google',
+        verificationId: $verification->id,
+        clientId: $client->id,
+        attemptId: $attempt->id,
+        attemptKind: 'sign_in',
+        redirectUrl: 'http://app.example.com/sign-in',
+        redirectUrlComplete: 'http://app.example.com/dashboard',
+        nonce: 'n-1',
+    );
+
+    $r = $this->withHeaders(['Host' => 'cb.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get('http://cb.authn.local/v1/oauth-callback/google?state='.urlencode($state).'&code=auth-code-1');
+
+    $r->assertRedirect();
+    expect($r->headers->get('Location'))->toBe('http://app.example.com/dashboard');
+
+    expect($verification->fresh()->status)->toBe(Verification::STATUS_VERIFIED);
+
+    $ext = ExternalAccount::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('oauth_provider_id', $provider->id)
+        ->where('provider_user_id', 'g-12345')
+        ->first();
+    expect($ext)->not->toBeNull();
+    $user = User::query()->withoutGlobalScopes()->where('id', $ext->user_id)->first();
+    expect($user)->not->toBeNull();
+    expect($user->first_name)->toBe('Alice');
+});
+
+it('callback handles IdP error by flipping verification + redirecting with the error', function (): void {
+    $env = envForOauthCallback();
+    app()->instance(Environment::class, $env);
+    makeEnabledGoogleProvider($env);
+    $client = Client::create(['environment_id' => $env->id]);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => $client->id,
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+    $verification = Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => 'oauth_google',
+        'status' => Verification::STATUS_UNVERIFIED,
+        'attempts' => 0,
+        'expire_at' => now()->addMinutes(10),
+    ]);
+    $state = StateToken::mint(
+        environmentId: $env->id,
+        providerKey: 'google',
+        verificationId: $verification->id,
+        clientId: $client->id,
+        attemptId: $attempt->id,
+        attemptKind: 'sign_in',
+        redirectUrl: 'http://app.example.com/sign-in',
+        redirectUrlComplete: 'http://app.example.com/dashboard',
+        nonce: 'n-1',
+    );
+
+    $r = $this->withHeaders(['Host' => 'cb.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get('http://cb.authn.local/v1/oauth-callback/google?state='.urlencode($state).'&error=access_denied&error_description=denied');
+
+    $r->assertRedirect();
+    expect($r->headers->get('Location'))->toContain('__authn_error=access_denied');
+    expect($verification->fresh()->status)->toBe(Verification::STATUS_FAILED);
+    expect($verification->fresh()->error_code)->toBe('access_denied');
+});
+
+it('callback existing-user re-link updates tokens without creating a duplicate ExternalAccount', function (): void {
+    $env = envForOauthCallback();
+    app()->instance(Environment::class, $env);
+    $provider = makeEnabledGoogleProvider($env);
+    $user = User::query()->withoutGlobalScopes()->create(['environment_id' => $env->id, 'first_name' => 'Existing']);
+    ExternalAccount::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'oauth_provider_id' => $provider->id,
+        'provider_user_id' => 'g-existing',
+        'encrypted_access_token' => 'old-at',
+        'linked_at' => now(),
+    ]);
+    $client = Client::create(['environment_id' => $env->id]);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => $client->id,
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+    $verification = Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => 'oauth_google',
+        'status' => Verification::STATUS_UNVERIFIED,
+        'attempts' => 0,
+        'expire_at' => now()->addMinutes(10),
+    ]);
+    $state = StateToken::mint(
+        environmentId: $env->id,
+        providerKey: 'google',
+        verificationId: $verification->id,
+        clientId: $client->id,
+        attemptId: $attempt->id,
+        attemptKind: 'sign_in',
+        redirectUrl: 'http://app.example.com/',
+        redirectUrlComplete: 'http://app.example.com/done',
+        nonce: 'n-1',
+    );
+
+    Http::fake([
+        'oauth2.googleapis.com/token' => Http::response(['access_token' => 'fresh-at', 'refresh_token' => 'fresh-rt', 'expires_in' => 3600], 200),
+        'openidconnect.googleapis.com/v1/userinfo' => Http::response(['sub' => 'g-existing', 'email' => 'existing@example.com', 'email_verified' => true], 200),
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'cb.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get('http://cb.authn.local/v1/oauth-callback/google?state='.urlencode($state).'&code=ok');
+
+    $r->assertRedirect();
+    expect($r->headers->get('Location'))->toBe('http://app.example.com/done');
+
+    $rows = ExternalAccount::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('oauth_provider_id', $provider->id)
+        ->get();
+    expect($rows)->toHaveCount(1);
+    expect($rows->first()->encrypted_access_token)->toBe('fresh-at');
+});


### PR DESCRIPTION
Closes #125.

## Summary

- New `OauthRedirectStrategy`: prepares the IdP authorize URL via `OauthProviderResolver`, mints an encrypted `state` token (Crypt::encryptString, 10-min TTL) carrying attempt + verification + redirect URLs + nonce, sets `Verification.external_verification_redirect_url` so the SDK does the redirect dance.
- `StrategyResolver` matches `^oauth_<key>$` by regex and dispatches every concrete `oauth_<key>` to the single OauthRedirectStrategy instance.
- New `OauthCallbackController` mounted at `GET /v1/oauth-callback/{provider_key}` (no Origin / Client cookie required — top-level redirect from the IdP). Validates `state`, exchanges code, fetches userinfo (or decodes id_token claims for Apple's collapsed userinfo), applies `attribute_mapping`, finds-or-creates User + ExternalAccount, marks the Verification + Challenge verified, mints the Session, 302's to `redirect_url_complete`.
- Honours `allow_sign_in` / `allow_sign_up` / `block_email_subaddresses`. Failure path flips the verification + redirects to `redirect_url?__authn_error=<code>`.
- `ChallengeController.signInSupportedStrategies()` appends every enabled provider's `oauth_<key>` to the first-factor list.

## Test plan

- [x] `vendor/bin/pest --filter OauthCallback` — 4 / 4 passing (state-mismatch, success-path with `Http::fake()`-mocked Google, IdP-error path, existing-user re-link)
- [x] `vendor/bin/pest` — 637 / 637 passing
- [x] `vendor/bin/pint --test` — clean

## Out of scope (note)

- ID-token JWS validation against `jwks_uri` is deferred; userinfo is the authoritative source for now.
- `transferable` cross-flow polish lives in AU-16's E2E sweep.