### PR TITLE
Emit pnv + dsf claims on Session JWT (closes #153)

### DIFF
--- a/app/Services/Sessions/SessionTokenIssuer.php
+++ b/app/Services/Sessions/SessionTokenIssuer.php
@@ -6,8 +6,10 @@ namespace App\Services\Sessions;
 
 use App\Models\Environment;
 use App\Models\OrganizationMembership;
+use App\Models\PhoneNumber;
 use App\Models\Session;
 use App\Models\SigningKey;
+use App\Models\TotpSecret;
 use App\Support\Url;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
@@ -80,6 +82,13 @@ final class SessionTokenIssuer
         $orgClaim = $this->orgClaim($session);
         if ($orgClaim !== null) {
             $builder = $builder->withClaim('org', $orgClaim);
+        }
+
+        $builder = $builder->withClaim('pnv', $this->phoneNumberVerified($session));
+
+        $dsf = $this->defaultSecondFactor($session);
+        if ($dsf !== null) {
+            $builder = $builder->withClaim('dsf', $dsf);
         }
 
         if ($shape === 'flat') {
@@ -184,6 +193,43 @@ final class SessionTokenIssuer
             'rol' => $membership->role->key,
             'per' => $membership->role->permissions->pluck('key')->unique()->values()->all(),
         ];
+    }
+
+    private function phoneNumberVerified(Session $session): bool
+    {
+        return PhoneNumber::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $session->user_id)
+            ->whereNotNull('verified_at')
+            ->exists();
+    }
+
+    /**
+     * Resolves the user's preferred second-factor strategy. Phone wins when
+     * a verified row is flagged `default_second_factor`; otherwise any
+     * verified TOTP enrolment maps to `"totp"`. Returns null when neither
+     * holds, so `dsf` is omitted entirely from the JWT (consumers default
+     * to "no preference").
+     */
+    private function defaultSecondFactor(Session $session): ?string
+    {
+        $hasDefaultPhone = PhoneNumber::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $session->user_id)
+            ->whereNotNull('verified_at')
+            ->where('default_second_factor', true)
+            ->exists();
+        if ($hasDefaultPhone) {
+            return 'phone_code';
+        }
+
+        $hasTotp = TotpSecret::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $session->user_id)
+            ->whereNotNull('verified_at')
+            ->exists();
+
+        return $hasTotp ? 'totp' : null;
     }
 
     /**

--- a/tests/Feature/Services/Sessions/SessionTokenIssuerPhoneClaimsTest.php
+++ b/tests/Feature/Services/Sessions/SessionTokenIssuerPhoneClaimsTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\PhoneNumber;
+use App\Models\TotpSecret;
+use App\Services\Sessions\SessionTokenIssuer;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function decodeIssuedClaims(string $jwt): array
+{
+    $config = Configuration::forSymmetricSigner(
+        new Sha256,
+        InMemory::plainText(str_repeat('x', 64)),
+    );
+
+    return $config->parser()->parse($jwt)->claims()->all();
+}
+
+it('emits pnv: false when the user has no phone numbers', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeIssuedClaims($minted['jwt']);
+
+    expect($claims)->toHaveKey('pnv');
+    expect($claims['pnv'])->toBeFalse();
+});
+
+it('emits pnv: false when the user has only an unverified phone', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'phone_number' => '+15555550100',
+        'is_primary' => false,
+    ]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeIssuedClaims($minted['jwt']);
+
+    expect($claims['pnv'])->toBeFalse();
+});
+
+it('emits pnv: true when the user has at least one verified phone', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'phone_number' => '+15555550100',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeIssuedClaims($minted['jwt']);
+
+    expect($claims['pnv'])->toBeTrue();
+});
+
+it('omits dsf when the user has no enrolled second factor', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeIssuedClaims($minted['jwt']);
+
+    expect($claims)->not->toHaveKey('dsf');
+});
+
+it('emits dsf: phone_code when the user has a verified phone with default_second_factor=true', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'phone_number' => '+15555550100',
+        'verified_at' => now(),
+        'reserved_for_second_factor' => true,
+        'default_second_factor' => true,
+        'is_primary' => false,
+    ]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeIssuedClaims($minted['jwt']);
+
+    expect($claims['pnv'])->toBeTrue();
+    expect($claims['dsf'])->toBe('phone_code');
+});
+
+it('emits dsf: totp when the user has only a verified TOTP secret', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeIssuedClaims($minted['jwt']);
+
+    expect($claims['dsf'])->toBe('totp');
+});
+
+it('prefers phone_code over totp when both are enrolled and phone is flagged default', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'phone_number' => '+15555550100',
+        'verified_at' => now(),
+        'reserved_for_second_factor' => true,
+        'default_second_factor' => true,
+        'is_primary' => false,
+    ]);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeIssuedClaims($minted['jwt']);
+
+    expect($claims['dsf'])->toBe('phone_code');
+});
+
+it('falls through to totp when a verified phone is enrolled but not flagged default', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'phone_number' => '+15555550100',
+        'verified_at' => now(),
+        'reserved_for_second_factor' => true,
+        'default_second_factor' => false,
+        'is_primary' => false,
+    ]);
+    TotpSecret::create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'secret' => 'JBSWY3DPEHPK3PXP',
+        'verified_at' => now(),
+    ]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeIssuedClaims($minted['jwt']);
+
+    expect($claims['dsf'])->toBe('totp');
+});


### PR DESCRIPTION
## Summary

Closes #153. Wires the two v0.4 phone-MFA claims the SP-3 sdk-php parser was already reading defensively.

| Claim | Type | Source |
|---|---|---|
| `pnv` | bool, always emitted | true when the user has any PhoneNumber row with verified_at IS NOT NULL |
| `dsf` | string, omitted when null | "phone_code" if a verified phone has default_second_factor=true; else "totp" if a verified TotpSecret exists; else omitted |

The phone-first preference matches AU-9's `PhoneCodeStrategy::resolvePhone()` priority — when the user has explicitly flagged a phone as their default, that beats TOTP. With no explicit preference, TOTP wins (since TotpSecret has no equivalent flag).

## Test plan

- [x] `./vendor/bin/pest` — 662 passing, 2159 assertions
- [x] `./vendor/bin/pint --test` — clean
- [x] `tests/Feature/Services/Sessions/SessionTokenIssuerPhoneClaimsTest.php` — 8 cases:
    - no phone → pnv: false, dsf: omitted
    - unverified phone only → pnv: false
    - verified phone → pnv: true
    - no MFA → dsf: omitted
    - verified phone with default_second_factor=true → dsf: "phone_code"
    - verified TotpSecret only → dsf: "totp"
    - phone flagged default + TotpSecret → dsf: "phone_code" (phone wins)
    - verified phone (default=false) + TotpSecret → dsf: "totp" (TOTP wins on tie)