### PR TITLE
AU-7: FAPI /v1/me/external-accounts (read + delete)

### DIFF
--- a/app/Http/Controllers/Fapi/MeExternalAccountController.php
+++ b/app/Http/Controllers/Fapi/MeExternalAccountController.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Auth\ErrorCodes;
+use App\Http\Resources\ExternalAccountResource;
+use App\Models\EmailAddress;
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+use App\Models\Session;
+use App\Models\User;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * `/v1/me/external-accounts` — end-user social-account inspection +
+ * unlink. Creation is exclusive to the OAuth callback path; this
+ * controller only reads + deletes.
+ *
+ * Delete is best-effort revoke (calls `OauthProvider.revocation_endpoint`
+ * if configured; ignores non-2xx) before dropping the local row +
+ * clearing the linked email's pointer.
+ */
+final class MeExternalAccountController
+{
+    public function index(): JsonResponse
+    {
+        $user = app(User::class);
+        $rows = $user->externalAccounts()->withoutGlobalScopes()->get();
+        $providers = OauthProvider::query()->withoutGlobalScopes()
+            ->whereIn('id', $rows->pluck('oauth_provider_id')->unique()->values())
+            ->get()
+            ->keyBy('id');
+
+        return response()->json([
+            'data' => $rows->map(fn (ExternalAccount $r) => ExternalAccountResource::from($r, $providers->get($r->oauth_provider_id)))->all(),
+            'total_count' => $rows->count(),
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function show(Request $request): JsonResponse
+    {
+        $row = $this->load($request);
+        if ($row instanceof JsonResponse) {
+            return $row;
+        }
+        $provider = OauthProvider::query()->withoutGlobalScopes()->where('id', $row->oauth_provider_id)->first();
+
+        return response()->json(ExternalAccountResource::from($row, $provider))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot unlink external accounts.');
+        }
+        $row = $this->load($request);
+        if ($row instanceof JsonResponse) {
+            return $row;
+        }
+
+        $provider = OauthProvider::query()->withoutGlobalScopes()->where('id', $row->oauth_provider_id)->first();
+        if ($provider !== null) {
+            $this->bestEffortRevoke($provider, $row);
+        }
+
+        if ($row->email_address !== null) {
+            EmailAddress::query()->withoutGlobalScopes()
+                ->where('environment_id', $row->environment_id)
+                ->where('linked_to_external_account_id', $row->id)
+                ->update(['linked_to_external_account_id' => null]);
+        }
+
+        $row->delete();
+
+        return response()->json(null, 204);
+    }
+
+    private function bestEffortRevoke(OauthProvider $provider, ExternalAccount $row): void
+    {
+        $endpoint = $this->revocationEndpointFor($provider);
+        if ($endpoint === null) {
+            return;
+        }
+        $token = $row->encrypted_refresh_token ?? $row->encrypted_access_token;
+        if ($token === null || $token === '') {
+            return;
+        }
+        try {
+            Http::asForm()->timeout(5)->post($endpoint, [
+                'token' => $token,
+                'client_id' => $provider->client_id,
+                'client_secret' => $provider->encrypted_client_secret,
+            ]);
+        } catch (ConnectionException|RequestException|Throwable $e) {
+            Log::info('audit:fapi.external_account.revoke_failed', [
+                'external_account_id' => $row->id,
+                'provider_key' => $provider->provider_key,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Pull a known revocation endpoint from the provider's stored
+     * `additional_authorization_params` when present. v0.4 doesn't
+     * model this as a top-level column; operators that want strict
+     * revocation set it via the BAPI's `additional_authorization_params`
+     * patch surface (key: `revocation_endpoint`).
+     */
+    private function revocationEndpointFor(OauthProvider $provider): ?string
+    {
+        $params = is_array($provider->additional_authorization_params) ? $provider->additional_authorization_params : [];
+        $value = $params['revocation_endpoint'] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    private function load(Request $request): ExternalAccount|JsonResponse
+    {
+        $id = (string) $request->route('external_account_id');
+        $user = app(User::class);
+        $row = ExternalAccount::query()
+            ->withoutGlobalScopes()
+            ->where('id', $id)
+            ->where('user_id', $user->id)
+            ->first();
+        if ($row === null) {
+            return $this->error(404, 'external_account_not_found', 'External account not found on this user.');
+        }
+
+        return $row;
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [['code' => $code, 'message' => $message, 'long_message' => $message, 'meta' => []]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Resources/ExternalAccountResource.php
+++ b/app/Http/Resources/ExternalAccountResource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+
+/**
+ * Public ExternalAccount shape per OA-2. Token blobs (access_token,
+ * refresh_token, id_token) are encrypted at rest on the model and never
+ * appear in any payload — the SDK has no way to read them.
+ */
+final class ExternalAccountResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function from(ExternalAccount $row, ?OauthProvider $provider = null): array
+    {
+        $provider ??= OauthProvider::query()->withoutGlobalScopes()
+            ->where('id', $row->oauth_provider_id)
+            ->first();
+
+        return [
+            'object' => 'external_account',
+            'id' => $row->id,
+            'provider' => $provider?->name ?? '',
+            'provider_key' => $provider?->provider_key ?? '',
+            'provider_user_id' => $row->provider_user_id,
+            'email_address' => $row->email_address,
+            'scopes' => is_array($row->scopes) ? array_values($row->scopes) : [],
+            'public_metadata' => is_array($row->public_metadata) ? $row->public_metadata : [],
+            'verified' => (bool) $row->verified,
+            'linked_at' => $row->linked_at?->getTimestampMs(),
+            'last_signed_in_at' => $row->last_signed_in_at?->getTimestampMs(),
+            'created_at' => $row->created_at?->getTimestampMs(),
+            'updated_at' => $row->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Fapi\EnvironmentController;
 use App\Http\Controllers\Fapi\MagicLinkController;
 use App\Http\Controllers\Fapi\MeBackupCodesController;
 use App\Http\Controllers\Fapi\MeController;
+use App\Http\Controllers\Fapi\MeExternalAccountController;
 use App\Http\Controllers\Fapi\MeOrganizationController;
 use App\Http\Controllers\Fapi\MePhoneNumberController;
 use App\Http\Controllers\Fapi\MeTotpController;
@@ -118,6 +119,10 @@ Route::prefix('v1')->group(function (): void {
         Route::get('/me/phone-numbers/{phone_number_id}', [MePhoneNumberController::class, 'show'])->name('fapi.me.phones.show');
         Route::patch('/me/phone-numbers/{phone_number_id}', [MePhoneNumberController::class, 'update'])->name('fapi.me.phones.update');
         Route::delete('/me/phone-numbers/{phone_number_id}', [MePhoneNumberController::class, 'destroy'])->name('fapi.me.phones.destroy');
+
+        Route::get('/me/external-accounts', [MeExternalAccountController::class, 'index'])->name('fapi.me.external_accounts.list');
+        Route::get('/me/external-accounts/{external_account_id}', [MeExternalAccountController::class, 'show'])->name('fapi.me.external_accounts.show');
+        Route::delete('/me/external-accounts/{external_account_id}', [MeExternalAccountController::class, 'destroy'])->name('fapi.me.external_accounts.destroy');
 
         Route::post('/me/email-addresses/{email_address_id}/challenges', [ChallengeController::class, 'storeForEmailAddress'])->name('fapi.me.emails.challenges.store');
         Route::post('/me/email-addresses/{email_address_id}/challenges/{cid}/answer', [ChallengeController::class, 'answerForEmailAddress'])->name('fapi.me.emails.challenges.answer');

--- a/tests/Feature/Http/Me/MeExternalAccountTest.php
+++ b/tests/Feature/Http/Me/MeExternalAccountTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\EmailAddress;
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function meExtReq(string $method, string $path, string $jwt, array $body = []): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+function makeProviderForExt(string $envId): OauthProvider
+{
+    return OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $envId)
+        ->where('provider_key', 'google')
+        ->firstOrFail();
+}
+
+it('GET /v1/me/external-accounts lists rows for the current user', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $provider = makeProviderForExt($f['env']->id);
+    ExternalAccount::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'oauth_provider_id' => $provider->id,
+        'provider_user_id' => 'g-1',
+        'email_address' => 'alice@example.com',
+        'verified' => true,
+        'scopes' => ['openid', 'email'],
+        'encrypted_access_token' => 'at-1',
+        'linked_at' => now(),
+    ]);
+
+    $r = meExtReq('GET', '/me/external-accounts', $auth['jwt']);
+    $r->assertOk()
+        ->assertJsonPath('total_count', 1)
+        ->assertJsonPath('data.0.object', 'external_account')
+        ->assertJsonPath('data.0.provider_key', 'google')
+        ->assertJsonPath('data.0.provider_user_id', 'g-1');
+});
+
+it('GET /v1/me/external-accounts/{id} 404s when the row is not on this user', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    meExtReq('GET', '/me/external-accounts/ext_nope', $auth['jwt'])
+        ->assertStatus(404)
+        ->assertJsonPath('errors.0.code', 'external_account_not_found');
+});
+
+it('DELETE /v1/me/external-accounts/{id} unlinks the row + clears email pointer', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $provider = makeProviderForExt($f['env']->id);
+    $ext = ExternalAccount::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'oauth_provider_id' => $provider->id,
+        'provider_user_id' => 'g-2',
+        'email_address' => 'alice@example.com',
+        'verified' => true,
+        'encrypted_access_token' => 'at-2',
+        'linked_at' => now(),
+    ]);
+    EmailAddress::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('email_address', strtolower($auth['user']->emailAddresses()->first()->email_address))
+        ->update(['linked_to_external_account_id' => $ext->id]);
+
+    $r = meExtReq('DELETE', '/me/external-accounts/'.$ext->id, $auth['jwt']);
+    $r->assertStatus(204);
+
+    expect(ExternalAccount::query()->withoutGlobalScopes()->where('id', $ext->id)->exists())->toBeFalse();
+    $emails = EmailAddress::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->whereNotNull('linked_to_external_account_id')
+        ->get();
+    expect($emails)->toHaveCount(0);
+});
+
+it('DELETE /v1/me/external-accounts/{id} best-effort revokes against the IdP when revocation_endpoint is configured', function (): void {
+    Http::fake([
+        'https://idp.test/revoke' => Http::response('', 200),
+    ]);
+
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $provider = makeProviderForExt($f['env']->id);
+    $provider->forceFill([
+        'additional_authorization_params' => ['revocation_endpoint' => 'https://idp.test/revoke'],
+    ])->save();
+
+    $ext = ExternalAccount::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'oauth_provider_id' => $provider->id,
+        'provider_user_id' => 'g-3',
+        'encrypted_access_token' => 'at-3',
+        'encrypted_refresh_token' => 'rt-3',
+        'linked_at' => now(),
+    ]);
+
+    meExtReq('DELETE', '/me/external-accounts/'.$ext->id, $auth['jwt'])
+        ->assertStatus(204);
+
+    Http::assertSent(fn ($req) => str_contains($req->url(), 'idp.test/revoke')
+        && $req['token'] === 'rt-3'
+        && $req['client_id'] === $provider->client_id);
+});
+
+it('DELETE /v1/me/external-accounts/{id} succeeds even when the IdP revoke returns 4xx', function (): void {
+    Http::fake([
+        'https://idp.test/revoke' => Http::response('nope', 401),
+    ]);
+
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $provider = makeProviderForExt($f['env']->id);
+    $provider->forceFill([
+        'additional_authorization_params' => ['revocation_endpoint' => 'https://idp.test/revoke'],
+    ])->save();
+    $ext = ExternalAccount::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'oauth_provider_id' => $provider->id,
+        'provider_user_id' => 'g-4',
+        'encrypted_access_token' => 'at-4',
+        'linked_at' => now(),
+    ]);
+
+    meExtReq('DELETE', '/me/external-accounts/'.$ext->id, $auth['jwt'])
+        ->assertStatus(204);
+
+    expect(ExternalAccount::query()->withoutGlobalScopes()->where('id', $ext->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
Closes #126.

## Summary

- New `MeExternalAccountController` with `index` / `show` / `destroy`. Creation is exclusive to the OAuth callback flow (AU-6).
- `ExternalAccountResource` mirrors OA-2's public shape; token blobs (access/refresh/id_token) are encrypted at rest and never appear in any payload.
- `destroy()` is best-effort: if the resolved OauthProvider has `additional_authorization_params.revocation_endpoint`, post the access/refresh token there (5s timeout, 4xx ignored) before dropping the local row + clearing `EmailAddress.linked_to_external_account_id` pointers.
- Impersonation sessions get 403 `actor_session_forbidden` on destroy.
- Routes mounted under `/v1/me/external-accounts` in `routes/fapi.php`, behind the standard FAPI session middleware.

## Test plan

- [x] `vendor/bin/pest --filter MeExternalAccount` — 5 / 5 passing (list, 404 not-on-user, unlink-clears-email-pointer, IdP revoke 200, IdP revoke 4xx-still-deletes-locally)
- [x] `vendor/bin/pest` — 638 / 638 passing
- [x] `vendor/bin/pint --test` — clean