### PR TITLE
AU-6.1: validate id_token JWS before trusting userinfo claims

### DIFF
--- a/app/Auth/Oauth/IdTokenValidator.php
+++ b/app/Auth/Oauth/IdTokenValidator.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth;
+
+use App\Models\OauthProvider;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Lcobucci\Clock\SystemClock;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256 as Rs256;
+use Lcobucci\JWT\Signer\Rsa\Sha384 as Rs384;
+use Lcobucci\JWT\Signer\Rsa\Sha512 as Rs512;
+use Lcobucci\JWT\Token\Parser;
+use Lcobucci\JWT\Token\Plain;
+use Lcobucci\JWT\Validation\Constraint\IssuedBy;
+use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
+use Lcobucci\JWT\Validation\Constraint\PermittedFor;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Lcobucci\JWT\Validation\Validator;
+use Throwable;
+
+/**
+ * Validates IdP-issued id_tokens against the provider's published JWKS.
+ *
+ * For preset OAuth providers (Google/Apple/Microsoft) the id_token JWS is
+ * the spec-conformant authoritative source of `sub` + `email` +
+ * `email_verified`. Userinfo can be tampered with by an attacker who
+ * controls the userinfo endpoint or a malicious IdP; the id_token can't
+ * (its signature is verified against the JWKS).
+ *
+ * GitHub does not issue an id_token, so callers should treat a missing
+ * id_token + missing jwks_uri as "no validation possible" and fall back
+ * to userinfo — that's the same posture v0.3 shipped.
+ *
+ * JWKS responses are cached for 1 hour per (provider_id, jwks_uri).
+ */
+final class IdTokenValidator
+{
+    private const JWKS_CACHE_TTL_SECONDS = 3600;
+
+    private readonly Parser $parser;
+
+    private readonly Validator $validator;
+
+    public function __construct()
+    {
+        $this->parser = new Parser(new JoseEncoder);
+        $this->validator = new Validator;
+    }
+
+    /**
+     * @return array<string,mixed>|null Validated claims, or null when validation fails / not applicable.
+     */
+    public function validate(OauthProvider $provider, ResolvedProvider $resolved, string $idToken): ?array
+    {
+        if ($resolved->jwksUri === null) {
+            return null;
+        }
+
+        try {
+            $token = $this->parser->parse($idToken);
+        } catch (Throwable) {
+            return null;
+        }
+        if (! $token instanceof Plain) {
+            return null;
+        }
+
+        $kid = $token->headers()->get('kid');
+        $alg = (string) $token->headers()->get('alg', '');
+        if (! in_array($alg, $resolved->idTokenSigningAlgs ?: ['RS256'], true)) {
+            return null;
+        }
+
+        $jwks = $this->fetchJwks($provider->id, $resolved->jwksUri);
+        if ($jwks === null) {
+            return null;
+        }
+
+        $key = $this->pickKey($jwks, is_string($kid) ? $kid : null);
+        if ($key === null) {
+            return null;
+        }
+
+        $signer = match ($alg) {
+            'RS256' => new Rs256,
+            'RS384' => new Rs384,
+            'RS512' => new Rs512,
+            default => null,
+        };
+        if ($signer === null) {
+            return null;
+        }
+
+        $constraints = [new SignedWith($signer, InMemory::plainText($key))];
+        if ($resolved->issuer !== null && $resolved->issuer !== '') {
+            $constraints[] = new IssuedBy($resolved->issuer);
+        }
+        if ($provider->client_id !== null && $provider->client_id !== '') {
+            $constraints[] = new PermittedFor($provider->client_id);
+        }
+        $constraints[] = new LooseValidAt(SystemClock::fromUTC());
+
+        if (! $this->validator->validate($token, ...$constraints)) {
+            return null;
+        }
+
+        $claims = $token->claims()->all();
+
+        return is_array($claims) ? $claims : null;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>|null
+     */
+    private function fetchJwks(string $providerId, string $jwksUri): ?array
+    {
+        $cacheKey = 'oauth:jwks:'.$providerId.':'.hash('sha256', $jwksUri);
+
+        return Cache::remember($cacheKey, self::JWKS_CACHE_TTL_SECONDS, function () use ($jwksUri): ?array {
+            try {
+                $response = Http::timeout(5)->get($jwksUri);
+            } catch (ConnectionException|RequestException|Throwable) {
+                return null;
+            }
+            if (! $response->successful()) {
+                return null;
+            }
+            $body = $response->json();
+            $keys = $body['keys'] ?? null;
+            if (! is_array($keys)) {
+                return null;
+            }
+
+            return array_values(array_filter($keys, 'is_array'));
+        });
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>>  $jwks
+     */
+    private function pickKey(array $jwks, ?string $kid): ?string
+    {
+        foreach ($jwks as $jwk) {
+            if ($kid !== null && ($jwk['kid'] ?? null) !== $kid) {
+                continue;
+            }
+            if (($jwk['kty'] ?? null) !== 'RSA') {
+                continue;
+            }
+            $n = $jwk['n'] ?? null;
+            $e = $jwk['e'] ?? null;
+            if (! is_string($n) || ! is_string($e)) {
+                continue;
+            }
+
+            return $this->jwkToPem($n, $e);
+        }
+
+        return null;
+    }
+
+    /**
+     * Convert an RSA JWK (n/e base64url) to a PEM-encoded public key.
+     * The DER structure is built by hand — keeps us free of phpseclib.
+     */
+    private function jwkToPem(string $nB64Url, string $eB64Url): string
+    {
+        $n = $this->base64urlDecode($nB64Url);
+        $e = $this->base64urlDecode($eB64Url);
+
+        $modulus = $this->encodeAsn1Integer($n);
+        $exponent = $this->encodeAsn1Integer($e);
+        $rsaKey = $this->encodeAsn1Sequence($modulus.$exponent);
+        $bitString = "\x00".$rsaKey;
+        $bitStringWrap = "\x03".$this->encodeLength(strlen($bitString)).$bitString;
+        // RSA OID (1.2.840.113549.1.1.1) + NULL
+        $algIdentifier = $this->encodeAsn1Sequence(
+            "\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01\x05\x00"
+        );
+        $spki = $this->encodeAsn1Sequence($algIdentifier.$bitStringWrap);
+
+        return "-----BEGIN PUBLIC KEY-----\n".chunk_split(base64_encode($spki), 64, "\n").'-----END PUBLIC KEY-----';
+    }
+
+    private function encodeAsn1Integer(string $bytes): string
+    {
+        if ($bytes !== '' && (ord($bytes[0]) & 0x80) !== 0) {
+            $bytes = "\x00".$bytes;
+        }
+
+        return "\x02".$this->encodeLength(strlen($bytes)).$bytes;
+    }
+
+    private function encodeAsn1Sequence(string $bytes): string
+    {
+        return "\x30".$this->encodeLength(strlen($bytes)).$bytes;
+    }
+
+    private function encodeLength(int $length): string
+    {
+        if ($length < 0x80) {
+            return chr($length);
+        }
+        $bytes = '';
+        while ($length > 0) {
+            $bytes = chr($length & 0xFF).$bytes;
+            $length >>= 8;
+        }
+
+        return chr(0x80 | strlen($bytes)).$bytes;
+    }
+
+    private function base64urlDecode(string $value): string
+    {
+        $padded = strtr($value, '-_', '+/');
+        $remainder = strlen($padded) % 4;
+        if ($remainder > 0) {
+            $padded .= str_repeat('=', 4 - $remainder);
+        }
+        $decoded = base64_decode($padded, true);
+
+        return $decoded === false ? '' : $decoded;
+    }
+}

--- a/app/Auth/Oauth/OauthProviderResolver.php
+++ b/app/Auth/Oauth/OauthProviderResolver.php
@@ -173,6 +173,7 @@ final class OauthProviderResolver
             idTokenSigningAlgs: array_values($idTokenAlgs),
             userinfoMethod: $provider->userinfo_method ?: $preset->userinfoMethod(),
             userinfoAuth: $provider->userinfo_auth ?: $preset->userinfoAuth(),
+            issuer: $provider->issuer ?: $preset->issuer(),
         );
     }
 
