### PR TITLE
AU-15: emit v0.4 webhook events + Dashboard audit log surface

### DIFF
--- a/app/Http/Controllers/Bapi/OauthProviderController.php
+++ b/app/Http/Controllers/Bapi/OauthProviderController.php
@@ -13,6 +13,7 @@ use App\Http\Resources\OauthProviderResource;
 use App\Models\Environment;
 use App\Models\ExternalAccount;
 use App\Models\OauthProvider;
+use App\Webhooks\Emitter;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\JsonResponse;
@@ -83,6 +84,8 @@ final class OauthProviderController
             'provider_key' => $provider->provider_key,
         ]);
 
+        app(Emitter::class)->emit('oauthProvider.created', OauthProviderResource::from($provider), $env);
+
         return response()->json(OauthProviderResource::from($provider), 201);
     }
 
@@ -141,7 +144,10 @@ final class OauthProviderController
             'oauth_provider_id' => $row->id,
         ]);
 
-        return response()->json(OauthProviderResource::from($row->refresh()));
+        $fresh = $row->refresh();
+        app(Emitter::class)->emit('oauthProvider.updated', OauthProviderResource::from($fresh), $env);
+
+        return response()->json(OauthProviderResource::from($fresh));
     }
 
     public function destroy(string $oauthProviderId): JsonResponse
@@ -160,12 +166,15 @@ final class OauthProviderController
             return $this->error(409, 'oauth_provider_in_use', 'Cannot delete: ExternalAccount rows still link to this provider.');
         }
 
+        $snapshot = OauthProviderResource::from($row);
         $row->delete();
 
         Log::info('audit:bapi.oauth_provider.deleted', [
             'environment_id' => $env->id,
             'oauth_provider_id' => $row->id,
         ]);
+
+        app(Emitter::class)->emit('oauthProvider.deleted', $snapshot, $env);
 
         return response()->json([
             'object' => 'deleted_object',

--- a/app/Http/Controllers/Dashboard/DashboardController.php
+++ b/app/Http/Controllers/Dashboard/DashboardController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\Dashboard;
 use App\Auth\Oauth\Exceptions\OauthDiscoveryFailedException;
 use App\Auth\Oauth\OauthProviderResolver;
 use App\Auth\Oauth\PresetRegistry;
+use App\Http\Resources\OauthProviderResource;
 use App\Jobs\Sms\SendSmsTemplate;
 use App\Models\AllowlistIdentifier;
 use App\Models\ApiKey;
@@ -29,10 +30,12 @@ use App\Models\SmsTemplate;
 use App\Models\User;
 use App\Models\WebhookDelivery;
 use App\Models\WebhookEndpoint;
+use App\Models\WebhookEvent;
 use App\Services\Keys\KeyGenerator;
 use App\Settings\MultiFactorSettings;
 use App\Support\RoutingLabel;
 use App\Support\Url;
+use App\Webhooks\Emitter;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\RedirectResponse;
@@ -565,7 +568,9 @@ final class DashboardController
             }
         }
 
-        OauthProvider::query()->withoutGlobalScopes()->create($payload);
+        $created = OauthProvider::query()->withoutGlobalScopes()->create($payload);
+
+        app(Emitter::class)->emit('oauthProvider.created', OauthProviderResource::from($created), $env);
 
         return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/social-providers")
             ->with('oauth_provider_saved', true);
@@ -612,6 +617,8 @@ final class DashboardController
 
         $row->forceFill($patch)->save();
 
+        app(Emitter::class)->emit('oauthProvider.updated', OauthProviderResource::from($row->refresh()), $env);
+
         return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/social-providers")
             ->with('oauth_provider_saved', true);
     }
@@ -638,7 +645,10 @@ final class DashboardController
             return redirect()->back()->withErrors(['oauth_provider_id' => 'ExternalAccount rows still link to this provider.']);
         }
 
+        $snapshot = OauthProviderResource::from($row);
         $row->delete();
+
+        app(Emitter::class)->emit('oauthProvider.deleted', $snapshot, $env);
 
         return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/social-providers")
             ->with('oauth_provider_saved', true);
@@ -836,16 +846,30 @@ final class DashboardController
             ->with('signing_secret', $row->displaySecret());
     }
 
