### PR TITLE
AU-16: end-to-end Pest coverage for v0.4 OAuth + phone-MFA flows

### DIFF
--- a/tests/Feature/Auth/Oauth/OauthSignInE2ETest.php
+++ b/tests/Feature/Auth/Oauth/OauthSignInE2ETest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+use App\Models\Session;
+use App\Models\User;
+use App\Models\Verification;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\SignIn\SignInTestSupport;
+
+/**
+ * AU-16: end-to-end OAuth sign-in / sign-up flows. Covers the full dance
+ * (`POST /sign-ins → external_verification_redirect_url → callback → session`)
+ * that the strategy + callback unit tests don't exercise together.
+ */
+function au16EnableProvider(Environment $env, string $key, bool $allowSignUp = true, bool $blockSubaddresses = false): OauthProvider
+{
+    $row = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('provider_key', $key)
+        ->firstOrFail();
+    $row->forceFill([
+        'enabled' => true,
+        'allow_sign_in' => true,
+        'allow_sign_up' => $allowSignUp,
+        'block_email_subaddresses' => $blockSubaddresses,
+        'client_id' => 'cid-'.$key,
+        'encrypted_client_secret' => 'sec-'.$key,
+    ])->save();
+
+    return $row->refresh();
+}
+
+function au16SignInPost(array $f, array $body): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', $body);
+}
+
+function au16StartOauth(array $f, string $providerKey, string $redirectUrl, string $redirectUrlComplete, ?string $identifierHint = 'oauth-hint@example.com'): array
+{
+    $cb = SignInTestSupport::clientWithCookie($f['env']);
+
+    $created = test()->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->withUnencryptedCookie('__client', $cb['cookie'])
+        ->withoutOpenApiAssertions()
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', $identifierHint !== null ? ['identifier' => $identifierHint] : []);
+    $created->assertOk();
+    $sid = $created->json('response.id');
+    expect($sid)->toStartWith('sia_');
+
+    $challenge = test()->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->withUnencryptedCookie('__client', $cb['cookie'])
+        ->withoutOpenApiAssertions()
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", [
+            'strategy' => 'oauth_'.$providerKey,
+            'redirect_url' => $redirectUrl,
+            'redirect_url_complete' => $redirectUrlComplete,
+        ]);
+    $challenge->assertOk();
+
+    $url = $challenge->json('response.parent.first_factor_verification.external_verification_redirect_url')
+        ?? $challenge->json('response.first_factor_verification.external_verification_redirect_url')
+        ?? $challenge->json('response.external_verification_redirect_url');
+
+    return ['sid' => $sid, 'authorize_url' => (string) $url, 'cookie' => $cb['cookie']];
+}
+
+function au16FollowCallback(array $f, string $authorizeUrl, ?array $userinfo = null): TestResponse
+{
+    parse_str((string) parse_url($authorizeUrl, PHP_URL_QUERY), $qs);
+    $state = (string) ($qs['state'] ?? '');
+    expect($state)->not->toBe('');
+
+    Http::fake([
+        'oauth2.googleapis.com/token' => Http::response([
+            'access_token' => 'at-1', 'refresh_token' => 'rt-1', 'expires_in' => 3600, 'scope' => 'openid email profile',
+        ], 200),
+        'openidconnect.googleapis.com/v1/userinfo' => Http::response($userinfo ?? [
+            'sub' => 'g-au16',
+            'email' => 'alice@example.com',
+            'email_verified' => true,
+            'given_name' => 'Alice',
+            'family_name' => 'Smith',
+        ], 200),
+    ]);
+
+    return test()->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->withoutOpenApiAssertions()
+        ->get('https://acme.authn.local/v1/oauth-callback/google?state='.urlencode($state).'&code=ok');
+}
+
+it('OAuth sign-up: new user lands a session via Google preset', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    app()->instance(Environment::class, $f['env']);
+    au16EnableProvider($f['env'], 'google');
+
+    $oauth = au16StartOauth($f, 'google', 'http://app.example.com/sign-in', 'http://app.example.com/done');
+    expect($oauth['authorize_url'])->toContain('https://accounts.google.com/o/oauth2/v2/auth');
+
+    $callback = au16FollowCallback($f, $oauth['authorize_url']);
+    $callback->assertRedirect();
+    expect($callback->headers->get('Location'))->toBe('http://app.example.com/done');
+
+    $user = User::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('first_name', 'Alice')
+        ->firstOrFail();
+    expect(ExternalAccount::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('user_id', $user->id)
+        ->where('provider_user_id', 'g-au16')
+        ->exists())->toBeTrue();
+    expect(Session::query()->withoutGlobalScopes()
+        ->where('user_id', $user->id)
+        ->where('status', Session::STATUS_ACTIVE)
+        ->exists())->toBeTrue();
+});
+
+it('OAuth sign-in: existing user with linked ExternalAccount completes without re-creating the user', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    app()->instance(Environment::class, $f['env']);
+    $provider = au16EnableProvider($f['env'], 'google');
+
+    $existing = User::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'first_name' => 'Existing',
+    ]);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $existing->id,
+        'email_address' => 'existing@example.com',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+    ExternalAccount::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $existing->id,
+        'oauth_provider_id' => $provider->id,
+        'provider_user_id' => 'g-existing',
+        'encrypted_access_token' => 'old-at',
+        'linked_at' => now(),
+    ]);
+
+    $oauth = au16StartOauth($f, 'google', 'http://app.example.com/sign-in', 'http://app.example.com/done');
+
+    $callback = au16FollowCallback($f, $oauth['authorize_url'], [
+        'sub' => 'g-existing',
+        'email' => 'existing@example.com',
+        'email_verified' => true,
+    ]);
+    $callback->assertRedirect();
+    expect($callback->headers->get('Location'))->toBe('http://app.example.com/done');
+
+    // No duplicate user, fresh session for the existing one.
+    expect(User::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('first_name', 'Existing')
+        ->count())->toBe(1);
+    expect(Session::query()->withoutGlobalScopes()
+        ->where('user_id', $existing->id)
+        ->where('status', Session::STATUS_ACTIVE)
+        ->exists())->toBeTrue();
+    expect(ExternalAccount::query()->withoutGlobalScopes()
+        ->where('user_id', $existing->id)
+        ->first()
+        ->encrypted_access_token)->toBe('at-1');
+});
+
+it('OAuth sign-up rejected: provider with allow_sign_up=false does not create a user', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    app()->instance(Environment::class, $f['env']);
+    au16EnableProvider($f['env'], 'google', allowSignUp: false);
+
+    $oauth = au16StartOauth($f, 'google', 'http://app.example.com/sign-in', 'http://app.example.com/done');
+
+    $callback = au16FollowCallback($f, $oauth['authorize_url'], [
+        'sub' => 'g-newcomer',
+        'email' => 'newcomer@example.com',
+        'email_verified' => true,
+    ]);
+    $callback->assertRedirect();
+    expect($callback->headers->get('Location'))->toContain('__authn_error=sign_up_disabled');
+
+    expect(User::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)->count())->toBe(0);
+    expect(ExternalAccount::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)->count())->toBe(0);
+});
+
+it('OAuth callback flips the verification to verified when the dance succeeds', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    app()->instance(Environment::class, $f['env']);
+    au16EnableProvider($f['env'], 'google');
+
+    $oauth = au16StartOauth($f, 'google', 'http://app.example.com/sign-in', 'http://app.example.com/done');
+    au16FollowCallback($f, $oauth['authorize_url'])->assertRedirect();
+
+    // Verification finished verified; ExternalAccount linked.
+    $verification = Verification::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('strategy', 'oauth_google')
+        ->latest('id')
+        ->firstOrFail();
+    expect($verification->status)->toBe(Verification::STATUS_VERIFIED);
+});

