### PR TITLE
AU-11: pin @authn-sh/* to ^0.4.0-alpha.0 (Account Portal v0.4 surfaces)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
-    "name": "html",
+    "name": "authn",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "dependencies": {
-                "@authn-sh/sdk-js": "0.3.0",
-                "@authn-sh/sdk-react": "0.3.0",
-                "@authn-sh/types": "0.3.0",
-                "@authn-sh/ui": "0.3.0"
+                "@authn-sh/sdk-js": "^0.4.0-alpha.0",
+                "@authn-sh/sdk-react": "^0.4.0-alpha.0",
+                "@authn-sh/types": "^0.4.0-alpha.0",
+                "@authn-sh/ui": "^0.4.0-alpha.0"
             },
             "devDependencies": {
                 "@inertiajs/react": "^3.0.3",
@@ -28,33 +28,33 @@
             }
         },
         "node_modules/@authn-sh/sdk-js": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.3.0.tgz",
-            "integrity": "sha512-YSXXFS0zHcXKwgTVaIYXre7W+gH8nsCl9jvZMqxUodT4hR89PE3z9W1Jx4HzVbVUH7fRSp+BbKia8GehBscUHQ==",
+            "version": "0.4.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.4.0-alpha.0.tgz",
+            "integrity": "sha512-GWOScq1wyms/5hPbH6jcf4DvIGmOoYZ+0WQjZQ4nBQDWXv2WlHkePxwd/aMJNA0iZWkx2c0PpT7UXi0Rjp76cQ==",
             "license": "AGPL-3.0-only"
         },
         "node_modules/@authn-sh/sdk-react": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-0.3.0.tgz",
-            "integrity": "sha512-JsJGHvD6EIEFGVbuOUVmw7Qw1YOCqm27UZCKeWOlfj2PkSap1GVcxyeurh1G7ec2p95JKOcOqy0g1xYSZcrTAg==",
+            "version": "0.4.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-0.4.0-alpha.0.tgz",
+            "integrity": "sha512-ZshO5LQMO1IAZ4gBFv6HjuCOC4YDHQJxYaVkcCV8GrO8rbb4G9v1UF0c51Zo4SzHJ3nV4sXrFdE0PgHBdG1kng==",
             "license": "AGPL-3.0-only",
             "peerDependencies": {
-                "@authn-sh/sdk-js": "0.3.0",
-                "@authn-sh/ui": "0.3.0",
+                "@authn-sh/sdk-js": "0.4.0-alpha.0",
+                "@authn-sh/ui": "0.4.0-alpha.0",
                 "react": "^18 || ^19",
                 "react-dom": "^18 || ^19"
             }
         },
         "node_modules/@authn-sh/types": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.3.0.tgz",
-            "integrity": "sha512-4EfuGB873ciqGgtd7vPqvbz1myx5CF1YhUgOowx3Lhh7AR5N75wFFfX+raL0s4MYiyMid/WH62jXMX+glqgxoA==",
+            "version": "0.4.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.4.0-alpha.0.tgz",
+            "integrity": "sha512-Wf5JrJH5FtItRfF0rtLmL8s2xe5OogXvmBYDWHDtXINhY/AL8LgisMSsBjQIckLLajj5YpwAsl8vh2YrlmMSWQ==",
             "license": "AGPL-3.0-only"
         },
         "node_modules/@authn-sh/ui": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/ui/-/ui-0.3.0.tgz",
-            "integrity": "sha512-4F08354NW74D41npLb6bepmfQZALXX11HqZEqn1+nx2lJxNdCMszdAMyowrg5Q2Cp+u7yLB6vFURJ0Yub9IC4w==",
+            "version": "0.4.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@authn-sh/ui/-/ui-0.4.0-alpha.0.tgz",
+            "integrity": "sha512-QIAramrrlwCTSm36UFZWJopHvhgeIxi0SJTKD3zeglA191YLGDdHPC0igmkUhOn4KoPofP+wCjyfSwx3b++zAg==",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@radix-ui/react-avatar": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
         "vite": "^8.0.0"
     },
     "dependencies": {
-        "@authn-sh/sdk-js": "0.3.0",
-        "@authn-sh/sdk-react": "0.3.0",
-        "@authn-sh/types": "0.3.0",
-        "@authn-sh/ui": "0.3.0"
+        "@authn-sh/sdk-js": "^0.4.0-alpha.0",
+        "@authn-sh/sdk-react": "^0.4.0-alpha.0",
+        "@authn-sh/types": "^0.4.0-alpha.0",
+        "@authn-sh/ui": "^0.4.0-alpha.0"
     }
 }


### PR DESCRIPTION
## Summary

Picks up the v0.4 SDK surfaces in the Account Portal:

- `<SignIn />` renders `<SocialButtons />` + handles `/sign-in/sso-callback` resume
- `<SignUp />` mirrors + adds `/sign-up/verify-phone-number` step
- `<UserProfile />` Account section shows phone-numbers + connected-accounts panels

Existing routes already accept the new step segments (`sso-callback`, `verify-phone-number`) per `routes/fapi.php:231,234`, so no new Inertia page wrappers are needed — the SDK handles sub-steps internally via `routing="virtual"`. The original ISSUES-v0.4.md called for separate `SsoCallbackSignIn.tsx` / `SsoCallbackSignUp.tsx` / `VerifyPhoneNumber.tsx` files, but inspection of the routing shows those would just be no-op duplicates of the existing `SignIn.tsx` / `SignUp.tsx`.

Closes #130.

## Test plan

- [x] AccountPortal feature tests: 14/14 pass
- [x] `npm run build` clean
- [ ] CI green