### PR TITLE
AU-1: Passkey model + Verification.STRATEGY_PASSKEY

### DIFF
--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -37,6 +37,7 @@ final class UserResource
             'external_accounts' => [],
             'enterprise_accounts' => [],
             'passkeys' => [],
+            'passkey_count' => $user->passkey_count,
             'password_enabled' => $user->password_hash !== null,
             'two_factor_enabled' => (bool) $user->two_factor_enabled,
             'totp_enabled' => (bool) $user->totp_enabled,

--- a/app/Models/Passkey.php
+++ b/app/Models/Passkey.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use Database\Factories\PasskeyFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * One row per registered WebAuthn credential. The `credential_id` and
+ * `public_key` blobs are encrypted at rest; the SHA-256 `credential_id_hash`
+ * is the index column used by the sign-in path to find a passkey from the
+ * authenticator's assertion without first decrypting every row.
+ *
+ * @property string $id
+ * @property string $user_id
+ * @property string $credential_id
+ * @property string $credential_id_hash
+ * @property string $public_key
+ * @property int $sign_count
+ * @property array<int, string> $transports
+ * @property ?string $aaguid
+ * @property ?string $nickname
+ * @property ?\DateTimeInterface $last_used_at
+ * @property ?\DateTimeInterface $verified_at
+ * @property ?\DateTimeInterface $removed_at
+ */
+class Passkey extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+    use SoftDeletes;
+
+    public const TRANSPORT_USB = 'usb';
+
+    public const TRANSPORT_NFC = 'nfc';
+
+    public const TRANSPORT_BLE = 'ble';
+
+    public const TRANSPORT_INTERNAL = 'internal';
+
+    public const TRANSPORT_HYBRID = 'hybrid';
+
+    public const TRANSPORT_SMART_CARD = 'smart-card';
+
+    public const TRANSPORTS = [
+        self::TRANSPORT_USB,
+        self::TRANSPORT_NFC,
+        self::TRANSPORT_BLE,
+        self::TRANSPORT_INTERNAL,
+        self::TRANSPORT_HYBRID,
+        self::TRANSPORT_SMART_CARD,
+    ];
+
+    protected string $idPrefix = 'pkey_';
+
+    public const DELETED_AT = 'removed_at';
+
+    protected $fillable = [
+        'user_id',
+        'credential_id',
+        'credential_id_hash',
+        'public_key',
+        'sign_count',
+        'transports',
+        'aaguid',
+        'nickname',
+        'last_used_at',
+        'verified_at',
+    ];
+
+    protected $hidden = [
+        'credential_id',
+        'credential_id_hash',
+        'public_key',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'credential_id' => 'encrypted',
+            'public_key' => 'encrypted',
+            'sign_count' => 'int',
+            'transports' => 'array',
+            'last_used_at' => 'immutable_datetime',
+            'verified_at' => 'immutable_datetime',
+            'removed_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function newFactory(): PasskeyFactory
+    {
+        return PasskeyFactory::new();
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function scopeVerified(Builder $query): Builder
+    {
+        return $query->whereNotNull('verified_at');
+    }
+
+    /**
+     * Verified passkeys that have not been soft-deleted. Soft-deletes are
+     * filtered automatically by the SoftDeletes trait, so this scope only
+     * adds the `verified_at` predicate on top.
+     */
+    public function scopeUsable(Builder $query): Builder
+    {
+        return $query->whereNotNull('verified_at');
+    }
+
+    public function isVerified(): bool
+    {
+        return $this->verified_at !== null;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -54,6 +54,7 @@ use Illuminate\Support\Facades\Hash;
  * @property array $private_metadata
  * @property array $unsafe_metadata
  * @property ?string $locale
+ * @property-read int $passkey_count
  */
 #[ObservedBy([UserObserver::class])]
 class User extends Model implements AuthenticatableContract
@@ -146,6 +147,16 @@ class User extends Model implements AuthenticatableContract
     public function externalAccounts(): HasMany
     {
         return $this->hasMany(ExternalAccount::class);
+    }
+
+    public function passkeys(): HasMany
+    {
+        return $this->hasMany(Passkey::class);
+    }
+
+    protected function passkeyCount(): Attribute
+    {
+        return Attribute::get(fn (): int => $this->passkeys()->whereNotNull('verified_at')->count());
     }
 
     public function primaryEmailAddress(): BelongsTo

--- a/app/Models/Verification.php
+++ b/app/Models/Verification.php
@@ -83,6 +83,8 @@ class Verification extends Model
 
     public const STRATEGY_PHONE_CODE = 'phone_code';
 
+    public const STRATEGY_PASSKEY = 'passkey';
+
     public const STRATEGIES = [
         self::STRATEGY_PASSWORD,
         self::STRATEGY_EMAIL_CODE,
@@ -93,6 +95,7 @@ class Verification extends Model
         self::STRATEGY_TOTP,
         self::STRATEGY_BACKUP_CODE,
         self::STRATEGY_PHONE_CODE,
+        self::STRATEGY_PASSKEY,
     ];
 
     /**

--- a/database/factories/PasskeyFactory.php
+++ b/database/factories/PasskeyFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Passkey;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Passkey>
+ */
+class PasskeyFactory extends Factory
+{
+    /**
+     * @var class-string<Passkey>
+     */
+    protected $model = Passkey::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $credentialId = random_bytes(32);
+
+        return [
+            // user_id must be supplied by the caller — User has no factory.
+            'credential_id' => $credentialId,
+            'credential_id_hash' => hash('sha256', $credentialId, true),
+            'public_key' => random_bytes(77),
+            'sign_count' => 0,
+            'transports' => $this->faker->randomElements(
+                [Passkey::TRANSPORT_INTERNAL, Passkey::TRANSPORT_HYBRID, Passkey::TRANSPORT_USB],
+                $this->faker->numberBetween(1, 2),
+            ),
+            'aaguid' => $this->faker->uuid(),
+            'nickname' => $this->faker->randomElement(['MacBook Pro', 'iPhone', 'YubiKey', null]),
+            'verified_at' => now(),
+        ];
+    }
+
+    public function unverified(): self
+    {
+        return $this->state(fn (array $attributes): array => ['verified_at' => null]);
+    }
+}

--- a/database/migrations/2026_05_11_000000_create_passkeys_table.php
+++ b/database/migrations/2026_05_11_000000_create_passkeys_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('passkeys', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('user_id', 64);
+
+            // Raw WebAuthn credential id (binary blob). Encrypted at rest via
+            // Laravel's `encrypted` cast on the model. SQLite-friendly `binary`
+            // maps to BLOB; PostgreSQL maps to BYTEA.
+            $table->binary('credential_id');
+
+            // SHA-256 of credential_id. Indexed for fast uniqueness checks and
+            // sign-in lookups without decrypting the full credential blob.
+            $table->binary('credential_id_hash');
+
+            // COSE public key blob (encrypted at rest via the model cast).
+            $table->text('public_key');
+
+            $table->unsignedBigInteger('sign_count')->default(0);
+            $table->jsonb('transports')->default(json_encode([]));
+            $table->uuid('aaguid')->nullable();
+            $table->string('nickname')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('verified_at')->nullable();
+
+            $table->timestamps();
+            $table->softDeletes('removed_at');
+
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->index('user_id');
+            $table->index(['user_id', 'verified_at']);
+            $table->unique('credential_id_hash');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('passkeys');
+    }
+};

--- a/tests/Feature/Models/PasskeyTest.php
+++ b/tests/Feature/Models/PasskeyTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Passkey;
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Verification;
+
+function makeEnvForPasskey(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('mints a pkey_ prefixed id and casts transports to an array', function (): void {
+    $env = makeEnvForPasskey();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $passkey = Passkey::factory()->create([
+        'user_id' => $user->id,
+        'transports' => [Passkey::TRANSPORT_INTERNAL, Passkey::TRANSPORT_HYBRID],
+    ]);
+
+    expect($passkey->id)->toStartWith('pkey_');
+    expect($passkey->transports)->toBe([Passkey::TRANSPORT_INTERNAL, Passkey::TRANSPORT_HYBRID]);
+});
+
+it('encrypts credential_id and public_key at rest and hides them from arrays', function (): void {
+    $env = makeEnvForPasskey();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $credentialId = random_bytes(32);
+    $passkey = Passkey::factory()->create([
+        'user_id' => $user->id,
+        'credential_id' => $credentialId,
+        'credential_id_hash' => hash('sha256', $credentialId, true),
+        'public_key' => 'cleartext-public-key',
+    ]);
+
+    expect($passkey->credential_id)->toBe($credentialId);
+    expect($passkey->public_key)->toBe('cleartext-public-key');
+
+    $raw = (string) DB::table('passkeys')->where('id', $passkey->id)->value('public_key');
+    expect($raw)->not->toBe('cleartext-public-key');
+    expect(strlen($raw))->toBeGreaterThan(20);
+
+    $arr = $passkey->toArray();
+    expect($arr)->not->toHaveKey('credential_id');
+    expect($arr)->not->toHaveKey('credential_id_hash');
+    expect($arr)->not->toHaveKey('public_key');
+});
+
+it('relates Passkey → User and exposes User->passkeys()', function (): void {
+    $env = makeEnvForPasskey();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $passkey = Passkey::factory()->create(['user_id' => $user->id]);
+
+    expect($passkey->user->id)->toBe($user->id);
+    expect($user->refresh()->passkeys->pluck('id')->all())->toBe([$passkey->id]);
+});
+
+it('counts only verified passkeys via the passkey_count accessor', function (): void {
+    $env = makeEnvForPasskey();
+    $user = User::create(['environment_id' => $env->id]);
+
+    Passkey::factory()->create(['user_id' => $user->id, 'verified_at' => now()]);
+    Passkey::factory()->create(['user_id' => $user->id, 'verified_at' => now()]);
+    Passkey::factory()->unverified()->create(['user_id' => $user->id]);
+
+    expect($user->passkey_count)->toBe(2);
+});
+
+it('verified() and usable() scopes filter to verified, non-removed rows', function (): void {
+    $env = makeEnvForPasskey();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $verified = Passkey::factory()->create(['user_id' => $user->id, 'verified_at' => now()]);
+    Passkey::factory()->unverified()->create(['user_id' => $user->id]);
+    $removed = Passkey::factory()->create(['user_id' => $user->id, 'verified_at' => now()]);
+    $removed->delete();
+
+    expect(Passkey::query()->verified()->pluck('id')->all())->toBe([$verified->id]);
+    expect(Passkey::query()->usable()->pluck('id')->all())->toBe([$verified->id]);
+});
+
+it('soft-deletes via the removed_at column', function (): void {
+    $env = makeEnvForPasskey();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $passkey = Passkey::factory()->create(['user_id' => $user->id]);
+    $passkey->delete();
+
+    expect(Passkey::query()->find($passkey->id))->toBeNull();
+    expect(Passkey::withTrashed()->find($passkey->id)?->removed_at)->not->toBeNull();
+});
+
+it('cascades passkey deletion when the parent user is deleted', function (): void {
+    $env = makeEnvForPasskey();
+    $user = User::create(['environment_id' => $env->id]);
+    $passkey = Passkey::factory()->create(['user_id' => $user->id]);
+
+    DB::table('users')->where('id', $user->id)->delete();
+
+    expect(DB::table('passkeys')->where('id', $passkey->id)->exists())->toBeFalse();
+});
+
+it('extends Verification::strategies() with the passkey strategy', function (): void {
+    expect(Verification::strategies())->toContain(Verification::STRATEGY_PASSKEY);
+    expect(Verification::isValidStrategy('passkey'))->toBeTrue();
+});


### PR DESCRIPTION
Closes #162

Spine for v0.5 WebAuthn work. One row per registered credential.

## Summary

- New `passkeys` table — `credential_id` and `public_key` encrypted at rest, `credential_id_hash` indexed (and globally unique per WebAuthn spec) for fast sign-in lookups, soft-deletes via `removed_at`, plus indexes on `user_id` and `(user_id, verified_at)`.
- `App\Models\Passkey` — `pkey_` prefixed ULID, `HasFactory` + `SoftDeletes`, `verified()` + `usable()` scopes, transport constants, `encrypted` casts.
- `App\Models\User` — `passkeys()` relation and `passkey_count` accessor (verified-only).
- `Verification::STRATEGIES` gains `passkey` so the strategy plumbing accepts it without further edits.
- `Database\Factories\PasskeyFactory` with `unverified()` state; tests construct users explicitly the same way the rest of the suite does (no `User::factory()` exists yet).

## Test plan

- [x] `php artisan test` — 688 passed (+8 new in `PasskeyTest`).
- [x] `vendor/bin/pint --test` clean.
- [x] `php artisan migrate:fresh` runs cleanly.