### PR TITLE
AU-9.1: pivot to needs_second_factor when user has phone-only MFA enrolment

### DIFF
--- a/app/Http/Controllers/Fapi/ChallengeController.php
+++ b/app/Http/Controllers/Fapi/ChallengeController.php
@@ -258,10 +258,20 @@ final class ChallengeController
             return true;
         }
 
-        return (bool) $user->backup_code_enabled && BackupCode::query()
+        $hasBackupCodes = (bool) $user->backup_code_enabled && BackupCode::query()
             ->withoutGlobalScopes()
             ->where('user_id', $user->id)
             ->whereNull('consumed_at')
+            ->exists();
+        if ($hasBackupCodes) {
+            return true;
+        }
+
+        return PhoneNumber::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->where('reserved_for_second_factor', true)
             ->exists();
     }
 

--- a/app/Http/Controllers/Fapi/SignInController.php
+++ b/app/Http/Controllers/Fapi/SignInController.php
@@ -16,6 +16,7 @@ use App\Models\Challenge;
 use App\Models\Client;
 use App\Models\EmailAddress;
 use App\Models\Environment;
+use App\Models\PhoneNumber;
 use App\Models\Session;
 use App\Models\SignInAttempt;
 use App\Models\TotpSecret;
@@ -292,10 +293,20 @@ final class SignInController
             return true;
         }
 
-        return (bool) $user->backup_code_enabled && BackupCode::query()
+        $hasBackupCodes = (bool) $user->backup_code_enabled && BackupCode::query()
             ->withoutGlobalScopes()
             ->where('user_id', $user->id)
             ->whereNull('consumed_at')
+            ->exists();
+        if ($hasBackupCodes) {
+            return true;
+        }
+
+        return PhoneNumber::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->where('reserved_for_second_factor', true)
             ->exists();
     }
 

--- a/tests/Feature/Auth/Strategies/PhoneCode2FAE2ETest.php
+++ b/tests/Feature/Auth/Strategies/PhoneCode2FAE2ETest.php
@@ -45,6 +45,23 @@ function au16PhoneSignInAnswer(string $sid, string $cid, array $f, array $body, 
         ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges/{$cid}/answer", $body);
 }
 
+function au16BootUserWithPhoneOnly(array $f): array
+{
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bundle['user']->id,
+        'phone_number' => '+15555550199',
+        'verified_at' => now(),
+        'reserved_for_second_factor' => true,
+        'default_second_factor' => true,
+        'is_primary' => false,
+    ]);
+    $bundle['user']->forceFill(['two_factor_enabled' => true])->save();
+
+    return $bundle;
+}
+
 function au16BootUserWithTotpAndPhone(array $f): array
 {
     $bundle = SignInTestSupport::makeUser($f['env']);
@@ -67,6 +84,23 @@ function au16BootUserWithTotpAndPhone(array $f): array
 
     return $bundle;
 }
+
+it('pivots to needs_second_factor when the user only has a verified+reserved phone (no TOTP, no backup codes)', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    app()->instance(Environment::class, $f['env']);
+    au16BootUserWithPhoneOnly($f);
+
+    $r = au16PhoneSignInPost($f, [
+        'identifier' => 'alice@example.com',
+        'strategy' => 'password',
+        'password' => 'super-secret-password',
+    ]);
+
+    $r->assertOk()->assertJsonPath('response.status', 'needs_second_factor');
+    expect($r->json('response.supported_strategies'))->toContain('phone_code')
+        ->and($r->json('response.supported_strategies'))->not->toContain('totp')
+        ->and($r->json('response.supported_strategies'))->not->toContain('backup_code');
+});
 
 it('phone_code is offered alongside totp once a verified+reserved phone is enrolled', function (): void {
     $f = SignInTestSupport::bootEnv();


### PR DESCRIPTION
Closes #155.

## Summary

`ChallengeController::userHasEnrolledSecondFactor` and `SignInController::shouldPivotToSecondFactor` only checked TOTP + backup-codes. A user whose only second factor was a verified+reserved phone number signed in fully on first factor — MFA silently bypassed.

Both helpers now also check for at least one `PhoneNumber` row with `verified_at IS NOT NULL AND reserved_for_second_factor = true`.

## Test plan

- [x] 670/670 pest pass, pint clean
- [x] New e2e test `pivots to needs_second_factor when the user only has a verified+reserved phone` — drops the TOTP-pairing workaround used elsewhere
- [ ] CI green