-    public function auditLog(string $project_slug, string $env_slug): InertiaResponse|RedirectResponse
+    public function auditLog(Request $request, string $project_slug, string $env_slug): InertiaResponse|RedirectResponse
     {
         $env = $this->env($project_slug, $env_slug);
         if ($env === null) {
             return redirect(Url::dashboardPathPrefix().'/create-project');
         }
 
+        $query = WebhookEvent::query()->withoutGlobalScopes()->where('environment_id', $env->id);
+        $filter = (string) $request->input('type', '');
+        if ($filter !== '') {
+            $query->where('type', 'like', $filter.'%');
+        }
+        $entries = $query->latest('created_at')->limit(100)->get();
+
         return Inertia::render('Dashboard/AuditLog', [
-            'note' => 'Full audit log lands in v0.8 (PLAN §15.5). v0.1 surfaces only API key + webhook endpoint mutations.',
-            'entries' => [],
+            'note' => 'Operator audit feed: all webhook events for this environment. Full audit log lands in v0.8 (PLAN §15.5).',
+            'filter' => $filter,
+            'entries' => $entries->map(fn (WebhookEvent $e) => [
+                'id' => $e->id,
+                'type' => $e->type,
+                'was_test' => (bool) $e->was_test,
+                'data' => $e->data,
+                'created_at' => $e->created_at?->getTimestampMs(),
+            ])->all(),
         ]);
     }
 

--- a/app/Http/Controllers/Fapi/MeExternalAccountController.php
+++ b/app/Http/Controllers/Fapi/MeExternalAccountController.php
@@ -7,10 +7,12 @@ namespace App\Http\Controllers\Fapi;
 use App\Auth\ErrorCodes;
 use App\Http\Resources\ExternalAccountResource;
 use App\Models\EmailAddress;
+use App\Models\Environment;
 use App\Models\ExternalAccount;
 use App\Models\OauthProvider;
 use App\Models\Session;
 use App\Models\User;
+use App\Webhooks\Emitter;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\JsonResponse;
@@ -80,7 +82,11 @@ final class MeExternalAccountController
                 ->update(['linked_to_external_account_id' => null]);
         }
 
+        $snapshot = ExternalAccountResource::from($row, $provider);
         $row->delete();
+
+        $env = app()->bound(Environment::class) ? app(Environment::class) : null;
+        app(Emitter::class)->emit('externalAccount.unlinked', $snapshot, $env);
 
         return response()->json(null, 204);
     }

--- a/app/Http/Controllers/Fapi/MePhoneNumberController.php
+++ b/app/Http/Controllers/Fapi/MePhoneNumberController.php
@@ -12,6 +12,7 @@ use App\Models\Environment;
 use App\Models\PhoneNumber;
 use App\Models\Session;
 use App\Models\User;
+use App\Webhooks\Emitter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -72,7 +73,10 @@ final class MePhoneNumberController
             'is_primary' => false,
         ]);
 
-        return $this->clientEnvelope(PhoneNumberResource::from($row->fresh()), 201);
+        $fresh = $row->fresh();
+        app(Emitter::class)->emit('phoneNumber.created', PhoneNumberResource::from($fresh), $env);
+
+        return $this->clientEnvelope(PhoneNumberResource::from($fresh), 201);
     }
 
     public function show(Request $request): JsonResponse
@@ -132,7 +136,11 @@ final class MePhoneNumberController
             return $this->error(409, ErrorCodes::PHONE_RESERVED_FOR_SECOND_FACTOR, 'Phone is reserved for second-factor MFA. Toggle reserved_for_second_factor off first.');
         }
 
+        $snapshot = PhoneNumberResource::from($row);
         $row->delete();
+
+        $env = app()->bound(Environment::class) ? app(Environment::class) : null;
+        app(Emitter::class)->emit('phoneNumber.removed', $snapshot, $env);
 
         return response()->json(null, 204);
     }

--- a/app/Http/Controllers/Fapi/OauthCallbackController.php
+++ b/app/Http/Controllers/Fapi/OauthCallbackController.php
@@ -8,6 +8,7 @@ use App\Auth\Oauth\Exceptions\OauthDiscoveryFailedException;
 use App\Auth\Oauth\OauthProviderResolver;
 use App\Auth\Oauth\ResolvedProvider;
 use App\Auth\Oauth\StateToken;
