### PR TITLE
authn#150: BAPI admin /v1/phone-numbers + /v1/external-accounts controllers

### DIFF
--- a/app/Http/Controllers/Bapi/ExternalAccountController.php
+++ b/app/Http/Controllers/Bapi/ExternalAccountController.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Http\Resources\ExternalAccountResource;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+use App\Webhooks\Emitter;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * BAPI admin external-accounts (OA-9 / authn#150).
+ *
+ *   GET    /v1/external-accounts             — list (filter user_id, oauth_provider_id)
+ *   GET    /v1/external-accounts/{id}
+ *   DELETE /v1/external-accounts/{id}        — best-effort IdP revocation + drop row
+ */
+final class ExternalAccountController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $query = ExternalAccount::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->orderBy('linked_at', 'desc');
+        if (is_string($request->input('user_id'))) {
+            $query->where('user_id', (string) $request->input('user_id'));
+        }
+        if (is_string($request->input('oauth_provider_id'))) {
+            $query->where('oauth_provider_id', (string) $request->input('oauth_provider_id'));
+        }
+
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        $providers = OauthProvider::query()->withoutGlobalScopes()
+            ->whereIn('id', $rows->pluck('oauth_provider_id')->unique()->values())
+            ->get()
+            ->keyBy('id');
+
+        return response()->json([
+            'data' => $rows->map(fn (ExternalAccount $r) => ExternalAccountResource::from($r, $providers->get($r->oauth_provider_id)))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function show(string $externalAccountId): JsonResponse
+    {
+        $row = $this->find($externalAccountId);
+        if ($row === null) {
+            return $this->error(404, 'external_account_not_found', 'No external account matches that id in this environment.');
+        }
+        $provider = OauthProvider::query()->withoutGlobalScopes()->where('id', $row->oauth_provider_id)->first();
+
+        return response()->json(ExternalAccountResource::from($row, $provider))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function destroy(string $externalAccountId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $row = $this->find($externalAccountId);
+        if ($row === null) {
+            return $this->error(404, 'external_account_not_found', 'No external account matches that id in this environment.');
+        }
+
+        $provider = OauthProvider::query()->withoutGlobalScopes()->where('id', $row->oauth_provider_id)->first();
+        if ($provider !== null) {
+            $this->bestEffortRevoke($provider, $row);
+        }
+
+        if ($row->email_address !== null) {
+            EmailAddress::query()->withoutGlobalScopes()
+                ->where('environment_id', $row->environment_id)
+                ->where('linked_to_external_account_id', $row->id)
+                ->update(['linked_to_external_account_id' => null]);
+        }
+
+        $snapshot = ExternalAccountResource::from($row, $provider);
+        $row->delete();
+
+        Log::info('audit:bapi.external_account.unlinked', [
+            'environment_id' => $env->id,
+            'external_account_id' => $externalAccountId,
+            'provider_key' => $provider?->provider_key,
+        ]);
+
+        app(Emitter::class)->emit('externalAccount.unlinked', $snapshot, $env);
+
+        return response()->json(null, 204);
+    }
+
+    private function bestEffortRevoke(OauthProvider $provider, ExternalAccount $row): void
+    {
+        $params = is_array($provider->additional_authorization_params) ? $provider->additional_authorization_params : [];
+        $endpoint = is_string($params['revocation_endpoint'] ?? null) ? (string) $params['revocation_endpoint'] : null;
+        if ($endpoint === null || $endpoint === '') {
+            return;
+        }
+        $token = $row->encrypted_refresh_token ?? $row->encrypted_access_token;
+        if ($token === null || $token === '') {
+            return;
+        }
+        try {
+            Http::asForm()->timeout(5)->post($endpoint, [
+                'token' => $token,
+                'client_id' => $provider->client_id,
+                'client_secret' => $provider->encrypted_client_secret,
+            ]);
+        } catch (ConnectionException|RequestException|Throwable $e) {
+            Log::info('audit:bapi.external_account.revoke_failed', [
+                'external_account_id' => $row->id,
+                'provider_key' => $provider->provider_key,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function find(string $externalAccountId): ?ExternalAccount
+    {
+        $env = app(Environment::class);
+
+        return ExternalAccount::query()->withoutGlobalScopes()
+            ->where('id', $externalAccountId)
+            ->where('environment_id', $env->id)
+            ->first();
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [['code' => $code, 'long_message' => $message, 'message' => $message]],
+        ], $status);
+    }
+}

--- a/app/Http/Controllers/Bapi/PhoneNumberController.php
+++ b/app/Http/Controllers/Bapi/PhoneNumberController.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Http\Resources\PhoneNumberResource;
+use App\Models\Environment;
+use App\Models\PhoneNumber;
+use App\Models\User;
+use App\Webhooks\Emitter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * BAPI admin phone-numbers (OA-9 / authn#150).
+ *
+ *   GET    /v1/phone-numbers              — list (filter by user_id)
+ *   POST   /v1/phone-numbers              — admin-create (links to user_id)
+ *   GET    /v1/phone-numbers/{id}
+ *   PATCH  /v1/phone-numbers/{id}         — toggle verified / primary / MFA flags
+ *   DELETE /v1/phone-numbers/{id}         — 409 on reserved_for_second_factor
+ */
+final class PhoneNumberController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $query = PhoneNumber::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->orderBy('created_at', 'desc');
+        if (is_string($request->input('user_id'))) {
+            $query->where('user_id', (string) $request->input('user_id'));
+        }
+
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (PhoneNumber $p) => PhoneNumberResource::from($p))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        $userId = (string) $request->input('user_id', '');
+        $phoneNumber = (string) $request->input('phone_number', '');
+        if ($userId === '' || $phoneNumber === '') {
+            return $this->error(422, 'form_param_nil', 'user_id and phone_number are required.');
+        }
+        if (preg_match('/^\+[1-9][0-9]{6,14}$/', $phoneNumber) !== 1) {
+            return $this->error(422, 'form_param_format_invalid', 'phone_number must be E.164 (e.g. +15555550100).');
+        }
+
+        $user = User::query()->withoutGlobalScopes()
+            ->where('id', $userId)
+            ->where('environment_id', $env->id)
+            ->first();
+        if ($user === null) {
+            return $this->error(404, 'user_not_found', 'No user matches that id in this environment.');
+        }
+
+        $duplicate = PhoneNumber::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('phone_number', $phoneNumber)
+            ->exists();
+        if ($duplicate) {
+            return $this->error(409, 'phone_number_in_use', 'That phone number is already attached to a user in this environment.');
+        }
+
+        $verified = (bool) $request->input('verified', false);
+        $primary = (bool) $request->input('primary', false);
+
+        $row = DB::transaction(function () use ($env, $user, $phoneNumber, $verified, $primary): PhoneNumber {
+            if ($primary) {
+                PhoneNumber::query()->withoutGlobalScopes()
+                    ->where('environment_id', $env->id)
+                    ->where('user_id', $user->id)
+                    ->where('is_primary', true)
+                    ->update(['is_primary' => false]);
+            }
+            $row = PhoneNumber::query()->withoutGlobalScopes()->create([
+                'environment_id' => $env->id,
+                'user_id' => $user->id,
+                'phone_number' => $phoneNumber,
+                'verified_at' => $verified ? now() : null,
+                'is_primary' => $primary,
+                'reserved_for_second_factor' => false,
+                'default_second_factor' => false,
+            ]);
+            if ($primary) {
+                $user->forceFill(['primary_phone_number_id' => $row->id])->save();
+            }
+
+            return $row;
+        });
+
+        Log::info('audit:bapi.phone_number.created', [
+            'environment_id' => $env->id,
+            'phone_number_id' => $row->id,
+            'user_id' => $user->id,
+            'verified' => $verified,
+            'primary' => $primary,
+        ]);
+
+        app(Emitter::class)->emit('phoneNumber.created', PhoneNumberResource::from($row), $env);
+        if ($verified) {
+            app(Emitter::class)->emit('phoneNumber.verified', PhoneNumberResource::from($row), $env);
+        }
+
+        return response()->json(PhoneNumberResource::from($row), 201);
+    }
+
+    public function show(string $phoneNumberId): JsonResponse
+    {
+        $row = $this->find($phoneNumberId);
+        if ($row === null) {
+            return $this->error(404, 'phone_number_not_found', 'No phone number matches that id in this environment.');
+        }
+
+        return response()->json(PhoneNumberResource::from($row))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function update(Request $request, string $phoneNumberId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $row = $this->find($phoneNumberId);
+        if ($row === null) {
+            return $this->error(404, 'phone_number_not_found', 'No phone number matches that id in this environment.');
+        }
+
+        $wasUnverified = $row->verified_at === null;
+
+        $payload = [];
+        if ($request->has('verified')) {
+            $payload['verified_at'] = (bool) $request->input('verified') ? ($row->verified_at ?? now()) : null;
+        }
+        if ($request->has('is_primary')) {
+            $payload['is_primary'] = (bool) $request->input('is_primary');
+        }
+        if ($request->has('reserved_for_second_factor')) {
+            $payload['reserved_for_second_factor'] = (bool) $request->input('reserved_for_second_factor');
+        }
+        if ($request->has('default_second_factor')) {
+            $payload['default_second_factor'] = (bool) $request->input('default_second_factor');
+        }
+
+        if ($payload === []) {
+            return response()->json(PhoneNumberResource::from($row));
+        }
+
+        DB::transaction(function () use ($env, $row, $payload): void {
+            if (($payload['is_primary'] ?? null) === true) {
+                PhoneNumber::query()->withoutGlobalScopes()
+                    ->where('environment_id', $env->id)
+                    ->where('user_id', $row->user_id)
+                    ->where('id', '!=', $row->id)
+                    ->where('is_primary', true)
+                    ->update(['is_primary' => false]);
+                $row->user?->forceFill(['primary_phone_number_id' => $row->id])->save();
+            }
+            if (($payload['default_second_factor'] ?? null) === true) {
+                PhoneNumber::query()->withoutGlobalScopes()
+                    ->where('environment_id', $env->id)
+                    ->where('user_id', $row->user_id)
+                    ->where('id', '!=', $row->id)
+                    ->where('default_second_factor', true)
+                    ->update(['default_second_factor' => false]);
+            }
+            $row->forceFill($payload)->save();
+        });
+
+        $row->refresh();
+
+        Log::info('audit:bapi.phone_number.updated', [
+            'environment_id' => $env->id,
+            'phone_number_id' => $row->id,
+        ]);
+
+        if ($wasUnverified && $row->verified_at !== null) {
+            app(Emitter::class)->emit('phoneNumber.verified', PhoneNumberResource::from($row), $env);
+        }
+
+        return response()->json(PhoneNumberResource::from($row));
+    }
+
+    public function destroy(string $phoneNumberId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $row = $this->find($phoneNumberId);
+        if ($row === null) {
+            return $this->error(404, 'phone_number_not_found', 'No phone number matches that id in this environment.');
+        }
+
+        if ($row->reserved_for_second_factor) {
+            return $this->error(409, 'phone_reserved_for_second_factor', 'This phone is currently committed to MFA. Clear reserved_for_second_factor first.');
+        }
+
+        $snapshot = PhoneNumberResource::from($row);
+        $row->delete();
+
+        Log::info('audit:bapi.phone_number.removed', [
+            'environment_id' => $env->id,
+            'phone_number_id' => $phoneNumberId,
+        ]);
+
+        app(Emitter::class)->emit('phoneNumber.removed', $snapshot, $env);
+
+        return response()->json(null, 204);
+    }
+
+    private function find(string $phoneNumberId): ?PhoneNumber
+    {
+        $env = app(Environment::class);
+
+        return PhoneNumber::query()->withoutGlobalScopes()
+            ->where('id', $phoneNumberId)
+            ->where('environment_id', $env->id)
+            ->first();
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [['code' => $code, 'long_message' => $message, 'message' => $message]],
+        ], $status);
+    }
+}

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\Bapi\AllowlistIdentifiersController;
 use App\Http\Controllers\Bapi\BlocklistIdentifiersController;
+use App\Http\Controllers\Bapi\ExternalAccountController;
 use App\Http\Controllers\Bapi\InstanceController;
 use App\Http\Controllers\Bapi\InvitationsController;
 use App\Http\Controllers\Bapi\OauthProviderController;
@@ -13,6 +14,7 @@ use App\Http\Controllers\Bapi\OrganizationDomainController;
 use App\Http\Controllers\Bapi\OrganizationInvitationController;
 use App\Http\Controllers\Bapi\OrganizationMembershipController;
 use App\Http\Controllers\Bapi\PermissionController;
+use App\Http\Controllers\Bapi\PhoneNumberController;
 use App\Http\Controllers\Bapi\PingController;
 use App\Http\Controllers\Bapi\RedirectUrlsController;
 use App\Http\Controllers\Bapi\RoleController;
@@ -111,6 +113,18 @@ Route::get('/oauth-providers/{oauth_provider_id}', [OauthProviderController::cla
 Route::patch('/oauth-providers/{oauth_provider_id}', [OauthProviderController::class, 'update'])->middleware(RateLimit::class.':oauth_providers.update,60,60')->name('bapi.oauth_providers.update');
 Route::delete('/oauth-providers/{oauth_provider_id}', [OauthProviderController::class, 'destroy'])->middleware(RateLimit::class.':oauth_providers.destroy,30,60')->name('bapi.oauth_providers.destroy');
 Route::post('/oauth-providers/{oauth_provider_id}/test', [OauthProviderController::class, 'test'])->middleware(RateLimit::class.':oauth_providers.test,30,60')->name('bapi.oauth_providers.test');
+
+// Phone numbers (admin)
+Route::get('/phone-numbers', [PhoneNumberController::class, 'index'])->middleware(RateLimit::class.':phone_numbers.list,300,60')->name('bapi.phone_numbers.index');
+Route::post('/phone-numbers', [PhoneNumberController::class, 'store'])->middleware(RateLimit::class.':phone_numbers.create,60,60')->name('bapi.phone_numbers.store');
+Route::get('/phone-numbers/{phone_number_id}', [PhoneNumberController::class, 'show'])->middleware(RateLimit::class.':phone_numbers.read,300,60')->name('bapi.phone_numbers.show');
+Route::patch('/phone-numbers/{phone_number_id}', [PhoneNumberController::class, 'update'])->middleware(RateLimit::class.':phone_numbers.update,60,60')->name('bapi.phone_numbers.update');
+Route::delete('/phone-numbers/{phone_number_id}', [PhoneNumberController::class, 'destroy'])->middleware(RateLimit::class.':phone_numbers.destroy,30,60')->name('bapi.phone_numbers.destroy');
+
+// External accounts (admin)
+Route::get('/external-accounts', [ExternalAccountController::class, 'index'])->middleware(RateLimit::class.':external_accounts.list,300,60')->name('bapi.external_accounts.index');
+Route::get('/external-accounts/{external_account_id}', [ExternalAccountController::class, 'show'])->middleware(RateLimit::class.':external_accounts.read,300,60')->name('bapi.external_accounts.read');
+Route::delete('/external-accounts/{external_account_id}', [ExternalAccountController::class, 'destroy'])->middleware(RateLimit::class.':external_accounts.destroy,30,60')->name('bapi.external_accounts.destroy');
 
 // Organizations
 Route::get('/organizations', [OrganizationController::class, 'index'])->middleware(RateLimit::class.':orgs.list,300,60')->name('bapi.organizations.index');

--- a/tests/Feature/Http/Bapi/ExternalAccountsAdminTest.php
+++ b/tests/Feature/Http/Bapi/ExternalAccountsAdminTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Bapi;
+
+use App\Models\ExternalAccount;
+use App\Models\OauthProvider;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    Bus::fake();
+});
+
+function ea_boot(string $slug): array
+{
+    $boot = BapiTestSupport::bootEnv($slug);
+    $user = User::create(['environment_id' => $boot['env']->id]);
+    $provider = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $boot['env']->id)
+        ->where('provider_key', 'google')
+        ->firstOrFail();
+    $ext = ExternalAccount::query()->withoutGlobalScopes()->create([
+        'environment_id' => $boot['env']->id,
+        'user_id' => $user->id,
+        'oauth_provider_id' => $provider->id,
+        'provider_user_id' => 'g-123',
+        'email_address' => 'alice@example.com',
+        'verified' => true,
+        'scopes' => ['openid', 'email'],
+        'public_metadata' => [],
+        'encrypted_access_token' => 'at-1',
+        'linked_at' => now(),
+    ]);
+
+    return ['boot' => $boot, 'user' => $user, 'provider' => $provider, 'ext' => $ext];
+}
+
+it('lists external accounts filtered by user_id', function (): void {
+    $f = ea_boot('ea-list');
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['boot']['token']))
+        ->withoutOpenApiAssertions()
+        ->get(BapiTestSupport::url('/external-accounts?user_id='.$f['user']->id));
+    $r->assertOk();
+    expect($r->json('data'))->toHaveCount(1);
+    expect($r->json('data.0.provider_user_id'))->toBe('g-123');
+});
+
+it('returns a single external account by id', function (): void {
+    $f = ea_boot('ea-show');
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['boot']['token']))
+        ->withoutOpenApiAssertions()
+        ->get(BapiTestSupport::url('/external-accounts/'.$f['ext']->id));
+    $r->assertOk();
+    expect($r->json('id'))->toBe($f['ext']->id);
+});
+
+it('deletes an external account and best-effort revokes', function (): void {
+    $f = ea_boot('ea-del');
+    Http::fake([
+        'idp.test/revoke' => Http::response(['ok' => true], 200),
+    ]);
+    $f['provider']->forceFill([
+        'additional_authorization_params' => ['revocation_endpoint' => 'https://idp.test/revoke'],
+    ])->save();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['boot']['token']))
+        ->withoutOpenApiAssertions()
+        ->deleteJson(BapiTestSupport::url('/external-accounts/'.$f['ext']->id));
+    $r->assertStatus(204);
+    expect(ExternalAccount::query()->withoutGlobalScopes()->where('id', $f['ext']->id)->exists())->toBeFalse();
+    Http::assertSent(fn ($request) => $request->url() === 'https://idp.test/revoke');
+});
+
+it('deletes even when IdP revocation fails', function (): void {
+    $f = ea_boot('ea-del-soft');
+    Http::fake([
+        'idp.test/revoke' => Http::response(['error' => 'unavailable'], 500),
+    ]);
+    $f['provider']->forceFill([
+        'additional_authorization_params' => ['revocation_endpoint' => 'https://idp.test/revoke'],
+    ])->save();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['boot']['token']))
+        ->withoutOpenApiAssertions()
+        ->deleteJson(BapiTestSupport::url('/external-accounts/'.$f['ext']->id));
+    $r->assertStatus(204);
+    expect(ExternalAccount::query()->withoutGlobalScopes()->where('id', $f['ext']->id)->exists())->toBeFalse();
+});