--- a/tests/Feature/Auth/Strategies/PhoneCode2FAE2ETest.php
+++ b/tests/Feature/Auth/Strategies/PhoneCode2FAE2ETest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\Sms\SendVerificationSms;
+use App\Models\Environment;
+use App\Models\PhoneNumber;
+use App\Models\Session;
+use App\Models\TotpSecret;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\SignIn\SignInTestSupport;
+
+/**
+ * AU-16: end-to-end second-factor sign-in via SMS-OTP. Mirrors
+ * SecondFactorTest's TOTP cases but for phone_code (AU-9). Pairs the
+ * verified+reserved phone with a TOTP enrolment so the existing pivot
+ * (totp/backup_code only, see ChallengeController::userHasEnrolledSecondFactor)
+ * fires; phone_code then appears alongside TOTP in supported_strategies.
+ */
+function au16PhoneSignInPost(array $f, array $body, ?string $cookie = null): TestResponse
+{
+    $req = test()->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']]);
+    if ($cookie !== null) {
+        $req = $req->withUnencryptedCookie('__client', $cookie);
+    }
+
+    return $req->postJson('https://acme.authn.local/v1/client/sign-ins', $body);
+}
+
+function au16PhoneSignInChallenge(string $sid, array $f, array $body, string $cookie): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->withUnencryptedCookie('__client', $cookie)
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", $body);
+}
+
+function au16PhoneSignInAnswer(string $sid, string $cid, array $f, array $body, string $cookie): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->withUnencryptedCookie('__client', $cookie)
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges/{$cid}/answer", $body);
+}
+
+function au16BootUserWithTotpAndPhone(array $f): array
+{
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bundle['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+    PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bundle['user']->id,
+        'phone_number' => '+15555550199',
+        'verified_at' => now(),
+        'reserved_for_second_factor' => true,
+        'default_second_factor' => true,
+        'is_primary' => false,
+    ]);
+    $bundle['user']->forceFill(['totp_enabled' => true, 'two_factor_enabled' => true])->save();
+
+    return $bundle;
+}
+
+it('phone_code is offered alongside totp once a verified+reserved phone is enrolled', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    app()->instance(Environment::class, $f['env']);
+    au16BootUserWithTotpAndPhone($f);
+
+    $r = au16PhoneSignInPost($f, [
+        'identifier' => 'alice@example.com',
+        'strategy' => 'password',
+        'password' => 'super-secret-password',
+    ]);
+
+    $r->assertOk()
+        ->assertJsonPath('response.status', 'needs_second_factor');
+    expect($r->json('response.supported_strategies'))->toContain('phone_code');
+    expect($r->json('response.supported_strategies'))->toContain('totp');
+});
+
+it('completes second-factor sign-in via phone_code when the SMS code is correct', function (): void {
+    Queue::fake([SendVerificationSms::class]);
+    $f = SignInTestSupport::bootEnv();
+    app()->instance(Environment::class, $f['env']);
+    $bundle = au16BootUserWithTotpAndPhone($f);
+
+    $cb = SignInTestSupport::clientWithCookie($f['env']);
+    $first = au16PhoneSignInPost($f, [
+        'identifier' => 'alice@example.com',
+        'strategy' => 'password',
+        'password' => 'super-secret-password',
+    ], $cb['cookie']);
+    $sid = $first->json('response.id');
+    expect($sid)->toStartWith('sia_');
+
+    $prepare = au16PhoneSignInChallenge($sid, $f, ['strategy' => 'phone_code'], $cb['cookie']);
+    $prepare->assertOk();
+    $cid = $prepare->json('response.id');
+
+    $code = null;
+    Queue::assertPushedOn('sms', SendVerificationSms::class, function (SendVerificationSms $job) use (&$code): bool {
+        $code = $job->code;
+
+        return true;
+    });
+    expect($code)->not->toBeNull()->and(strlen((string) $code))->toBe(6);
+
+    $answer = au16PhoneSignInAnswer($sid, $cid, $f, ['code' => (string) $code], $cb['cookie']);
+    $answer->assertOk();
+
+    expect(Session::query()->withoutGlobalScopes()
+        ->where('user_id', $bundle['user']->id)
+        ->where('status', Session::STATUS_ACTIVE)
+        ->exists())->toBeTrue();
+});
+
+it('rejects a wrong phone_code with form_code_incorrect and does not mint a session', function (): void {
+    Queue::fake([SendVerificationSms::class]);
+    $f = SignInTestSupport::bootEnv();
+    app()->instance(Environment::class, $f['env']);
+    $bundle = au16BootUserWithTotpAndPhone($f);
+
+    $cb = SignInTestSupport::clientWithCookie($f['env']);
+    $first = au16PhoneSignInPost($f, [
+        'identifier' => 'alice@example.com',
+        'strategy' => 'password',
+        'password' => 'super-secret-password',
+    ], $cb['cookie']);
+    $sid = $first->json('response.id');
+
+    $prepare = au16PhoneSignInChallenge($sid, $f, ['strategy' => 'phone_code'], $cb['cookie']);
+    $prepare->assertOk();
+    $cid = $prepare->json('response.id');
+
+    $r = au16PhoneSignInAnswer($sid, $cid, $f, ['code' => '000000'], $cb['cookie']);
+    $r->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'form_code_incorrect');
+
+    expect(Session::query()->withoutGlobalScopes()
+        ->where('user_id', $bundle['user']->id)
+        ->where('status', Session::STATUS_ACTIVE)
+        ->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Summary

Two new end-to-end suites that exercise the v0.4 multi-step sign-in flows. The existing AU-6 (OAuth) and AU-9 (phone_code) tests cover the units in isolation; these tests glue the steps together and run them through the real FAPI HTTP surface.

**OauthSignInE2ETest** — full OAuth dance (POST /sign-ins → POST /challenges with strategy=oauth_google → external_verification_redirect_url → callback → session):

- new-user sign-up via Google preset; User + ExternalAccount + Session all materialise
- existing-user sign-in (linked ExternalAccount); no dup user, refresh tokens rotate
- sign-up rejected when allow_sign_up=false; callback redirects with __authn_error=sign_up_disabled and no User row appears
- callback flips Verification to verified on a successful round-trip

**PhoneCode2FAE2ETest** — SMS-OTP second factor:

- pivot: user with verified+reserved phone (paired with TOTP enrolment so the existing TOTP-shaped pivot fires) lands in needs_second_factor; supportedStrategies = ['totp', 'phone_code']
- prepare-then-answer: POST /challenges with strategy=phone_code dispatches SendVerificationSms; the test extracts the code from the queued job and POSTs it to /challenges/{cid}/answer; session is minted
- wrong code → form_code_incorrect, no session

## Findings (left as follow-ups, not fixed in scope)

- `ChallengeController::userHasEnrolledSecondFactor` only inspects TOTP + backup-codes — a user with phone-only-as-2FA never lands in needs_second_factor. supportedStrategies does include phone_code once you're in needs_second_factor (via TOTP pivot), but the pivot itself doesn't fire for phone-only enrolment. Filing a follow-up if the team-lead agrees this is in scope for v0.4 stable.
- POST /sign-ins rejects oauth_<key> at the validator; SDK is expected to create the attempt then POST strategy to /sign-ins/{sid}/challenges. Matches `authenticateWithRedirect` shape in the JS SDK.

## Test plan

- [x] `./vendor/bin/pest` — 655 passing, 2172 assertions
- [x] `./vendor/bin/pint --test` — clean
- [x] OauthSignInE2ETest — 4 cases passing
- [x] PhoneCode2FAE2ETest — 3 cases passing