+use App\Http\Resources\ExternalAccountResource;
 use App\Models\Challenge;
 use App\Models\EmailAddress;
 use App\Models\Environment;
@@ -17,6 +18,7 @@ use App\Models\Session;
 use App\Models\SignInAttempt;
 use App\Models\User;
 use App\Models\Verification;
+use App\Webhooks\Emitter;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\RedirectResponse;
@@ -113,6 +115,10 @@ final class OauthCallbackController
             return $this->fail($state['ru'] ?? null, $verification, 'oauth_token_exchange_failed', 'Token endpoint returned no access_token.');
         }
 
+        // TODO(AU-6.1): for preset providers (Google/Apple/Microsoft) the
+        // id_token is the authoritative source of `sub` + `email_verified`.
+        // Validate the JWS signature against the provider's JWKS before
+        // trusting userinfo. Tracked for v0.4.0-stable.
         $userinfo = $this->fetchUserinfo($resolved, $tokenBody);
         if ($userinfo === null) {
             return $this->fail($state['ru'] ?? null, $verification, 'oauth_userinfo_failed', 'userinfo lookup returned no data.');
@@ -255,6 +261,14 @@ final class OauthCallbackController
             'external_account_id' => $result['external_account']?->id,
             'created' => $result['created'] ?? false,
         ]);
+
+        if (($result['created'] ?? false) === true && $result['external_account'] instanceof ExternalAccount) {
+            app(Emitter::class)->emit(
+                'externalAccount.connected',
+                ExternalAccountResource::from($result['external_account'], $provider),
+                $env,
+            );
+        }
 
         $redirect = (string) ($state['ruc'] ?? $state['ru'] ?? '/');
 

--- a/app/Models/PhoneNumber.php
+++ b/app/Models/PhoneNumber.php
@@ -6,7 +6,9 @@ namespace App\Models;
 
 use App\Concerns\HasPrefixedUlid;
 use App\Database\Scopes\EnvironmentScope;
+use App\Http\Resources\PhoneNumberResource;
 use App\Observers\PhoneNumberObserver;
+use App\Webhooks\Emitter;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -104,5 +106,8 @@ class PhoneNumber extends Model
             ->withoutGlobalScopes()
             ->whereKey($this->user_id)
             ->update(['phone_number_enabled' => true]);
+
+        $env = Environment::query()->withoutGlobalScopes()->whereKey($this->environment_id)->first();
+        app(Emitter::class)->emit('phoneNumber.verified', PhoneNumberResource::from($this->fresh() ?? $this), $env);
     }
 }

--- a/resources/js/dashboard/pages/AuditLog.tsx
+++ b/resources/js/dashboard/pages/AuditLog.tsx
@@ -1,15 +1,97 @@
-type Props = { note: string; entries: Array<{ id: string; type: string; at: number }> }
+import { Link } from '@inertiajs/react'
+import { useDashboard, useDashboardUrl } from '../shared'
 
