### PR TITLE
AU-5: 6 OAuth presets (Discord/Facebook/LinkedIn/X/GitLab/Slack)

### DIFF
--- a/app/Auth/Oauth/PresetRegistry.php
+++ b/app/Auth/Oauth/PresetRegistry.php
@@ -5,15 +5,23 @@ declare(strict_types=1);
 namespace App\Auth\Oauth;
 
 use App\Auth\Oauth\Presets\ApplePreset;
+use App\Auth\Oauth\Presets\DiscordPreset;
+use App\Auth\Oauth\Presets\FacebookPreset;
 use App\Auth\Oauth\Presets\GitHubPreset;
+use App\Auth\Oauth\Presets\GitLabPreset;
 use App\Auth\Oauth\Presets\GooglePreset;
+use App\Auth\Oauth\Presets\LinkedInPreset;
 use App\Auth\Oauth\Presets\MicrosoftPreset;
 use App\Auth\Oauth\Presets\PresetContract;
+use App\Auth\Oauth\Presets\SlackPreset;
+use App\Auth\Oauth\Presets\XPreset;
 
 /**
- * Canonical list of preset providers shipped with v0.4. Adding a new
- * preset is a one-line change here plus the corresponding implementation
- * under `app/Auth/Oauth/Presets/`.
+ * Canonical list of preset providers. Adding a new preset is a one-line
+ * change here plus the corresponding implementation under
+ * `app/Auth/Oauth/Presets/`. Every registered key gets a row seeded
+ * (disabled, blank credentials) on every freshly-created environment by
+ * `OauthProviderSeeder`.
  */
 final class PresetRegistry
 {
@@ -30,6 +38,12 @@ final class PresetRegistry
             (new GitHubPreset)->key() => new GitHubPreset,
             (new ApplePreset)->key() => new ApplePreset,
             (new MicrosoftPreset)->key() => new MicrosoftPreset,
+            (new DiscordPreset)->key() => new DiscordPreset,
+            (new FacebookPreset)->key() => new FacebookPreset,
+            (new LinkedInPreset)->key() => new LinkedInPreset,
+            (new XPreset)->key() => new XPreset,
+            (new GitLabPreset)->key() => new GitLabPreset,
+            (new SlackPreset)->key() => new SlackPreset,
         ];
     }
 