--- a/tests/Feature/Http/Bapi/PhoneNumbersAdminTest.php
+++ b/tests/Feature/Http/Bapi/PhoneNumbersAdminTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Bapi;
+
+use App\Models\PhoneNumber;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+
+beforeEach(function (): void {
+    Bus::fake();
+});
+
+it('lists phone numbers filtered by user_id', function (): void {
+    $boot = BapiTestSupport::bootEnv('acmeph');
+    $user = User::create(['environment_id' => $boot['env']->id]);
+    PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $boot['env']->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15555550101',
+        'verified_at' => now(),
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($boot['token']))
+        ->withoutOpenApiAssertions()
+        ->get(BapiTestSupport::url('/phone-numbers?user_id='.$user->id));
+    $r->assertOk();
+    expect($r->json('data'))->toHaveCount(1);
+    expect($r->json('data.0.phone_number'))->toBe('+15555550101');
+    expect($r->json('data.0.verified'))->toBeTrue();
+});
+
+it('creates an admin phone with verified + primary shortcuts', function (): void {
+    $boot = BapiTestSupport::bootEnv('acmeph2');
+    $user = User::create(['environment_id' => $boot['env']->id]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($boot['token']))
+        ->withoutOpenApiAssertions()
+        ->postJson(BapiTestSupport::url('/phone-numbers'), [
+            'user_id' => $user->id,
+            'phone_number' => '+15555550102',
+            'verified' => true,
+            'primary' => true,
+        ]);
+    $r->assertCreated();
+    expect($r->json('verified'))->toBeTrue();
+    expect($r->json('is_primary'))->toBeTrue();
+    expect($user->fresh()->primary_phone_number_id)->toBe($r->json('id'));
+});
+
+it('refuses delete when reserved_for_second_factor is set', function (): void {
+    $boot = BapiTestSupport::bootEnv('acmeph3');
+    $user = User::create(['environment_id' => $boot['env']->id]);
+    $row = PhoneNumber::query()->withoutGlobalScopes()->create([
+        'environment_id' => $boot['env']->id,
+        'user_id' => $user->id,
+        'phone_number' => '+15555550103',
+        'verified_at' => now(),
+        'reserved_for_second_factor' => true,
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($boot['token']))
+        ->withoutOpenApiAssertions()
+        ->deleteJson(BapiTestSupport::url('/phone-numbers/'.$row->id));
+    $r->assertStatus(409);
+    expect($r->json('errors.0.code'))->toBe('phone_reserved_for_second_factor');
+    expect(PhoneNumber::query()->withoutGlobalScopes()->where('id', $row->id)->exists())->toBeTrue();
+});
+
+it('rejects non-E.164 phone formats on store', function (): void {
+    $boot = BapiTestSupport::bootEnv('acmeph4');
+    $user = User::create(['environment_id' => $boot['env']->id]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($boot['token']))
+        ->withoutOpenApiAssertions()
+        ->postJson(BapiTestSupport::url('/phone-numbers'), [
+            'user_id' => $user->id,
+            'phone_number' => '555-1234',
+        ]);
+    $r->assertStatus(422);
+    expect($r->json('errors.0.code'))->toBe('form_param_format_invalid');
+});


### PR DESCRIPTION
Closes #150.

## Summary

Implements OA-9's spec on the server side.

**PhoneNumberController**:
- `GET /v1/phone-numbers` (filter by `user_id`, paginate)
- `POST /v1/phone-numbers` (admin-create with `verified` + `primary` BAPI shortcuts; flips other primary rows when needed)
- `GET` / `PATCH` (admin verify, MFA flag toggles, single-primary invariant) / `DELETE` (409 on `reserved_for_second_factor`)

**ExternalAccountController**:
- `GET` (filter by `user_id` + `oauth_provider_id`, paginate)
- `GET` / `DELETE` (best-effort IdP revocation via `additional_authorization_params.revocation_endpoint`, then drops the local row + clears `EmailAddress.linked_to_external_account_id`)

Per-route rate-limit buckets added (300/60 list, 60/60 mutating).

## Test plan

- [x] 8 new admin tests passing
- [x] 677/677 full pest suite passing
- [x] pint clean
- [ ] CI green