-export default function AuditLog({ note, entries }: Props) {
+type Entry = {
+    id: string
+    type: string
+    was_test: boolean
+    data: Record<string, unknown>
+    created_at: number | null
+}
+
+type Props = {
+    note: string
+    filter: string
+    entries: Entry[]
+}
+
+export default function AuditLog({ note, filter, entries }: Props) {
+    const url = useDashboardUrl()
+    const { active_project, active_environment } = useDashboard()
+    const base = active_project && active_environment
+        ? `/${active_project.slug}/${active_environment.slug}/audit-log`
+        : '/audit-log'
+
+    const facets = [
+        { slug: '', label: 'all' },
+        { slug: 'user', label: 'user' },
+        { slug: 'session', label: 'session' },
+        { slug: 'oauthProvider', label: 'oauth provider' },
+        { slug: 'externalAccount', label: 'external account' },
+        { slug: 'phoneNumber', label: 'phone number' },
+        { slug: 'organization', label: 'organization' },
+        { slug: 'sms', label: 'sms' },
+        { slug: 'email', label: 'email' },
+    ]
+
     return (
         <div>
             <h1>Audit log</h1>
-            <p>{note}</p>
-            <ul>
-                {entries.map(e => (
-                    <li key={e.id}>{e.type} — {new Date(e.at).toISOString()}</li>
-                ))}
-            </ul>
+            <p style={{ color: '#64748b' }}>{note}</p>
+            <nav style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
+                {facets.map(f => {
+                    const active = filter === f.slug
+                    const href = f.slug === '' ? url(base) : url(`${base}?type=${encodeURIComponent(f.slug)}`)
+                    return (
+                        <Link
+                            key={f.slug || 'all'}
+                            href={href}
+                            style={{
+                                padding: '4px 8px',
+                                borderRadius: 4,
+                                fontSize: 13,
+                                background: active ? '#0f172a' : '#f1f5f9',
+                                color: active ? '#fff' : '#0f172a',
+                                textDecoration: 'none',
+                            }}
+                        >
+                            {f.label}
+                        </Link>
+                    )
+                })}
+            </nav>
+            {entries.length === 0 ? (
+                <p style={{ color: '#94a3b8' }}>No events match the current filter.</p>
+            ) : (
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+                    <thead>
+                        <tr style={{ textAlign: 'left', borderBottom: '1px solid #e2e8f0' }}>
+                            <th style={{ padding: '6px 8px', width: 200 }}>at</th>
+                            <th style={{ padding: '6px 8px', width: 240 }}>type</th>
+                            <th style={{ padding: '6px 8px' }}>data</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {entries.map(e => (
+                            <tr key={e.id} style={{ borderBottom: '1px solid #f1f5f9', verticalAlign: 'top' }}>
+                                <td style={{ padding: '6px 8px', fontFamily: 'monospace', color: '#475569' }}>
+                                    {e.created_at ? new Date(e.created_at).toISOString() : '—'}
+                                    {e.was_test && <span style={{ marginLeft: 6, fontSize: 11, color: '#b45309' }}>test</span>}
+                                </td>
+                                <td style={{ padding: '6px 8px' }}><code>{e.type}</code></td>
+                                <td style={{ padding: '6px 8px' }}>
+                                    <details>
+                                        <summary style={{ cursor: 'pointer', color: '#64748b' }}>view payload</summary>
+                                        <pre style={{ fontSize: 12, marginTop: 4, padding: 8, background: '#f8fafc', borderRadius: 4, overflow: 'auto' }}>
+                                            {JSON.stringify(e.data, null, 2)}
+                                        </pre>
+                                    </details>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
         </div>
     )
 }

--- a/tests/Feature/Http/Dashboard/DashboardTest.php
+++ b/tests/Feature/Http/Dashboard/DashboardTest.php
@@ -16,6 +16,7 @@ use App\Models\Session;
 use App\Models\SmsTemplate;
 use App\Models\User;
 use App\Models\WebhookEndpoint;
+use App\Models\WebhookEvent;
 use App\Services\Keys\SigningKeyGenerator;
 use App\Services\Sessions\SessionTokenIssuer;
 use Illuminate\Routing\RouteCollection;
@@ -733,4 +734,71 @@ it('DELETE /configure/oauth-providers/{id} removes the row when no ExternalAccou
 
     $r->assertRedirect();
     expect(OauthProvider::query()->withoutGlobalScopes()->where('id', $row->id)->whereNull('deleted_at')->exists())->toBeFalse();
+});
+
+it('PATCH /configure/oauth-providers/{id} emits oauthProvider.updated', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+    $row = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)->where('provider_key', 'google')->firstOrFail();
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->patch('http://dashboard.authn.local/acme/production/configure/oauth-providers/'.$row->id, [
+            'name' => 'Renamed via Dashboard',
+        ]);
+
+    $r->assertRedirect();
+    $types = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->pluck('type')
+        ->all();
+    expect($types)->toContain('oauthProvider.updated');
+});
+
+it('GET /audit-log surfaces recent WebhookEvent rows for the environment', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+    WebhookEvent::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'type' => 'phoneNumber.created',
+        'data' => ['object' => 'phone_number', 'id' => 'phn_test'],
+        'was_test' => false,
+    ]);
+    WebhookEvent::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'type' => 'oauthProvider.created',
+        'data' => ['object' => 'oauth_provider', 'id' => 'oauthp_test'],
+        'was_test' => false,
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->get('http://dashboard.authn.local/acme/production/audit-log');
+
+    $r->assertOk()->assertJsonPath('component', 'Dashboard/AuditLog');
+    $types = collect($r->json('props.entries'))->pluck('type')->all();
+    expect($types)->toContain('phoneNumber.created')
+        ->and($types)->toContain('oauthProvider.created');
+
+    // Filter narrows to one type prefix.
+    $r2 = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->get('http://dashboard.authn.local/acme/production/audit-log?type=oauthProvider');
+    $types2 = collect($r2->json('props.entries'))->pluck('type')->all();
+    expect($types2)->toContain('oauthProvider.created')
+        ->and($types2)->not->toContain('phoneNumber.created');
 });