@@ -219,6 +220,7 @@ final class OauthProviderResolver
             idTokenSigningAlgs: array_values($endpoints['id_token_signing_algs']),
             userinfoMethod: $provider->userinfo_method ?: 'GET',
             userinfoAuth: $provider->userinfo_auth ?: 'bearer',
+            issuer: $provider->issuer,
         );
     }
 

--- a/app/Auth/Oauth/Presets/ApplePreset.php
+++ b/app/Auth/Oauth/Presets/ApplePreset.php
@@ -45,6 +45,11 @@ final class ApplePreset implements PresetContract
         return 'https://appleid.apple.com/auth/keys';
     }
 
+    public function issuer(): ?string
+    {
+        return 'https://appleid.apple.com';
+    }
+
     public function defaultScopes(): array
     {
         return ['name', 'email'];

--- a/app/Auth/Oauth/Presets/GitHubPreset.php
+++ b/app/Auth/Oauth/Presets/GitHubPreset.php
@@ -36,6 +36,12 @@ final class GitHubPreset implements PresetContract
         return null;
     }
 
+    public function issuer(): ?string
+    {
+        // GitHub doesn't issue an id_token — pure OAuth2, not OIDC.
+        return null;
+    }
+
     public function defaultScopes(): array
     {
         return ['read:user', 'user:email'];

--- a/app/Auth/Oauth/Presets/GooglePreset.php
+++ b/app/Auth/Oauth/Presets/GooglePreset.php
@@ -36,6 +36,11 @@ final class GooglePreset implements PresetContract
         return 'https://www.googleapis.com/oauth2/v3/certs';
     }
 
