### PR TITLE
AU-6: Environment.appearance BAPI (/v1/instance/appearance)

### DIFF
--- a/app/Http/Controllers/Bapi/InstanceAppearanceController.php
+++ b/app/Http/Controllers/Bapi/InstanceAppearanceController.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Models\Environment;
+use App\Webhooks\Emitter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ *   GET    /v1/instance/appearance     — read the current Appearance blob
+ *   PUT    /v1/instance/appearance     — full replace; missing keys clear
+ *   PATCH  /v1/instance/appearance     — deep merge; explicit nulls clear
+ *
+ * The blob lives at `Environment.appearance` (`jsonb`, default
+ * `{"variables":{},"elements":{},"layout":{}}`). The SDK fetches the
+ * read-through copy via `/v1/environment`.
+ */
+final class InstanceAppearanceController
+{
+    private const TOP_LEVEL_KEYS = ['variables', 'elements', 'layout'];
+
+    public function show(): JsonResponse
+    {
+        return response()->json($this->payload(app(Environment::class)));
+    }
+
+    public function replace(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $before = $this->normalise($env->appearance);
+
+        $next = $this->validateBlob($request);
+        $env->forceFill(['appearance' => $next])->save();
+        $this->emitUpdated($env, $before, $next);
+
+        return response()->json($this->payload($env->refresh()));
+    }
+
+    public function patch(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $before = $this->normalise($env->appearance);
+        $patch = $this->validateBlob($request);
+
+        $next = $before;
+        foreach (self::TOP_LEVEL_KEYS as $axis) {
+            $patchAxis = isset($patch[$axis]) && is_array($patch[$axis]) ? $patch[$axis] : [];
+            $existing = isset($next[$axis]) && is_array($next[$axis]) ? $next[$axis] : [];
+            foreach ($patchAxis as $key => $value) {
+                if ($value === null) {
+                    unset($existing[$key]);
+
+                    continue;
+                }
+                $existing[$key] = $value;
+            }
+            $next[$axis] = $existing;
+        }
+
+        $env->forceFill(['appearance' => $next])->save();
+        $this->emitUpdated($env, $before, $next);
+
+        return response()->json($this->payload($env->refresh()));
+    }
+
+    /**
+     * @return array{variables: array<string, mixed>, elements: array<string, mixed>, layout: array<string, mixed>}
+     */
+    private function validateBlob(Request $request): array
+    {
+        $body = $request->all();
+        Validator::make($body, [
+            'variables' => 'sometimes|array',
+            'elements' => 'sometimes|array',
+            'layout' => 'sometimes|array',
+        ])->validate();
+
+        $out = Environment::defaultAppearance();
+        foreach (self::TOP_LEVEL_KEYS as $axis) {
+            if (isset($body[$axis]) && is_array($body[$axis])) {
+                $out[$axis] = $body[$axis];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  mixed  $stored
+     * @return array{variables: array<string, mixed>, elements: array<string, mixed>, layout: array<string, mixed>}
+     */
+    private function normalise($stored): array
+    {
+        $base = Environment::defaultAppearance();
+        if (! is_array($stored)) {
+            return $base;
+        }
+        foreach (self::TOP_LEVEL_KEYS as $axis) {
+            if (isset($stored[$axis]) && is_array($stored[$axis])) {
+                $base[$axis] = $stored[$axis];
+            }
+        }
+
+        return $base;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(Environment $env): array
+    {
+        $blob = $this->normalise($env->appearance);
+
+        return [
+            'variables' => (object) $blob['variables'],
+            'elements' => (object) $blob['elements'],
+            'layout' => (object) $blob['layout'],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $before
+     * @param  array<string, mixed>  $after
+     */
+    private function emitUpdated(Environment $env, array $before, array $after): void
+    {
+        if ($before == $after) {
+            return;
+        }
+
+        Log::info('instance.config.appearance_updated', [
+            'environment_id' => $env->id,
+        ]);
+        app(Emitter::class)->emit(
+            'instance.config.appearance_updated',
+            [
+                'environment_id' => $env->id,
+                'before' => $before,
+                'after' => $after,
+            ],
+            $env,
+        );
+    }
+}

--- a/app/Http/Resources/EnvironmentResource.php
+++ b/app/Http/Resources/EnvironmentResource.php
@@ -168,6 +168,13 @@ final class EnvironmentResource
 
             'paths' => $appearance['paths'] ?? [],
 
+            'appearance' => [
+                'variables' => (object) (is_array($appearance['variables'] ?? null) ? $appearance['variables'] : []),
+                'elements' => (object) (is_array($appearance['elements'] ?? null) ? $appearance['elements'] : []),
+                'layout' => (object) (is_array($appearance['layout'] ?? null) ? $appearance['layout'] : []),
+                'etag' => $environment->appearance_etag,
+            ],
+
             'sessions' => [
                 'session_token_lifetime_seconds' => $sessions['lifetime_seconds'] ?? 60,
                 'multi_session' => (bool) ($sessions['multi_session'] ?? true),

--- a/app/Models/Environment.php
+++ b/app/Models/Environment.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property array $allowed_origins
  * @property array $appearance
  * @property array $localization
+ * @property-read string $appearance_etag
  */
 class Environment extends Model
 {
@@ -86,6 +87,38 @@ class Environment extends Model
 
     public const TEST_MODES = [self::TEST_MODE_ENABLED, self::TEST_MODE_DISABLED, self::TEST_MODE_REJECTED];
 
+    /**
+     * Default appearance blob. Mirrored by the column default — kept here so
+     * the seeder, observer, and BAPI controller agree on the empty shape.
+     *
+     * @return array{variables: array<string,string>, elements: array<string,string>, layout: array<string,mixed>}
+     */
+    public static function defaultAppearance(): array
+    {
+        return [
+            'variables' => [],
+            'elements' => [],
+            'layout' => [],
+        ];
+    }
+
+    /**
+     * Stable etag for the current `appearance` blob. SDKs use it as a
+     * cheap "did the appearance change since last render?" gate.
+     */
+    protected function appearanceEtag(): Attribute
+    {
+        return Attribute::get(function (): string {
+            $blob = is_array($this->appearance) ? $this->appearance : [];
+            $canonical = json_encode(
+                $blob,
+                JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            );
+
+            return 'sha256:'.hash('sha256', (string) $canonical);
+        });
+    }
+
     protected static function booted(): void
     {
         static::creating(function (self $env): void {
@@ -98,6 +131,11 @@ class Environment extends Model
                     ? self::TEST_MODE_REJECTED
                     : self::TEST_MODE_ENABLED;
                 $env->user_settings = $userSettings;
+            }
+
+            $appearance = is_array($env->appearance) ? $env->appearance : [];
+            if ($appearance === []) {
+                $env->appearance = self::defaultAppearance();
             }
         });
     }

--- a/database/migrations/0002_01_01_000001_create_projects_and_environments.php
+++ b/database/migrations/0002_01_01_000001_create_projects_and_environments.php
@@ -45,7 +45,11 @@ return new class extends Migration
             $table->boolean('is_satellite')->default(false);
             $table->string('proxy_url')->nullable();
             $table->jsonb('allowed_origins')->default(json_encode([]));
-            $table->jsonb('appearance')->default(json_encode((object) []));
+            $table->jsonb('appearance')->default(json_encode([
+                'variables' => (object) [],
+                'elements' => (object) [],
+                'layout' => (object) [],
+            ]));
             $table->jsonb('localization')->default(json_encode([
                 'default_locale' => 'en-US',
                 'supported_locales' => ['en-US'],

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Http\Controllers\Bapi\AllowlistIdentifiersController;
 use App\Http\Controllers\Bapi\BlocklistIdentifiersController;
 use App\Http\Controllers\Bapi\ExternalAccountController;
+use App\Http\Controllers\Bapi\InstanceAppearanceController;
 use App\Http\Controllers\Bapi\InstanceController;
 use App\Http\Controllers\Bapi\InvitationsController;
 use App\Http\Controllers\Bapi\OauthProviderController;
@@ -168,3 +169,7 @@ Route::get('/instance', [InstanceController::class, 'show'])->middleware(RateLim
 Route::patch('/instance', [InstanceController::class, 'update'])->middleware(RateLimit::class.':instance.update,30,60');
 Route::patch('/instance/restrictions', [InstanceController::class, 'updateRestrictions'])->middleware(RateLimit::class.':instance.update,30,60');
 Route::patch('/instance/organization-settings', [InstanceController::class, 'updateOrganizationSettings'])->middleware(RateLimit::class.':instance.update,30,60');
+
+Route::get('/instance/appearance', [InstanceAppearanceController::class, 'show'])->middleware(RateLimit::class.':instance.read,300,60')->name('bapi.instance.appearance.show');
+Route::put('/instance/appearance', [InstanceAppearanceController::class, 'replace'])->middleware(RateLimit::class.':instance.update,30,60')->name('bapi.instance.appearance.replace');
+Route::patch('/instance/appearance', [InstanceAppearanceController::class, 'patch'])->middleware(RateLimit::class.':instance.update,30,60')->name('bapi.instance.appearance.patch');

--- a/tests/Feature/Http/Bapi/InstanceAppearanceTest.php
+++ b/tests/Feature/Http/Bapi/InstanceAppearanceTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Bapi;
+
+use App\Http\Resources\EnvironmentResource;
+use App\Models\Environment;
+use Tests\TestCase;
+
+final class InstanceAppearanceTest extends TestCase
+{
+    public function test_show_returns_the_defaulted_blob(): void
+    {
+        $boot = BapiTestSupport::bootEnv('apone');
+        app()->instance(Environment::class, $boot['env']);
+
+        $resp = $this->getJson(
+            BapiTestSupport::url('/instance/appearance'),
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $body = $resp->json();
+        $this->assertSame(['variables', 'elements', 'layout'], array_keys($body));
+        $this->assertSame([], (array) $body['variables']);
+        $this->assertSame([], (array) $body['elements']);
+        $this->assertSame([], (array) $body['layout']);
+    }
+
+    public function test_put_replaces_the_blob_entirely(): void
+    {
+        $boot = BapiTestSupport::bootEnv('aptwo');
+        app()->instance(Environment::class, $boot['env']);
+
+        $boot['env']->forceFill([
+            'appearance' => [
+                'variables' => ['colorPrimary' => '#aaaaaa'],
+                'elements' => ['card' => 'shadow-xl'],
+                'layout' => ['logoImageUrl' => 'https://old.example/logo.svg'],
+            ],
+        ])->save();
+
+        $resp = $this->putJson(
+            BapiTestSupport::url('/instance/appearance'),
+            [
+                'variables' => ['colorPrimary' => '#0a84ff'],
+                'layout' => ['socialButtonsPlacement' => 'top'],
+            ],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $body = $resp->json();
+        $this->assertSame(['colorPrimary' => '#0a84ff'], $body['variables']);
+        // PUT clears anything not supplied — elements goes back to {}.
+        $this->assertSame([], (array) $body['elements']);
+        $this->assertSame(['socialButtonsPlacement' => 'top'], $body['layout']);
+    }
+
+    public function test_patch_deep_merges_axes(): void
+    {
+        $boot = BapiTestSupport::bootEnv('apthree');
+        app()->instance(Environment::class, $boot['env']);
+
+        $boot['env']->forceFill([
+            'appearance' => [
+                'variables' => ['colorPrimary' => '#aaaaaa', 'fontFamily' => 'Inter'],
+                'elements' => ['card' => 'shadow-xl'],
+                'layout' => ['logoImageUrl' => 'https://example/logo.svg'],
+            ],
+        ])->save();
+
+        $resp = $this->patchJson(
+            BapiTestSupport::url('/instance/appearance'),
+            ['variables' => ['colorPrimary' => '#0a84ff']],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $body = $resp->json();
+        $this->assertSame(['colorPrimary' => '#0a84ff', 'fontFamily' => 'Inter'], $body['variables']);
+        $this->assertSame(['card' => 'shadow-xl'], $body['elements']);
+        $this->assertSame(['logoImageUrl' => 'https://example/logo.svg'], $body['layout']);
+    }
+
+    public function test_patch_clears_keys_when_value_is_null(): void
+    {
+        $boot = BapiTestSupport::bootEnv('apfour');
+        app()->instance(Environment::class, $boot['env']);
+
+        $boot['env']->forceFill([
+            'appearance' => [
+                'variables' => ['colorPrimary' => '#aaaaaa', 'fontFamily' => 'Inter'],
+                'elements' => [],
+                'layout' => [],
+            ],
+        ])->save();
+
+        $resp = $this->patchJson(
+            BapiTestSupport::url('/instance/appearance'),
+            ['variables' => ['colorPrimary' => null]],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $this->assertSame(['fontFamily' => 'Inter'], $resp->json('variables'));
+    }
+
+    public function test_etag_changes_when_the_blob_changes(): void
+    {
+        $boot = BapiTestSupport::bootEnv('apfive');
+        app()->instance(Environment::class, $boot['env']);
+
+        $before = $boot['env']->appearance_etag;
+        $boot['env']->forceFill([
+            'appearance' => ['variables' => ['colorPrimary' => '#0a84ff'], 'elements' => [], 'layout' => []],
+        ])->save();
+
+        $after = $boot['env']->fresh()->appearance_etag;
+        $this->assertNotSame($before, $after);
+        $this->assertStringStartsWith('sha256:', $before);
+        $this->assertStringStartsWith('sha256:', $after);
+    }
+
+    public function test_etag_is_stable_across_two_identical_puts(): void
+    {
+        $boot = BapiTestSupport::bootEnv('apsix');
+        app()->instance(Environment::class, $boot['env']);
+
+        $payload = [
+            'variables' => ['colorPrimary' => '#0a84ff'],
+            'layout' => ['socialButtonsPlacement' => 'top'],
+        ];
+
+        $this->putJson(BapiTestSupport::url('/instance/appearance'), $payload, BapiTestSupport::headers($boot['token']))->assertOk();
+        $etag1 = $boot['env']->fresh()->appearance_etag;
+
+        $this->putJson(BapiTestSupport::url('/instance/appearance'), $payload, BapiTestSupport::headers($boot['token']))->assertOk();
+        $etag2 = $boot['env']->fresh()->appearance_etag;
+
+        $this->assertSame($etag1, $etag2);
+    }
+
+    public function test_environment_endpoint_surfaces_appearance_with_etag(): void
+    {
+        $boot = BapiTestSupport::bootEnv('apseven');
+        $env = $boot['env'];
+
+        $env->forceFill([
+            'appearance' => ['variables' => ['colorPrimary' => '#0a84ff'], 'elements' => [], 'layout' => []],
+        ])->save();
+
+        config([
+            'authn.app_host' => 'authn.local',
+            'authn.app_scheme' => 'http',
+            'authn.routing_mode' => 'subdomain',
+            'authn.app_port_suffix' => '',
+        ]);
+
+        $shape = EnvironmentResource::from($env->fresh());
+
+        $this->assertArrayHasKey('appearance', $shape);
+        $this->assertArrayHasKey('etag', $shape['appearance']);
+        $this->assertStringStartsWith('sha256:', $shape['appearance']['etag']);
+        $this->assertSame(['colorPrimary' => '#0a84ff'], (array) $shape['appearance']['variables']);
+    }
+}


### PR DESCRIPTION
Closes #167

## Summary

- `Environment.appearance` migration default is now `{variables:{}, elements:{}, layout:{}}` — reads always come back in the canonical three-axis shape.
- `Environment::defaultAppearance()` helper + `creating` observer seed the same shape when an Eloquent caller leaves `appearance` blank.
- `Environment::appearance_etag` accessor — sha256 over the canonical-JSON encoding; stable across identical writes.
- BAPI `app/Http/Controllers/Bapi/InstanceAppearanceController` with three handlers:
  - `GET /v1/instance/appearance` — returns the blob.
  - `PUT /v1/instance/appearance` — full replace; missing keys clear to empty.
  - `PATCH /v1/instance/appearance` — deep-merge per axis; explicit \`null\` removes the key.
- Both mutations emit `instance.config.appearance_updated` via the webhook emitter.
- FAPI `GET /v1/environment` now carries the operator-configured Appearance + `etag` inline (the spec requires it).

## Test plan

- [x] `php artisan migrate:fresh --env=testing` clean.
- [x] `vendor/bin/pint --test` clean.
- [x] `php artisan test --filter InstanceAppearanceTest` — 7 / 7 passing.
- [x] Resolves the 10 \`appearance is required\` OpenAPI contract failures the spec was emitting against \`GET /v1/environment\`.