--- a/tests/Feature/Webhooks/V04EventEmissionTest.php
+++ b/tests/Feature/Webhooks/V04EventEmissionTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\Webhooks\DispatchWebhookDelivery;
+use App\Models\Environment;
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+use App\Models\PhoneNumber;
+use App\Models\WebhookEndpoint;
+use App\Models\WebhookEvent;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function au15Endpoint(Environment $env, array $types): WebhookEndpoint
+{
+    return WebhookEndpoint::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'url' => 'https://hook.test/ep',
+        'enabled' => true,
+        'enabled_event_types' => $types,
+        'signing_secret' => 'whsec_'.bin2hex(random_bytes(8)),
+    ]);
+}
+
+function au15MeReq(string $method, string $path, string $jwt, array $body = []): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+it('emits oauthProvider.created/updated/deleted across the BAPI lifecycle', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $boot = BapiTestSupport::bootEnv('au15oauth');
+    app()->instance(Environment::class, $boot['env']);
+    au15Endpoint($boot['env'], ['oauthProvider.created', 'oauthProvider.updated', 'oauthProvider.deleted']);
+
+    $createResp = test()->postJson(
+        BapiTestSupport::url('/oauth-providers'),
+        [
+            'provider_kind' => 'custom_oauth2',
+            'provider_key' => 'acme_au15',
+            'name' => 'Acme',
+            'enabled' => true,
+            'client_id' => 'cid',
+            'client_secret' => 'sec',
+            'authorization_endpoint' => 'https://acme.test/authorize',
+            'token_endpoint' => 'https://acme.test/token',
+            'userinfo_endpoint' => 'https://acme.test/userinfo',
+            'userinfo_method' => 'GET',
+            'userinfo_auth' => 'bearer',
+        ],
+        BapiTestSupport::headers($boot['token']),
+    );
+    $createResp->assertCreated();
+    $providerId = $createResp->json('id');
+
+    test()->patchJson(
+        BapiTestSupport::url('/oauth-providers/'.$providerId),
+        ['name' => 'Acme Renamed'],
+        BapiTestSupport::headers($boot['token']),
+    )->assertOk();
+
+    test()->deleteJson(
+        BapiTestSupport::url('/oauth-providers/'.$providerId),
+        [],
+        BapiTestSupport::headers($boot['token']),
+    )->assertOk();
+
+    $types = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $boot['env']->id)
+        ->orderBy('created_at')
+        ->pluck('type')
+        ->all();
+    expect($types)->toContain('oauthProvider.created')
+        ->and($types)->toContain('oauthProvider.updated')
+        ->and($types)->toContain('oauthProvider.deleted');
+
+    Bus::assertDispatched(DispatchWebhookDelivery::class, 3);
+});
+
+it('emits phoneNumber.created on POST /v1/me/phone-numbers and phoneNumber.removed on DELETE', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = MeTestSupport::bootEnv();
+    app()->instance(Environment::class, $f['env']);
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    au15Endpoint($f['env'], ['phoneNumber.created', 'phoneNumber.removed']);
+
+    $createResp = au15MeReq('POST', '/me/phone-numbers', $auth['jwt'], ['phone_number' => '+15555550111']);
+    $createResp->assertCreated();
+    $phoneId = $createResp->json('response.id');
+
+    au15MeReq('DELETE', '/me/phone-numbers/'.$phoneId, $auth['jwt'])->assertNoContent();
+
+    $types = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->orderBy('created_at')
+        ->pluck('type')
+        ->all();
+    expect($types)->toContain('phoneNumber.created')
+        ->and($types)->toContain('phoneNumber.removed');
+});
+
+it('emits phoneNumber.verified once per row when markVerified() flips the cached flag', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = MeTestSupport::bootEnv();
+    app()->instance(Environment::class, $f['env']);
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    au15Endpoint($f['env'], ['phoneNumber.verified']);
+
+    $phone = PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'phone_number' => '+15555550112',
+        'is_primary' => false,
+    ]);
+
+    $phone->markVerified();
+    $phone->fresh()->markVerified(); // idempotent — must not double-emit.
+
+    $count = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('type', 'phoneNumber.verified')
+        ->count();
+    expect($count)->toBe(1);
+});
+
+it('emits externalAccount.unlinked on DELETE /v1/me/external-accounts/{id}', function (): void {
+    Bus::fake([DispatchWebhookDelivery::class]);
+    $f = MeTestSupport::bootEnv();
+    app()->instance(Environment::class, $f['env']);
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    au15Endpoint($f['env'], ['externalAccount.unlinked']);
+
+    $provider = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('provider_key', 'google')
+        ->firstOrFail();
+    $external = ExternalAccount::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'oauth_provider_id' => $provider->id,
+        'provider_user_id' => 'sub-au15',
+        'email_address' => 'au15@example.test',
+        'verified' => true,
+        'scopes' => [],
+        'public_metadata' => [],
+        'encrypted_access_token' => 'tok',
+        'linked_at' => now(),
+        'last_signed_in_at' => now(),
+    ]);
+
+    au15MeReq('DELETE', '/me/external-accounts/'.$external->id, $auth['jwt'])->assertNoContent();
+
+    $types = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->pluck('type')
+        ->all();
+    expect($types)->toContain('externalAccount.unlinked');
+});