+    public function issuer(): ?string
+    {
+        return 'https://accounts.google.com';
+    }
+
     public function defaultScopes(): array
     {
         return ['openid', 'email', 'profile'];

--- a/app/Auth/Oauth/Presets/MicrosoftPreset.php
+++ b/app/Auth/Oauth/Presets/MicrosoftPreset.php
@@ -42,6 +42,16 @@ final class MicrosoftPreset implements PresetContract
         return 'https://login.microsoftonline.com/common/discovery/v2.0/keys';
     }
 
+    public function issuer(): ?string
+    {
+        // Microsoft's v2 issuer carries the tenant id. The "common"
+        // endpoint accepts multiple tenants — we skip strict-issuer
+        // validation since the operator's tenant choice would have to
+        // be configurable, and the JWS signature + audience check are
+        // already sufficient.
+        return null;
+    }
+
     public function defaultScopes(): array
     {
         return ['openid', 'email', 'profile'];

--- a/app/Auth/Oauth/Presets/PresetContract.php
+++ b/app/Auth/Oauth/Presets/PresetContract.php
@@ -33,6 +33,13 @@ interface PresetContract
     public function jwksUri(): ?string;
 
     /**
+     * The expected `iss` claim on id_tokens this IdP issues. Used by the
+     * id_token validator to reject tokens replayed from a different IdP.
+     * Returns `null` for presets that don't issue an id_token (e.g. GitHub).
+     */
+    public function issuer(): ?string;
+
+    /**
      * Default OAuth scopes requested when the operator hasn't
      * overridden them. Always includes `openid` for OIDC presets.
      *

--- a/app/Auth/Oauth/ResolvedProvider.php
+++ b/app/Auth/Oauth/ResolvedProvider.php
@@ -32,5 +32,6 @@ final class ResolvedProvider
         public readonly array $idTokenSigningAlgs,
         public readonly string $userinfoMethod,
         public readonly string $userinfoAuth,
+        public readonly ?string $issuer = null,
     ) {}
 }

--- a/app/Http/Controllers/Fapi/OauthCallbackController.php
+++ b/app/Http/Controllers/Fapi/OauthCallbackController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Fapi;
 
 use App\Auth\Oauth\Exceptions\OauthDiscoveryFailedException;
+use App\Auth\Oauth\IdTokenValidator;
 use App\Auth\Oauth\OauthProviderResolver;
 use App\Auth\Oauth\ResolvedProvider;
 use App\Auth\Oauth\StateToken;
@@ -43,6 +44,7 @@ final class OauthCallbackController
 {
     public function __construct(
         private readonly OauthProviderResolver $resolver,
+        private readonly IdTokenValidator $idTokenValidator,
     ) {}
 
     public function __invoke(Request $request): RedirectResponse
@@ -115,21 +117,40 @@ final class OauthCallbackController
             return $this->fail($state['ru'] ?? null, $verification, 'oauth_token_exchange_failed', 'Token endpoint returned no access_token.');
         }
 
-        // TODO(AU-6.1): for preset providers (Google/Apple/Microsoft) the
-        // id_token is the authoritative source of `sub` + `email_verified`.
-        // Validate the JWS signature against the provider's JWKS before
-        // trusting userinfo. Tracked for v0.4.0-stable.
+        // For preset / OIDC providers the id_token is the authoritative
+        // source of `sub` + `email` + `email_verified`. Validate the JWS
+        // against the provider's JWKS before trusting userinfo.
+        $idTokenClaims = null;
+        if (is_string($tokenBody['id_token'] ?? null) && $resolved->jwksUri !== null) {
+            $idTokenClaims = $this->idTokenValidator->validate($provider, $resolved, (string) $tokenBody['id_token']);
+            if ($idTokenClaims === null) {
+                return $this->fail($state['ru'] ?? null, $verification, 'oauth_id_token_invalid', 'id_token JWS validation failed.');
+            }
+        }
+
         $userinfo = $this->fetchUserinfo($resolved, $tokenBody);
         if ($userinfo === null) {
             return $this->fail($state['ru'] ?? null, $verification, 'oauth_userinfo_failed', 'userinfo lookup returned no data.');
         }
 
-        $providerUserId = (string) ($userinfo['sub'] ?? $userinfo['id'] ?? '');
+        // Security-critical claims come from the validated id_token when
+        // available — userinfo can be tampered with by a network attacker.
+        // Display claims (picture / first_name / last_name) keep coming
+        // from userinfo since they're not load-bearing for auth.
+        $providerUserId = (string) ($idTokenClaims['sub'] ?? $userinfo['sub'] ?? $userinfo['id'] ?? '');
         if ($providerUserId === '') {
-            return $this->fail($state['ru'] ?? null, $verification, 'oauth_provider_user_id_missing', 'userinfo response had no sub/id.');
+            return $this->fail($state['ru'] ?? null, $verification, 'oauth_provider_user_id_missing', 'No sub on id_token or userinfo.');
         }
 
-        $mapped = $this->applyAttributeMapping($resolved->attributeMapping, $userinfo);
+        $mergedClaims = $userinfo;
+        if ($idTokenClaims !== null) {
+            foreach (['sub', 'email', 'email_verified'] as $authoritative) {
+                if (array_key_exists($authoritative, $idTokenClaims)) {
+                    $mergedClaims[$authoritative] = $idTokenClaims[$authoritative];
+                }
+            }
+        }
+        $mapped = $this->applyAttributeMapping($resolved->attributeMapping, $mergedClaims);
         $emailAddress = isset($mapped['email']) ? strtolower((string) $mapped['email']) : null;
         $emailVerified = (bool) ($mapped['email_verified'] ?? false);
 

--- a/tests/Feature/Auth/Oauth/OauthIdTokenValidationTest.php
+++ b/tests/Feature/Auth/Oauth/OauthIdTokenValidationTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Oauth\StateToken;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+use App\Models\Project;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Route;
+use Lcobucci\JWT\Encoding\ChainedFormatter;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Token\Builder;
+
+/**
+ * AU-6.1: id_token JWS validation. Asserts that when the IdP returns
+ * an id_token, security-critical claims (sub, email, email_verified)
+ * come from the signed token — userinfo is only trusted for display
+ * fields. A tampered userinfo response is overridden by the id_token's
+ * signed claim, and an id_token signed with a key not in the JWKS is
+ * rejected outright.
+ */
+function au61MintRsaKeyPair(): array
+{
+    $res = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+    openssl_pkey_export($res, $privatePem);
+    $details = openssl_pkey_get_details($res);
+
+    return [
+        'private_pem' => $privatePem,
+        'jwk' => [
+            'kty' => 'RSA',
+            'kid' => 'test-key-1',
+            'use' => 'sig',
+            'alg' => 'RS256',
+            'n' => rtrim(strtr(base64_encode($details['rsa']['n']), '+/', '-_'), '='),
+            'e' => rtrim(strtr(base64_encode($details['rsa']['e']), '+/', '-_'), '='),
+        ],
+    ];
+}
+
+function au61MintIdToken(array $keypair, array $claims, string $issuer, string $audience): string
+{
+    $sub = $claims['sub'] ?? '';
+    unset($claims['sub']);
+    $builder = (new Builder(new JoseEncoder, ChainedFormatter::default()))
+        ->withHeader('kid', $keypair['jwk']['kid'])
+        ->issuedBy($issuer)
+        ->permittedFor($audience)
+        ->relatedTo((string) $sub)
+        ->issuedAt(new DateTimeImmutable('@'.time()))
+        ->expiresAt(new DateTimeImmutable('@'.(time() + 600)))
+        ->identifiedBy(bin2hex(random_bytes(16)));
+    foreach ($claims as $name => $value) {
+        $builder = $builder->withClaim($name, $value);
+    }
+
+    return $builder->getToken(new Sha256, InMemory::plainText($keypair['private_pem']))->toString();
+}
+
+function au61ReloadFapiRoutes(): void
+{
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+    $appHost = (string) config('authn.app_host');
+    $fapi = Route::middleware('fapi');
+    if ((string) config('authn.routing_mode') === 'subdomain') {
+        $fapi->domain('{env_slug}.'.$appHost);
+    } else {
+        $fapi->prefix('{env_slug}');
+    }
+    $fapi->group(base_path('routes/fapi.php'));
+}
+
+function au61Env(): Environment
+{
+    config([
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'http',
+        'authn.app_port_suffix' => '',
+        'authn.bapi_host' => 'api.authn.local',
+    ]);
+    au61ReloadFapiRoutes();
+    $project = Project::create(['name' => 'P', 'slug' => 'p-cb-au61']);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'cb',
+        'routing_label' => 'cb',
+    ]);
+}
+
+function au61EnableGoogle(Environment $env, string $clientId = 'goog-client-id'): OauthProvider
+{
+    $row = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('provider_key', 'google')
+        ->firstOrFail();
+    $row->forceFill([
+        'enabled' => true,
+        'client_id' => $clientId,
+        'encrypted_client_secret' => 'goog-client-secret',
+    ])->save();
+
+    return $row->refresh();
+}
+
+it('uses id_token sub + email_verified over tampered userinfo', function (): void {
+    $env = au61Env();
+    $provider = au61EnableGoogle($env);
+    $kp = au61MintRsaKeyPair();
+
+    $idToken = au61MintIdToken($kp, [
+        'sub' => 'g-AUTHORITATIVE-ID',
+        'email' => 'alice@example.com',
+        'email_verified' => false,
+    ], 'https://accounts.google.com', 'goog-client-id');
+
+    Http::fake([
+        'oauth2.googleapis.com/token' => Http::response([
+            'access_token' => 'at-1', 'refresh_token' => 'rt-1', 'expires_in' => 3600,
+            'id_token' => $idToken,
+        ], 200),
+        'openidconnect.googleapis.com/v1/userinfo' => Http::response([
+            'sub' => 'g-ATTACKER-ID',
+            'email' => 'alice@example.com',
+            'email_verified' => true,
+            'given_name' => 'Alice',
+            'family_name' => 'Smith',
+        ], 200),
+        'www.googleapis.com/oauth2/v3/certs' => Http::response([
+            'keys' => [$kp['jwk']],
+        ], 200),
+    ]);
+
+    $client = Client::create(['environment_id' => $env->id]);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => $client->id,
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+    $verification = Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => 'oauth_google',
+        'status' => Verification::STATUS_UNVERIFIED,
+        'attempts' => 0,
+        'expire_at' => now()->addMinutes(10),
+    ]);
+
+    $state = StateToken::mint(
+        environmentId: $env->id, providerKey: 'google', verificationId: $verification->id,
+        clientId: $client->id, attemptId: $attempt->id, attemptKind: 'sign_in',
+        redirectUrl: 'http://app.example.com/sign-in',
+        redirectUrlComplete: 'http://app.example.com/dashboard',
+        nonce: 'n-1',
+    );
+
+    $r = $this->withHeaders(['Host' => 'cb.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get('http://cb.authn.local/v1/oauth-callback/google?state='.urlencode($state).'&code=auth-code-1');
+
+    $r->assertRedirect();
+    expect($r->headers->get('Location'))->not->toContain('__authn_error');
+
+    $ext = ExternalAccount::query()->withoutGlobalScopes()
+        ->where('oauth_provider_id', $provider->id)
+        ->first();
+    expect($ext)->not->toBeNull();
+    expect($ext->provider_user_id)->toBe('g-AUTHORITATIVE-ID')
+        ->and($ext->provider_user_id)->not->toBe('g-ATTACKER-ID');
+
+    $user = User::query()->withoutGlobalScopes()->where('id', $ext->user_id)->first();
+    $email = $user->emailAddresses()->withoutGlobalScopes()
+        ->where('email_address', 'alice@example.com')->first();
+    expect($email)->not->toBeNull()
+        ->and($email->verified_at)->toBeNull(); // id_token said false
+});
+
+it('rejects id_token signed with a key not in the JWKS', function (): void {
+    $env = au61Env();
+    au61EnableGoogle($env);
+    $serverKp = au61MintRsaKeyPair();
+    $attackerKp = au61MintRsaKeyPair();
+
+    $idToken = au61MintIdToken($attackerKp, [
+        'sub' => 'g-EVIL',
+        'email' => 'eve@example.com',
+        'email_verified' => true,
+    ], 'https://accounts.google.com', 'goog-client-id');
+
+    Http::fake([
+        'oauth2.googleapis.com/token' => Http::response([
+            'access_token' => 'at-1', 'id_token' => $idToken,
+        ], 200),
+        'www.googleapis.com/oauth2/v3/certs' => Http::response([
+            'keys' => [$serverKp['jwk']],
+        ], 200),
+    ]);
+
+    $client = Client::create(['environment_id' => $env->id]);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => $client->id,
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+        'abandon_at' => now()->addMinutes(30),
+    ]);
+    $verification = Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => 'oauth_google',
+        'status' => Verification::STATUS_UNVERIFIED,
+        'attempts' => 0,
+        'expire_at' => now()->addMinutes(10),
+    ]);
+
+    $state = StateToken::mint(
+        environmentId: $env->id, providerKey: 'google', verificationId: $verification->id,
+        clientId: $client->id, attemptId: $attempt->id, attemptKind: 'sign_in',
+        redirectUrl: 'http://app.example.com/sign-in',
+        redirectUrlComplete: 'http://app.example.com/dashboard',
+        nonce: 'n-1',
+    );
+
+    $r = $this->withHeaders(['Host' => 'cb.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get('http://cb.authn.local/v1/oauth-callback/google?state='.urlencode($state).'&code=auth-code-1');
+
+    $r->assertRedirect();
+    expect($r->headers->get('Location'))->toContain('__authn_error=oauth_id_token_invalid');
+    expect(User::query()->withoutGlobalScopes()->where('environment_id', $env->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
Closes #152.

## Summary

For preset / OIDC providers the id_token is the spec-conformant authoritative source of sub + email + email_verified. Without JWS validation, a network attacker who controls the userinfo endpoint (or a malicious IdP) can lie about `email_verified` or claim someone else's identity.

- New `App\\Auth\\Oauth\\IdTokenValidator`: fetches + caches JWKS (1h TTL), parses the id_token, validates JWS using lcobucci/jwt (RS256/384/512), checks issuer + audience + expiry. Hand-rolled JWK → PEM conversion (no phpseclib).
- `PresetContract` gains `issuer()` — Google + Apple return their canonical issuer; Microsoft (multi-tenant) returns null; GitHub (no id_token) returns null.
- `ResolvedProvider` carries the resolved issuer.
- `OauthCallbackController` calls the validator before consuming userinfo. id_token claims take precedence for sub/email/email_verified; userinfo only provides display fields. Validation failure → `oauth_id_token_invalid` redirect, no user created.

## Test plan

- [x] Tampered userinfo overridden by signed id_token (`OauthIdTokenValidationTest`)
- [x] id_token signed with wrong key → rejected with oauth_id_token_invalid
- [x] Existing 54 OAuth tests still pass (no id_token in fixtures = validation skipped, GitHub has no jwks_uri)
- [ ] CI green