--- a/app/Auth/Oauth/Presets/DiscordPreset.php
+++ b/app/Auth/Oauth/Presets/DiscordPreset.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * Discord OAuth2 (not OIDC). Claims come from `/users/@me`; there is no
+ * id_token. The `provider_user_id` mapping pins our External Account row
+ * to Discord's stable `id` snowflake.
+ */
+final class DiscordPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'discord';
+    }
+
+    public function name(): string
+    {
+        return 'Discord';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://discord.com/oauth2/authorize';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://discord.com/api/oauth2/token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://discord.com/api/users/@me';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return null;
+    }
+
+    public function issuer(): ?string
+    {
+        return null;
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['identify', 'email'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'provider_user_id' => 'id',
+            'username' => 'username',
+            'email_address' => 'email',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return [];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/FacebookPreset.php
+++ b/app/Auth/Oauth/Presets/FacebookPreset.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * Facebook Login (Graph API v18.0). Operator picks `public_profile` +
+ * `email`; `email` requires the user to have a confirmed email on
+ * their Facebook account.
+ */
+final class FacebookPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'facebook';
+    }
+
+    public function name(): string
+    {
+        return 'Facebook';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://www.facebook.com/v18.0/dialog/oauth';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://graph.facebook.com/v18.0/oauth/access_token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://graph.facebook.com/v18.0/me';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return null;
+    }
+
+    public function issuer(): ?string
+    {
+        return null;
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['public_profile', 'email'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'provider_user_id' => 'id',
+            'email_address' => 'email',
+            'first_name' => 'first_name',
+            'last_name' => 'last_name',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        // Graph `/me` returns only id + name by default. Operators that
+        // need email + first/last must request the fields explicitly on
+        // the userinfo call; the v0.4 callback will append `?fields=...`
+        // when configured.
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return [];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/GitLabPreset.php
+++ b/app/Auth/Oauth/Presets/GitLabPreset.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * GitLab.com OIDC. Self-hosted GitLab instances should be configured as
+ * `custom_oidc` rows pointed at the operator's instance issuer; this
+ * preset specifically targets gitlab.com.
+ */
+final class GitLabPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'gitlab';
+    }
+
+    public function name(): string
+    {
+        return 'GitLab';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://gitlab.com/oauth/authorize';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://gitlab.com/oauth/token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://gitlab.com/oauth/userinfo';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return 'https://gitlab.com/oauth/discovery/keys';
+    }
+
+    public function issuer(): ?string
+    {
+        return 'https://gitlab.com';
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['openid', 'profile', 'email'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'provider_user_id' => 'sub',
+            'email' => 'email',
+            'email_verified' => 'email_verified',
+            'first_name' => 'given_name',
+            'last_name' => 'family_name',
+            'username' => 'preferred_username',
+            'image_url' => 'picture',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return ['RS256'];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/LinkedInPreset.php
+++ b/app/Auth/Oauth/Presets/LinkedInPreset.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * LinkedIn "Sign In with LinkedIn using OpenID Connect". Endpoints
+ * mirror the values discovery at
+ * `https://www.linkedin.com/oauth/.well-known/openid-configuration`
+ * exposes; discovery isn't run here because preset rows ship with
+ * the endpoints baked in.
+ */
+final class LinkedInPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'linkedin';
+    }
+
+    public function name(): string
+    {
+        return 'LinkedIn';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://www.linkedin.com/oauth/v2/authorization';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://www.linkedin.com/oauth/v2/accessToken';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://api.linkedin.com/v2/userinfo';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return 'https://www.linkedin.com/oauth/openid/jwks';
+    }
+
+    public function issuer(): ?string
+    {
+        return 'https://www.linkedin.com/oauth';
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['openid', 'profile', 'email'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'provider_user_id' => 'sub',
+            'email' => 'email',
+            'email_verified' => 'email_verified',
+            'first_name' => 'given_name',
+            'last_name' => 'family_name',
+            'image_url' => 'picture',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return ['RS256'];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/SlackPreset.php
+++ b/app/Auth/Oauth/Presets/SlackPreset.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * Sign in with Slack — Slack's OIDC product (not the legacy v2 OAuth
+ * scopes). The standard OIDC claim set is sufficient for our shape.
+ */
+final class SlackPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'slack';
+    }
+
+    public function name(): string
+    {
+        return 'Slack';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://slack.com/openid/connect/authorize';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://slack.com/api/openid.connect.token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://slack.com/api/openid.connect.userInfo';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return 'https://slack.com/openid/connect/keys';
+    }
+
+    public function issuer(): ?string
+    {
+        return 'https://slack.com';
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['openid', 'profile', 'email'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'provider_user_id' => 'sub',
+            'email' => 'email',
+            'email_verified' => 'email_verified',
+            'first_name' => 'given_name',
+            'last_name' => 'family_name',
+            'image_url' => 'picture',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return ['RS256'];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/XPreset.php
+++ b/app/Auth/Oauth/Presets/XPreset.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * X (formerly Twitter) OAuth2 v2. X mandates PKCE on the authorization
+ * code grant — when the engine gains PKCE plumbing the X preset will be
+ * marked as requiring it; until then operators must configure their
+ * X developer app for confidential PKCE flow on the X side.
+ */
+final class XPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'x';
+    }
+
+    public function name(): string
+    {
+        return 'X';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://twitter.com/i/oauth2/authorize';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://api.twitter.com/2/oauth2/token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://api.twitter.com/2/users/me';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return null;
+    }
+
+    public function issuer(): ?string
+    {
+        return null;
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['tweet.read', 'users.read'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'provider_user_id' => 'id',
+            'username' => 'username',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return [];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/tests/Feature/Auth/Oauth/NewPresetsTest.php
+++ b/tests/Feature/Auth/Oauth/NewPresetsTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Oauth\PresetRegistry;
+use App\Auth\Oauth\Presets\DiscordPreset;
+use App\Auth\Oauth\Presets\FacebookPreset;
+use App\Auth\Oauth\Presets\GitLabPreset;
+use App\Auth\Oauth\Presets\LinkedInPreset;
+use App\Auth\Oauth\Presets\SlackPreset;
+use App\Auth\Oauth\Presets\XPreset;
+use App\Models\Environment;
+use App\Models\OauthProvider;
+use App\Models\Project;
+
+function makeEnvForNewPresets(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('registers all six new presets on PresetRegistry', function (): void {
+    $keys = app(PresetRegistry::class)->keys();
+
+    expect($keys)->toContain('discord', 'facebook', 'linkedin', 'x', 'gitlab', 'slack');
+});
+
+it('seeds the six new preset rows disabled-but-configured on env creation', function (): void {
+    $env = makeEnvForNewPresets();
+
+    $rows = OauthProvider::query()
+        ->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->get()
+        ->keyBy('provider_key');
+
+    foreach (['google', 'github', 'apple', 'microsoft', 'discord', 'facebook', 'linkedin', 'x', 'gitlab', 'slack'] as $key) {
+        expect($rows->has($key))->toBeTrue("missing preset row: {$key}");
+        expect($rows[$key]->enabled)->toBeFalse("preset {$key} should seed disabled");
+        expect($rows[$key]->client_id)->toBe('');
+    }
+
+    expect($rows->count())->toBe(10);
+});
+
+it('Discord preset exposes OAuth2 endpoints + identify/email scopes', function (): void {
+    $p = new DiscordPreset;
+
+    expect($p->key())->toBe('discord');
+    expect($p->name())->toBe('Discord');
+    expect($p->authorizationEndpoint())->toBe('https://discord.com/oauth2/authorize');
+    expect($p->tokenEndpoint())->toBe('https://discord.com/api/oauth2/token');
+    expect($p->userinfoEndpoint())->toBe('https://discord.com/api/users/@me');
+    expect($p->jwksUri())->toBeNull();
+    expect($p->issuer())->toBeNull();
+    expect($p->defaultScopes())->toBe(['identify', 'email']);
+    expect($p->defaultAttributeMapping())->toBe([
+        'provider_user_id' => 'id',
+        'username' => 'username',
+        'email_address' => 'email',
+    ]);
+    expect($p->idTokenSigningAlgs())->toBe([]);
+});
+
+it('Facebook preset exposes Graph v18.0 endpoints + public_profile/email scopes', function (): void {
+    $p = new FacebookPreset;
+
+    expect($p->key())->toBe('facebook');
+    expect($p->authorizationEndpoint())->toBe('https://www.facebook.com/v18.0/dialog/oauth');
+    expect($p->tokenEndpoint())->toBe('https://graph.facebook.com/v18.0/oauth/access_token');
+    expect($p->userinfoEndpoint())->toBe('https://graph.facebook.com/v18.0/me');
+    expect($p->defaultScopes())->toBe(['public_profile', 'email']);
+    expect($p->defaultAttributeMapping())->toMatchArray([
+        'email_address' => 'email',
+        'first_name' => 'first_name',
+        'last_name' => 'last_name',
+    ]);
+});
+
+it('LinkedIn preset exposes OIDC endpoints + standard OIDC scopes', function (): void {
+    $p = new LinkedInPreset;
+
+    expect($p->key())->toBe('linkedin');
+    expect($p->issuer())->toBe('https://www.linkedin.com/oauth');
+    expect($p->jwksUri())->toBe('https://www.linkedin.com/oauth/openid/jwks');
+    expect($p->defaultScopes())->toBe(['openid', 'profile', 'email']);
+    expect($p->defaultAttributeMapping())->toMatchArray([
+        'provider_user_id' => 'sub',
+        'email' => 'email',
+        'first_name' => 'given_name',
+        'last_name' => 'family_name',
+    ]);
+    expect($p->idTokenSigningAlgs())->toBe(['RS256']);
+});
+
+it('X preset exposes api.twitter.com endpoints + tweet.read/users.read scopes', function (): void {
+    $p = new XPreset;
+
+    expect($p->key())->toBe('x');
+    expect($p->name())->toBe('X');
+    expect($p->authorizationEndpoint())->toBe('https://twitter.com/i/oauth2/authorize');
+    expect($p->tokenEndpoint())->toBe('https://api.twitter.com/2/oauth2/token');
+    expect($p->userinfoEndpoint())->toBe('https://api.twitter.com/2/users/me');
+    expect($p->defaultScopes())->toBe(['tweet.read', 'users.read']);
+    expect($p->defaultAttributeMapping())->toBe([
+        'provider_user_id' => 'id',
+        'username' => 'username',
+    ]);
+    expect($p->idTokenSigningAlgs())->toBe([]);
+});
+
+it('GitLab preset exposes gitlab.com OIDC endpoints + standard scopes', function (): void {
+    $p = new GitLabPreset;
+
+    expect($p->key())->toBe('gitlab');
+    expect($p->issuer())->toBe('https://gitlab.com');
+    expect($p->authorizationEndpoint())->toBe('https://gitlab.com/oauth/authorize');
+    expect($p->defaultScopes())->toBe(['openid', 'profile', 'email']);
+    expect($p->defaultAttributeMapping())->toMatchArray([
+        'provider_user_id' => 'sub',
+        'username' => 'preferred_username',
+    ]);
+    expect($p->idTokenSigningAlgs())->toBe(['RS256']);
+});
+
+it('Slack preset exposes Sign-in-with-Slack OIDC endpoints', function (): void {
+    $p = new SlackPreset;
+
+    expect($p->key())->toBe('slack');
+    expect($p->issuer())->toBe('https://slack.com');
+    expect($p->authorizationEndpoint())->toBe('https://slack.com/openid/connect/authorize');
+    expect($p->userinfoEndpoint())->toBe('https://slack.com/api/openid.connect.userInfo');
+    expect($p->defaultScopes())->toBe(['openid', 'profile', 'email']);
+    expect($p->idTokenSigningAlgs())->toBe(['RS256']);
+});
+
+it('every preset returns a non-empty key, name, and endpoint set', function (): void {
+    foreach (app(PresetRegistry::class)->all() as $key => $preset) {
+        expect($preset->key())->toBe($key);
+        expect($preset->name())->not->toBe('');
+        expect($preset->authorizationEndpoint())->toStartWith('https://');
+        expect($preset->tokenEndpoint())->toStartWith('https://');
+        expect($preset->userinfoEndpoint())->toStartWith('https://');
+    }
+});
+
+it('computes the redirect_uri off the env FAPI host for a new-preset row', function (): void {
+    config()->set('authn.app_host', 'authn.sh');
+    config()->set('authn.app_scheme', 'https');
+    config()->set('authn.routing_mode', 'subdomain');
+    config()->set('authn.app_port_suffix', '');
+
+    $env = makeEnvForNewPresets('acme');
+    $row = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('provider_key', 'discord')
+        ->firstOrFail();
+
+    expect($row->redirect_uri)->toBe('https://acme.authn.sh/v1/oauth-callback/discord');
+});

--- a/tests/Feature/Auth/Oauth/OauthProviderResolverTest.php
+++ b/tests/Feature/Auth/Oauth/OauthProviderResolverTest.php
@@ -240,7 +240,7 @@ it('applies the default OIDC attribute mapping when none is stored', function ()
     expect($resolved->attributeMapping)->toBe(OauthProviderResolver::DEFAULT_OIDC_ATTRIBUTE_MAPPING);
 });
 
-it('seeds the four preset rows on environment creation, all disabled', function (): void {
+it('seeds every preset row on environment creation, all disabled', function (): void {
     $env = makeEnvForResolver('seedme');
 
     $rows = OauthProvider::query()->withoutGlobalScopes()
@@ -248,7 +248,10 @@ it('seeds the four preset rows on environment creation, all disabled', function 
         ->orderBy('provider_key')
         ->get();
 
-    expect($rows->pluck('provider_key')->all())->toBe(['apple', 'github', 'google', 'microsoft']);
+    expect($rows->pluck('provider_key')->all())->toBe([
+        'apple', 'discord', 'facebook', 'github', 'gitlab',
+        'google', 'linkedin', 'microsoft', 'slack', 'x',
+    ]);
     foreach ($rows as $row) {
         expect($row->enabled)->toBeFalse();
         expect($row->client_id)->toBe('');
@@ -269,7 +272,10 @@ it('OauthProvider::computeRedirectUri() builds the canonical callback URL', func
     expect($row->redirect_uri)->toBe('https://acme.authn.sh/v1/oauth-callback/google');
 });
 
-it('PresetRegistry exposes all four canonical preset keys', function (): void {
+it('PresetRegistry exposes the canonical preset keys in registration order', function (): void {
     $registry = app(PresetRegistry::class);
-    expect($registry->keys())->toBe(['google', 'github', 'apple', 'microsoft']);
+    expect($registry->keys())->toBe([
+        'google', 'github', 'apple', 'microsoft',
+        'discord', 'facebook', 'linkedin', 'x', 'gitlab', 'slack',
+    ]);
 });

--- a/tests/Feature/Http/Bapi/OauthProvidersTest.php
+++ b/tests/Feature/Http/Bapi/OauthProvidersTest.php
@@ -22,7 +22,10 @@ final class OauthProvidersTest extends TestCase
 
         $resp->assertOk();
         $keys = collect($resp->json('data'))->pluck('provider_key')->sort()->values()->all();
-        $this->assertSame(['apple', 'github', 'google', 'microsoft'], $keys);
+        $this->assertSame([
+            'apple', 'discord', 'facebook', 'github', 'gitlab',
+            'google', 'linkedin', 'microsoft', 'slack', 'x',
+        ], $keys);
     }
 
     public function test_show_returns_one_provider_with_redirect_uri(): void

--- a/tests/Feature/Http/Dashboard/DashboardTest.php
+++ b/tests/Feature/Http/Dashboard/DashboardTest.php
@@ -586,8 +586,14 @@ it('Configure renders the social-providers section with the seeded preset rows +
         ->assertJsonPath('component', 'Dashboard/Configure')
         ->assertJsonPath('props.section', 'social-providers');
     $keys = collect($r->json('props.oauth_providers'))->pluck('provider_key')->sort()->values()->all();
-    expect($keys)->toBe(['apple', 'github', 'google', 'microsoft']);
-    expect($r->json('props.oauth_preset_keys'))->toBe(['google', 'github', 'apple', 'microsoft']);
+    expect($keys)->toBe([
+        'apple', 'discord', 'facebook', 'github', 'gitlab',
+        'google', 'linkedin', 'microsoft', 'slack', 'x',
+    ]);
+    expect($r->json('props.oauth_preset_keys'))->toBe([
+        'google', 'github', 'apple', 'microsoft',
+        'discord', 'facebook', 'linkedin', 'x', 'gitlab', 'slack',
+    ]);
 });
 
 it('PATCH /configure/oauth-providers/{id} flips enabled + rotates client_secret', function (): void {


### PR DESCRIPTION
Closes #166

Extends the v0.4 OAuth preset registry with six new IdPs. The v0.4 plumbing already handles any registered preset — this PR is preset classes plus their registration.

## Summary

- `DiscordPreset`, `FacebookPreset` — OAuth2-only (no id_token).
- `LinkedInPreset`, `GitLabPreset`, `SlackPreset` — OIDC with standard claim mapping (`sub`, `email`, `given_name`, `family_name`, `picture`).
- `XPreset` — OAuth2; X mandates PKCE on the authorization-code grant. The engine does not yet emit a PKCE challenge, so operators currently need to enable confidential-client flow on the X side. PKCE plumbing lands in a follow-up.
- `PresetRegistry::all()` registers the six new keys. `OauthProviderSeeder` picks them up automatically and seeds ten preset rows (4 original + 6 new) disabled-with-blank-credentials on every freshly-created environment.

## Test plan

- [x] `php artisan test --filter NewPresetsTest` — 10/10 passing.
- [x] `php artisan test tests/Feature/Auth/Oauth/ tests/Feature/Http/Bapi/OauthProvidersTest.php tests/Feature/Http/Dashboard/DashboardTest.php` — 73/73 passing.
- [x] `vendor/bin/pint --test` clean.
- [x] Full suite shows 0 regressions from this branch. Remaining failures on the branch are pre-existing on main (84 from the in-flight AU-1 `passkey_count` field, 10 from the in-flight AU-6 `appearance` field).