### PR DESCRIPTION
## Summary

Wires the eight v0.4 webhook events declared in the OpenAPI catalogue and turns the empty Dashboard audit-log panel into a real recent-events feed.

**Events emitted** (catalogue in `openapi/components/schemas/WebhookEvent.yaml` lines 96-104):

| Event | Callsite |
|---|---|
| `oauthProvider.created` | BAPI `OauthProviderController::store` + Dashboard `storeOauthProvider` |
| `oauthProvider.updated` | BAPI `OauthProviderController::update` + Dashboard `updateOauthProvider` |
| `oauthProvider.deleted` | BAPI `OauthProviderController::destroy` + Dashboard `destroyOauthProvider` |
| `externalAccount.connected` | `OauthCallbackController` after first-link create |
| `externalAccount.unlinked` | `MeExternalAccountController::destroy` (snapshot captured pre-delete) |
| `phoneNumber.created` | `MePhoneNumberController::store` |
| `phoneNumber.removed` | `MePhoneNumberController::destroy` (snapshot captured pre-delete) |
| `phoneNumber.verified` | `PhoneNumber::markVerified()` — emits idempotently from any path that flips verified_at (phone-attribute sign-up, MFA enrolment, /verify-phone-number) |

**Audit log surface**: `Dashboard/AuditLog` now lists the latest 100 `WebhookEvent` rows for the environment with a `?type=…` prefix filter. The Inertia page renders type, ISO timestamp, was_test badge, and the JSON payload behind a \`<details>\` toggle.

**AU-6.1 TODO**: dropped in `OauthCallbackController` flagging that preset providers should validate the `id_token` JWS against the JWKS before trusting userinfo for `sub`/`email_verified`. Deferred to v0.4.0-stable per team-lead direction; tracked separately so the issue can land once #148 has settled.

## Test plan

- [x] `./vendor/bin/pest` — 654 passing, 2149 assertions
- [x] `./vendor/bin/pint --test` — clean
- [x] `npm run build` — clean
- [x] `tests/Feature/Webhooks/V04EventEmissionTest.php` — 4 new cases: BAPI oauth-provider lifecycle, phoneNumber.created+removed, phoneNumber.verified idempotency, externalAccount.unlinked
- [x] `tests/Feature/Http/Dashboard/DashboardTest.php` — 2 new cases: audit-log render with filter, oauthProvider.updated emit on Dashboard PATCH