### PR TITLE
AU-2: WebAuthn engine — web-auth/webauthn-lib + PasskeyService

### DIFF
--- a/app/Auth/Oauth/PresetRegistry.php
+++ b/app/Auth/Oauth/PresetRegistry.php
@@ -5,15 +5,23 @@ declare(strict_types=1);
 namespace App\Auth\Oauth;
 
 use App\Auth\Oauth\Presets\ApplePreset;
+use App\Auth\Oauth\Presets\DiscordPreset;
+use App\Auth\Oauth\Presets\FacebookPreset;
 use App\Auth\Oauth\Presets\GitHubPreset;
+use App\Auth\Oauth\Presets\GitLabPreset;
 use App\Auth\Oauth\Presets\GooglePreset;
+use App\Auth\Oauth\Presets\LinkedInPreset;
 use App\Auth\Oauth\Presets\MicrosoftPreset;
 use App\Auth\Oauth\Presets\PresetContract;
+use App\Auth\Oauth\Presets\SlackPreset;
+use App\Auth\Oauth\Presets\XPreset;
 
 /**
- * Canonical list of preset providers shipped with v0.4. Adding a new
- * preset is a one-line change here plus the corresponding implementation
- * under `app/Auth/Oauth/Presets/`.
+ * Canonical list of preset providers. Adding a new preset is a one-line
+ * change here plus the corresponding implementation under
+ * `app/Auth/Oauth/Presets/`. Every registered key gets a row seeded
+ * (disabled, blank credentials) on every freshly-created environment by
+ * `OauthProviderSeeder`.
  */
 final class PresetRegistry
 {
@@ -30,6 +38,12 @@ final class PresetRegistry
             (new GitHubPreset)->key() => new GitHubPreset,
             (new ApplePreset)->key() => new ApplePreset,
             (new MicrosoftPreset)->key() => new MicrosoftPreset,
+            (new DiscordPreset)->key() => new DiscordPreset,
+            (new FacebookPreset)->key() => new FacebookPreset,
+            (new LinkedInPreset)->key() => new LinkedInPreset,
+            (new XPreset)->key() => new XPreset,
+            (new GitLabPreset)->key() => new GitLabPreset,
+            (new SlackPreset)->key() => new SlackPreset,
         ];
     }
 

--- a/app/Auth/Oauth/Presets/DiscordPreset.php
+++ b/app/Auth/Oauth/Presets/DiscordPreset.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * Discord OAuth2 (not OIDC). Claims come from `/users/@me`; there is no
+ * id_token. The `provider_user_id` mapping pins our External Account row
+ * to Discord's stable `id` snowflake.
+ */
+final class DiscordPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'discord';
+    }
+
+    public function name(): string
+    {
+        return 'Discord';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://discord.com/oauth2/authorize';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://discord.com/api/oauth2/token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://discord.com/api/users/@me';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return null;
+    }
+
+    public function issuer(): ?string
+    {
+        return null;
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['identify', 'email'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'provider_user_id' => 'id',
+            'username' => 'username',
+            'email_address' => 'email',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return [];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/FacebookPreset.php
+++ b/app/Auth/Oauth/Presets/FacebookPreset.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * Facebook Login (Graph API v18.0). Operator picks `public_profile` +
+ * `email`; `email` requires the user to have a confirmed email on
+ * their Facebook account.
+ */
+final class FacebookPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'facebook';
+    }
+
+    public function name(): string
+    {
+        return 'Facebook';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://www.facebook.com/v18.0/dialog/oauth';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://graph.facebook.com/v18.0/oauth/access_token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://graph.facebook.com/v18.0/me';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return null;
+    }
+
+    public function issuer(): ?string
+    {
+        return null;
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['public_profile', 'email'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'provider_user_id' => 'id',
+            'email_address' => 'email',
+            'first_name' => 'first_name',
+            'last_name' => 'last_name',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        // Graph `/me` returns only id + name by default. Operators that
+        // need email + first/last must request the fields explicitly on
+        // the userinfo call; the v0.4 callback will append `?fields=...`
+        // when configured.
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return [];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/GitLabPreset.php
+++ b/app/Auth/Oauth/Presets/GitLabPreset.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * GitLab.com OIDC. Self-hosted GitLab instances should be configured as
+ * `custom_oidc` rows pointed at the operator's instance issuer; this
+ * preset specifically targets gitlab.com.
+ */
+final class GitLabPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'gitlab';
+    }
+
+    public function name(): string
+    {
+        return 'GitLab';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://gitlab.com/oauth/authorize';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://gitlab.com/oauth/token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://gitlab.com/oauth/userinfo';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return 'https://gitlab.com/oauth/discovery/keys';
+    }
+
+    public function issuer(): ?string
+    {
+        return 'https://gitlab.com';
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['openid', 'profile', 'email'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'provider_user_id' => 'sub',
+            'email' => 'email',
+            'email_verified' => 'email_verified',
+            'first_name' => 'given_name',
+            'last_name' => 'family_name',
+            'username' => 'preferred_username',
+            'image_url' => 'picture',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return ['RS256'];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/LinkedInPreset.php
+++ b/app/Auth/Oauth/Presets/LinkedInPreset.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * LinkedIn "Sign In with LinkedIn using OpenID Connect". Endpoints
+ * mirror the values discovery at
+ * `https://www.linkedin.com/oauth/.well-known/openid-configuration`
+ * exposes; discovery isn't run here because preset rows ship with
+ * the endpoints baked in.
+ */
+final class LinkedInPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'linkedin';
+    }
+
+    public function name(): string
+    {
+        return 'LinkedIn';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://www.linkedin.com/oauth/v2/authorization';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://www.linkedin.com/oauth/v2/accessToken';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://api.linkedin.com/v2/userinfo';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return 'https://www.linkedin.com/oauth/openid/jwks';
+    }
+
+    public function issuer(): ?string
+    {
+        return 'https://www.linkedin.com/oauth';
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['openid', 'profile', 'email'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'provider_user_id' => 'sub',
+            'email' => 'email',
+            'email_verified' => 'email_verified',
+            'first_name' => 'given_name',
+            'last_name' => 'family_name',
+            'image_url' => 'picture',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return ['RS256'];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/SlackPreset.php
+++ b/app/Auth/Oauth/Presets/SlackPreset.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * Sign in with Slack — Slack's OIDC product (not the legacy v2 OAuth
+ * scopes). The standard OIDC claim set is sufficient for our shape.
+ */
+final class SlackPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'slack';
+    }
+
+    public function name(): string
+    {
+        return 'Slack';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://slack.com/openid/connect/authorize';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://slack.com/api/openid.connect.token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://slack.com/api/openid.connect.userInfo';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return 'https://slack.com/openid/connect/keys';
+    }
+
+    public function issuer(): ?string
+    {
+        return 'https://slack.com';
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['openid', 'profile', 'email'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'provider_user_id' => 'sub',
+            'email' => 'email',
+            'email_verified' => 'email_verified',
+            'first_name' => 'given_name',
+            'last_name' => 'family_name',
+            'image_url' => 'picture',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return ['RS256'];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Oauth/Presets/XPreset.php
+++ b/app/Auth/Oauth/Presets/XPreset.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Oauth\Presets;
+
+/**
+ * X (formerly Twitter) OAuth2 v2. X mandates PKCE on the authorization
+ * code grant — when the engine gains PKCE plumbing the X preset will be
+ * marked as requiring it; until then operators must configure their
+ * X developer app for confidential PKCE flow on the X side.
+ */
+final class XPreset implements PresetContract
+{
+    public function key(): string
+    {
+        return 'x';
+    }
+
+    public function name(): string
+    {
+        return 'X';
+    }
+
+    public function authorizationEndpoint(): string
+    {
+        return 'https://twitter.com/i/oauth2/authorize';
+    }
+
+    public function tokenEndpoint(): string
+    {
+        return 'https://api.twitter.com/2/oauth2/token';
+    }
+
+    public function userinfoEndpoint(): string
+    {
+        return 'https://api.twitter.com/2/users/me';
+    }
+
+    public function jwksUri(): ?string
+    {
+        return null;
+    }
+
+    public function issuer(): ?string
+    {
+        return null;
+    }
+
+    public function defaultScopes(): array
+    {
+        return ['tweet.read', 'users.read'];
+    }
+
+    public function defaultAttributeMapping(): array
+    {
+        return [
+            'provider_user_id' => 'id',
+            'username' => 'username',
+        ];
+    }
+
+    public function additionalAuthorizationParams(): array
+    {
+        return [];
+    }
+
+    public function idTokenSigningAlgs(): array
+    {
+        return [];
+    }
+
+    public function userinfoMethod(): string
+    {
+        return 'GET';
+    }
+
+    public function userinfoAuth(): string
+    {
+        return 'bearer';
+    }
+}

--- a/app/Auth/Passkey/Exceptions/PasskeyAssertionInvalid.php
+++ b/app/Auth/Passkey/Exceptions/PasskeyAssertionInvalid.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Passkey\Exceptions;
+
+final class PasskeyAssertionInvalid extends PasskeyException
+{
+    public function code(): string
+    {
+        return 'passkey_assertion_invalid';
+    }
+}

--- a/app/Auth/Passkey/Exceptions/PasskeyAttestationInvalid.php
+++ b/app/Auth/Passkey/Exceptions/PasskeyAttestationInvalid.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Passkey\Exceptions;
+
+final class PasskeyAttestationInvalid extends PasskeyException
+{
+    public function code(): string
+    {
+        return 'passkey_attestation_invalid';
+    }
+}

--- a/app/Auth/Passkey/Exceptions/PasskeyException.php
+++ b/app/Auth/Passkey/Exceptions/PasskeyException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Passkey\Exceptions;
+
+use RuntimeException;
+
+abstract class PasskeyException extends RuntimeException
+{
+    /**
+     * Stable error code surfaced by the FAPI on 422 responses.
+     */
+    abstract public function code(): string;
+}

--- a/app/Auth/Passkey/Exceptions/PasskeyNoCredentials.php
+++ b/app/Auth/Passkey/Exceptions/PasskeyNoCredentials.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Passkey\Exceptions;
+
+final class PasskeyNoCredentials extends PasskeyException
+{
+    public function code(): string
+    {
+        return 'passkey_no_credentials';
+    }
+}

--- a/app/Auth/Passkey/Exceptions/PasskeyOriginMismatch.php
+++ b/app/Auth/Passkey/Exceptions/PasskeyOriginMismatch.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Passkey\Exceptions;
+
+final class PasskeyOriginMismatch extends PasskeyException
+{
+    public function code(): string
+    {
+        return 'passkey_origin_mismatch';
+    }
+}

--- a/app/Auth/Passkey/Exceptions/PasskeyReplayed.php
+++ b/app/Auth/Passkey/Exceptions/PasskeyReplayed.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Passkey\Exceptions;
+
+final class PasskeyReplayed extends PasskeyException
+{
+    public function code(): string
+    {
+        return 'passkey_replayed';
+    }
+}

--- a/app/Auth/Passkey/Exceptions/PasskeyUserHandleMismatch.php
+++ b/app/Auth/Passkey/Exceptions/PasskeyUserHandleMismatch.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Passkey\Exceptions;
+
+final class PasskeyUserHandleMismatch extends PasskeyException
+{
+    public function code(): string
+    {
+        return 'passkey_user_handle_mismatch';
+    }
+}

--- a/app/Auth/Passkey/PasskeyService.php
+++ b/app/Auth/Passkey/PasskeyService.php
@@ -1,0 +1,462 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Passkey;
+
+use App\Auth\Passkey\Exceptions\PasskeyAssertionInvalid;
+use App\Auth\Passkey\Exceptions\PasskeyAttestationInvalid;
+use App\Auth\Passkey\Exceptions\PasskeyException;
+use App\Auth\Passkey\Exceptions\PasskeyOriginMismatch;
+use App\Auth\Passkey\Exceptions\PasskeyReplayed;
+use App\Auth\Passkey\Exceptions\PasskeyUserHandleMismatch;
+use App\Models\Challenge;
+use App\Models\Environment;
+use App\Models\Passkey;
+use App\Models\User;
+use App\Support\Base64Url;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\AuthenticatorSelectionCriteria;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+use Webauthn\CredentialRecord;
+use Webauthn\Denormalizer\WebauthnSerializerFactory;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialParameters;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+/**
+ * Thin wrapper around `web-auth/webauthn-lib` for the four WebAuthn
+ * ceremonies the FAPI / Account Portal need:
+ *   - build registration options (begin) + verify attestation (complete)
+ *   - build authentication options (begin) + verify assertion (complete)
+ *
+ * Per-environment RP-ID and origin allowlist come from `RpConfigResolver`.
+ * The webauthn challenge bytes are persisted on `Challenge.nonce` as
+ * base64url and retrieved on the matching complete-* call.
+ *
+ * @phpstan-type PkccoArray array<string, mixed>
+ * @phpstan-type PkcroArray array<string, mixed>
+ */
+final class PasskeyService
+{
+    /** Supported COSE algorithm identifiers (ES256 + RS256). */
+    private const COSE_ES256 = -7;
+
+    private const COSE_RS256 = -257;
+
+    private SerializerInterface $serializer;
+
+    public function __construct(private readonly RpConfigResolver $rp)
+    {
+        $this->serializer = (new WebauthnSerializerFactory(
+            new AttestationStatementSupportManager([new NoneAttestationStatementSupport]),
+        ))->create();
+    }
+
+    /**
+     * Builds the `creationOptions` blob the SDK hands to
+     * `navigator.credentials.create({ publicKey })`. The challenge bytes are
+     * written to `Challenge.nonce` (base64url) so the matching
+     * `verifyAttestation` call can replay them.
+     *
+     * @param  list<string>  $excludeCredentialIds  raw bytes of the user's already-enrolled credential ids
+     * @return PkccoArray
+     */
+    public function buildRegistrationOptions(
+        Environment $environment,
+        User $user,
+        Challenge $challenge,
+        array $excludeCredentialIds = [],
+    ): array {
+        $challengeBytes = random_bytes(32);
+        $challenge->forceFill(['nonce' => Base64Url::encode($challengeBytes)])->save();
+
+        $userEntity = PublicKeyCredentialUserEntity::create(
+            $this->userHandleDisplay($user),
+            $user->id,
+            $this->userHandleDisplayName($user),
+        );
+
+        $exclude = [];
+        foreach ($excludeCredentialIds as $id) {
+            $exclude[] = PublicKeyCredentialDescriptor::create(
+                PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+                $id,
+            );
+        }
+
+        $options = PublicKeyCredentialCreationOptions::create(
+            rp: $this->rp->rpEntity($environment),
+            user: $userEntity,
+            challenge: $challengeBytes,
+            pubKeyCredParams: [
+                PublicKeyCredentialParameters::create('public-key', self::COSE_ES256),
+                PublicKeyCredentialParameters::create('public-key', self::COSE_RS256),
+            ],
+            authenticatorSelection: AuthenticatorSelectionCriteria::create(
+                userVerification: AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+                residentKey: AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED,
+            ),
+            attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+            excludeCredentials: $exclude,
+            timeout: 60_000,
+        );
+
+        $json = $this->serializer->serialize($options, 'json', [
+            'jsonEncodeOptions' => JSON_UNESCAPED_SLASHES,
+        ]);
+
+        /** @var PkccoArray $decoded */
+        $decoded = json_decode($json, true);
+
+        return $decoded;
+    }
+
+    /**
+     * Verifies an attestation response against the matching challenge,
+     * creates a verified `Passkey` row, and flips the Challenge to
+     * `verified`. Throws `PasskeyAttestationInvalid`,
+     * `PasskeyOriginMismatch`, or `PasskeyReplayed` on validation failure.
+     *
+     * @param  array<string, mixed>  $attestation  WebAuthn `AuthenticatorAttestationResponseJSON`
+     */
+    public function verifyAttestation(
+        Environment $environment,
+        User $user,
+        Challenge $challenge,
+        array $attestation,
+        ?string $nickname,
+    ): Passkey {
+        $options = $this->reconstructCreationOptions($environment, $user, $challenge);
+        $credential = $this->deserializePublicKeyCredential($attestation);
+
+        $response = $credential->response;
+        if (! $response instanceof AuthenticatorAttestationResponse) {
+            throw new PasskeyAttestationInvalid('Expected an attestation response.');
+        }
+
+        $factory = new CeremonyStepManagerFactory;
+        $factory->setAllowedOrigins($this->rp->allowedOrigins($environment));
+        $validator = AuthenticatorAttestationResponseValidator::create($factory->creationCeremony());
+
+        try {
+            $record = $validator->check($response, $options, $this->rp->rpId($environment));
+        } catch (AuthenticatorResponseVerificationException $e) {
+            throw $this->translateAttestationException($e);
+        } catch (Throwable $e) {
+            throw new PasskeyAttestationInvalid($e->getMessage(), previous: $e);
+        }
+
+        $credentialId = $record->publicKeyCredentialId;
+        $credentialIdHash = hash('sha256', $credentialId, true);
+
+        if (Passkey::query()
+            ->where('credential_id_hash', $credentialIdHash)
+            ->withTrashed()
+            ->exists()) {
+            throw new PasskeyReplayed('Credential is already enrolled.');
+        }
+
+        $passkey = Passkey::create([
+            'user_id' => $user->id,
+            'credential_id' => $credentialId,
+            'credential_id_hash' => $credentialIdHash,
+            'public_key' => $record->credentialPublicKey,
+            'sign_count' => $record->counter,
+            'transports' => $this->extractTransports($attestation),
+            'aaguid' => $this->extractAaguid($record),
+            'nickname' => $nickname !== '' && $nickname !== null ? $nickname : null,
+            'verified_at' => now(),
+        ]);
+
+        $challenge->forceFill(['status' => Challenge::STATUS_VERIFIED])->save();
+
+        return $passkey;
+    }
+
+    /**
+     * Builds the `requestOptions` blob the SDK hands to
+     * `navigator.credentials.get({ publicKey })`. Caller passes the User
+     * the assertion is bound to (matched by username/email lookup before
+     * the ceremony starts); the `allowCredentials` list narrows the
+     * authenticator picker to that user's verified passkeys.
+     *
+     * @return PkcroArray
+     */
+    public function buildAuthenticationOptions(
+        Environment $environment,
+        Challenge $challenge,
+        ?User $user = null,
+    ): array {
+        $challengeBytes = random_bytes(32);
+        $challenge->forceFill(['nonce' => Base64Url::encode($challengeBytes)])->save();
+
+        $allowed = [];
+        if ($user !== null) {
+            $passkeys = $user->passkeys()->whereNotNull('verified_at')->get();
+            foreach ($passkeys as $passkey) {
+                $allowed[] = PublicKeyCredentialDescriptor::create(
+                    PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+                    $passkey->credential_id,
+                    $passkey->transports ?? [],
+                );
+            }
+        }
+
+        $options = PublicKeyCredentialRequestOptions::create(
+            challenge: $challengeBytes,
+            rpId: $this->rp->rpId($environment),
+            allowCredentials: $allowed,
+            userVerification: AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+            timeout: 60_000,
+        );
+
+        $json = $this->serializer->serialize($options, 'json', [
+            'jsonEncodeOptions' => JSON_UNESCAPED_SLASHES,
+        ]);
+        /** @var PkcroArray $decoded */
+        $decoded = json_decode($json, true);
+
+        return $decoded;
+    }
+
+    /**
+     * Verifies an assertion response, bumps `sign_count`, updates
+     * `last_used_at`, and returns the matched Passkey. Throws
+     * `PasskeyAssertionInvalid`, `PasskeyOriginMismatch`, `PasskeyReplayed`,
+     * or `PasskeyUserHandleMismatch` on failure.
+     *
+     * @param  array<string, mixed>  $assertion  WebAuthn `AuthenticatorAssertionResponseJSON`
+     */
+    public function verifyAssertion(
+        Environment $environment,
+        Challenge $challenge,
+        User $resolvedUser,
+        array $assertion,
+    ): Passkey {
+        $options = $this->reconstructRequestOptions($environment, $challenge);
+        $credential = $this->deserializePublicKeyCredential($assertion);
+
+        $response = $credential->response;
+        if (! $response instanceof AuthenticatorAssertionResponse) {
+            throw new PasskeyAssertionInvalid('Expected an assertion response.');
+        }
+
+        $credentialId = $credential->rawId;
+        $hash = hash('sha256', $credentialId, true);
+        $passkey = Passkey::query()
+            ->where('user_id', $resolvedUser->id)
+            ->where('credential_id_hash', $hash)
+            ->whereNotNull('verified_at')
+            ->first();
+        if ($passkey === null) {
+            throw new PasskeyAssertionInvalid('No matching credential for this user.');
+        }
+
+        if ($response->userHandle !== null && $response->userHandle !== '' && $response->userHandle !== $resolvedUser->id) {
+            throw new PasskeyUserHandleMismatch('userHandle does not match the resolved user.');
+        }
+
+        $record = $this->credentialRecordFor($passkey);
+
+        $factory = new CeremonyStepManagerFactory;
+        $factory->setAllowedOrigins($this->rp->allowedOrigins($environment));
+        $validator = AuthenticatorAssertionResponseValidator::create($factory->requestCeremony());
+
+        try {
+            $updated = $validator->check(
+                $record,
+                $response,
+                $options,
+                $this->rp->rpId($environment),
+                $resolvedUser->id,
+            );
+        } catch (AuthenticatorResponseVerificationException $e) {
+            throw $this->translateAssertionException($e);
+        } catch (Throwable $e) {
+            throw new PasskeyAssertionInvalid($e->getMessage(), previous: $e);
+        }
+
+        $passkey->forceFill([
+            'sign_count' => $updated->counter,
+            'last_used_at' => now(),
+        ])->save();
+        $challenge->forceFill(['status' => Challenge::STATUS_VERIFIED])->save();
+
+        return $passkey;
+    }
+
+    /**
+     * Reconstruct the PKCCO used at begin-time so we can re-validate the
+     * client's attestation against the same RP / challenge / user. We
+     * don't persist the full options blob (the only mutable bit is the
+     * challenge nonce); RP-ID + user identity are recoverable from the
+     * env + the Challenge's resolved User.
+     */
+    private function reconstructCreationOptions(
+        Environment $environment,
+        User $user,
+        Challenge $challenge,
+    ): PublicKeyCredentialCreationOptions {
+        $challengeBytes = Base64Url::decode((string) $challenge->nonce);
+        $userEntity = PublicKeyCredentialUserEntity::create(
+            $this->userHandleDisplay($user),
+            $user->id,
+            $this->userHandleDisplayName($user),
+        );
+
+        return PublicKeyCredentialCreationOptions::create(
+            rp: $this->rp->rpEntity($environment),
+            user: $userEntity,
+            challenge: $challengeBytes,
+            pubKeyCredParams: [
+                PublicKeyCredentialParameters::create('public-key', self::COSE_ES256),
+                PublicKeyCredentialParameters::create('public-key', self::COSE_RS256),
+            ],
+            attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        );
+    }
+
+    private function reconstructRequestOptions(
+        Environment $environment,
+        Challenge $challenge,
+    ): PublicKeyCredentialRequestOptions {
+        return PublicKeyCredentialRequestOptions::create(
+            challenge: Base64Url::decode((string) $challenge->nonce),
+            rpId: $this->rp->rpId($environment),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $clientResponse
+     */
+    private function deserializePublicKeyCredential(array $clientResponse): PublicKeyCredential
+    {
+        try {
+            $json = json_encode($clientResponse, JSON_THROW_ON_ERROR);
+
+            return $this->serializer->deserialize($json, PublicKeyCredential::class, 'json');
+        } catch (Throwable $e) {
+            throw new PasskeyAttestationInvalid('Malformed credential payload: '.$e->getMessage(), previous: $e);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $attestation
+     * @return list<string>
+     */
+    private function extractTransports(array $attestation): array
+    {
+        $response = is_array($attestation['response'] ?? null) ? $attestation['response'] : [];
+        $transports = is_array($response['transports'] ?? null) ? $response['transports'] : [];
+
+        $out = [];
+        foreach ($transports as $t) {
+            if (is_string($t) && in_array($t, Passkey::TRANSPORTS, true)) {
+                $out[] = $t;
+            }
+        }
+
+        return array_values(array_unique($out));
+    }
+
+    private function extractAaguid(CredentialRecord $record): ?string
+    {
+        $aaguid = $record->aaguid;
+        if ($aaguid === null) {
+            return null;
+        }
+        $str = (string) $aaguid;
+
+        return $str === '' || $str === '00000000-0000-0000-0000-000000000000' ? null : $str;
+    }
+
+    private function userHandleDisplay(User $user): string
+    {
+        if ($user->username !== null && $user->username !== '') {
+            return (string) $user->username;
+        }
+        $primaryEmail = $user->primaryEmailAddress()->withoutGlobalScopes()->first();
+        if ($primaryEmail !== null && $primaryEmail->email_address !== '') {
+            return (string) $primaryEmail->email_address;
+        }
+
+        return $user->id;
+    }
+
+    private function userHandleDisplayName(User $user): string
+    {
+        $name = trim((string) $user->first_name.' '.(string) $user->last_name);
+
+        return $name !== '' ? $name : $this->userHandleDisplay($user);
+    }
+
+    /**
+     * Rebuild a CredentialRecord from our Passkey row's columns. The
+     * webauthn-lib assertion validator needs the same shape it produced
+     * during registration; we reconstruct it from persisted columns
+     * (credential_id / public_key / sign_count / transports / aaguid)
+     * rather than persisting the whole CredentialRecord blob.
+     */
+    private function credentialRecordFor(Passkey $passkey): CredentialRecord
+    {
+        try {
+            $aaguid = $passkey->aaguid !== null && $passkey->aaguid !== ''
+                ? Uuid::fromString($passkey->aaguid)
+                : Uuid::fromString('00000000-0000-0000-0000-000000000000');
+        } catch (Throwable $e) {
+            throw new PasskeyAssertionInvalid('Stored aaguid is malformed.', previous: $e);
+        }
+
+        return new CredentialRecord(
+            publicKeyCredentialId: (string) $passkey->credential_id,
+            type: 'public-key',
+            transports: is_array($passkey->transports) ? array_values(array_map('strval', $passkey->transports)) : [],
+            attestationType: 'none',
+            trustPath: new EmptyTrustPath,
+            aaguid: $aaguid,
+            credentialPublicKey: (string) $passkey->public_key,
+            userHandle: (string) $passkey->user_id,
+            counter: (int) $passkey->sign_count,
+        );
+    }
+
+    private function translateAttestationException(AuthenticatorResponseVerificationException $e): PasskeyException
+    {
+        $msg = strtolower($e->getMessage());
+        if (str_contains($msg, 'origin')) {
+            return new PasskeyOriginMismatch($e->getMessage(), previous: $e);
+        }
+
+        return new PasskeyAttestationInvalid($e->getMessage(), previous: $e);
+    }
+
+    private function translateAssertionException(AuthenticatorResponseVerificationException $e): PasskeyException
+    {
+        $msg = strtolower($e->getMessage());
+        if (str_contains($msg, 'counter') || str_contains($msg, 'sign count')) {
+            return new PasskeyReplayed($e->getMessage(), previous: $e);
+        }
+        if (str_contains($msg, 'origin')) {
+            return new PasskeyOriginMismatch($e->getMessage(), previous: $e);
+        }
+        if (str_contains($msg, 'user handle')) {
+            return new PasskeyUserHandleMismatch($e->getMessage(), previous: $e);
+        }
+
+        return new PasskeyAssertionInvalid($e->getMessage(), previous: $e);
+    }
+}

--- a/app/Auth/Passkey/RpConfigResolver.php
+++ b/app/Auth/Passkey/RpConfigResolver.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Passkey;
+
+use App\Models\Environment;
+use Webauthn\PublicKeyCredentialRpEntity;
+
+/**
+ * Per-environment WebAuthn relying-party config:
+ *   - `rp.id` is the FAPI host (`<env_slug>.authn.sh` in subdomain mode,
+ *     the bare app host in path mode).
+ *   - `rp.name` is the operator's application name (falls back to the env
+ *     slug).
+ *   - The allowed-origin list is the FAPI host's URL plus every entry in
+ *     `Environment.allowed_origins`. WebAuthn requires HTTPS in
+ *     production; we mirror `authn.app_scheme` so dev installs on
+ *     `http://localhost` keep working.
+ */
+final class RpConfigResolver
+{
+    public function rpEntity(Environment $environment): PublicKeyCredentialRpEntity
+    {
+        $appearance = is_array($environment->appearance) ? $environment->appearance : [];
+        $name = is_string($appearance['application_name'] ?? null) && $appearance['application_name'] !== ''
+            ? $appearance['application_name']
+            : ((string) (config('app.name') ?? $environment->slug));
+
+        return PublicKeyCredentialRpEntity::create($name, $environment->frontend_api_host);
+    }
+
+    public function rpId(Environment $environment): string
+    {
+        return $environment->frontend_api_host;
+    }
+
+    /**
+     * Origins WebAuthn responses are allowed to come from. Always includes
+     * the env's FAPI URL; operators add more via `Environment.allowed_origins`
+     * (the same list used for CORS).
+     *
+     * @return list<string>
+     */
+    public function allowedOrigins(Environment $environment): array
+    {
+        $scheme = (string) (config('authn.app_scheme') ?? 'https');
+        $host = $environment->frontend_api_host;
+        $port = (string) (config('authn.app_port_suffix') ?? '');
+        $primary = $scheme.'://'.$host.$port;
+
+        $extra = is_array($environment->allowed_origins) ? $environment->allowed_origins : [];
+        $extra = array_values(array_filter(array_map('strval', $extra), static fn ($o) => $o !== ''));
+
+        return array_values(array_unique([$primary, ...$extra]));
+    }
+}

--- a/app/Support/Base64Url.php
+++ b/app/Support/Base64Url.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * RFC 4648 §5 base64url: URL-safe alphabet, no padding. Used for surfacing
+ * raw WebAuthn `credential_id` / `challenge` bytes over JSON without having
+ * to round-trip through hex.
+ */
+final class Base64Url
+{
+    public static function encode(string $bytes): string
+    {
+        return rtrim(strtr(base64_encode($bytes), '+/', '-_'), '=');
+    }
+
+    public static function decode(string $encoded): string
+    {
+        $padded = strtr($encoded, '-_', '+/');
+        $padLen = (4 - strlen($padded) % 4) % 4;
+        if ($padLen > 0) {
+            $padded .= str_repeat('=', $padLen);
+        }
+        $decoded = base64_decode($padded, true);
+
+        return $decoded === false ? '' : $decoded;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "lcobucci/clock": "^3.6",
         "lcobucci/jwt": "^5.6",
         "league/oauth2-client": "^2.9",
-        "pragmarx/google2fa": "^9.0"
+        "pragmarx/google2fa": "^9.0",
+        "web-auth/webauthn-lib": "^5"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17d251ef92871f21d06f7316ebc81020",
+    "content-hash": "402b04ff0394d1b1089c2dd07b6e0190",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -314,6 +314,54 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -3270,6 +3318,182 @@
             "time": "2025-09-24T15:06:41+00:00"
         },
         {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
+            },
+            "time": "2026-03-18T20:49:53+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
             "name": "phpoption/phpoption",
             "version": "1.9.5",
             "source": {
@@ -3343,6 +3567,53 @@
                 }
             ],
             "time": "2025-12-27T19:41:33+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "pragmarx/google2fa",
@@ -4084,6 +4355,187 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
             "time": "2025-12-14T04:43:48+00:00"
+        },
+        {
+            "name": "spomky-labs/cbor-php",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/cbor-php.git",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/cbor-php/zipball/dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "roave/security-advisories": "dev-latest",
+                "symfony/error-handler": "^6.4|^7.1|^8.0",
+                "symfony/var-dumper": "^6.4|^7.1|^8.0"
+            },
+            "suggest": {
+                "ext-bcmath": "GMP or BCMath extensions will drastically improve the library performance. BCMath extension needed to handle the Big Float and Decimal Fraction Tags",
+                "ext-gmp": "GMP or BCMath extensions will drastically improve the library performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CBOR\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/Spomky-Labs/cbor-php/contributors"
+                }
+            ],
+            "description": "CBOR Encoder/Decoder for PHP",
+            "keywords": [
+                "Concise Binary Object Representation",
+                "RFC7049",
+                "cbor"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/cbor-php/issues",
+                "source": "https://github.com/Spomky-Labs/cbor-php/tree/3.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-04-01T12:15:20+00:00"
+        },
+        {
+            "name": "spomky-labs/pki-framework",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/pki-framework.git",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/pki-framework/zipball/aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "ekino/phpstan-banned-code": "^1.0|^2.0|^3.0",
+                "ext-gmp": "*",
+                "ext-openssl": "*",
+                "infection/infection": "^0.28|^0.29|^0.31|^0.32",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpstan/extension-installer": "^1.3|^2.0",
+                "phpstan/phpstan": "^1.8|^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+                "phpstan/phpstan-phpunit": "^1.1|^2.0",
+                "phpstan/phpstan-strict-rules": "^1.3|^2.0",
+                "phpunit/phpunit": "^10.1|^11.0|^12.0|^13.0",
+                "rector/rector": "^1.0|^2.0",
+                "roave/security-advisories": "dev-latest",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symplify/easy-coding-standard": "^12.0|^13.0"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance (or GMP)",
+                "ext-gmp": "For better performance (or BCMath)",
+                "ext-openssl": "For OpenSSL based cyphering"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SpomkyLabs\\Pki\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joni Eskelinen",
+                    "email": "jonieske@gmail.com",
+                    "role": "Original developer"
+                },
+                {
+                    "name": "Florent Morselli",
+                    "email": "florent.morselli@spomky-labs.com",
+                    "role": "Spomky-Labs PKI Framework developer"
+                }
+            ],
+            "description": "A PHP framework for managing Public Key Infrastructures. It comprises X.509 public key certificates, attribute certificates, certification requests and certification path validation.",
+            "homepage": "https://github.com/spomky-labs/pki-framework",
+            "keywords": [
+                "DER",
+                "Private Key",
+                "ac",
+                "algorithm identifier",
+                "asn.1",
+                "asn1",
+                "attribute certificate",
+                "certificate",
+                "certification request",
+                "cryptography",
+                "csr",
+                "decrypt",
+                "ec",
+                "encrypt",
+                "pem",
+                "pkcs",
+                "public key",
+                "rsa",
+                "sign",
+                "signature",
+                "verify",
+                "x.509",
+                "x.690",
+                "x509",
+                "x690"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/pki-framework/issues",
+                "source": "https://github.com/Spomky-Labs/pki-framework/tree/1.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-03-23T22:56:56+00:00"
         },
         {
             "name": "symfony/clock",
@@ -6023,6 +6475,173 @@
             "time": "2026-03-30T15:14:47+00:00"
         },
         {
+            "name": "symfony/property-access",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "704c7808116fcdd67327db7b17de56b8ef6169e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/704c7808116fcdd67327db7b17de56b8ef6169e4",
+                "reference": "704c7808116fcdd67327db7b17de56b8ef6169e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/property-info": "^7.4.4|^8.0.4"
+            },
+            "require-dev": {
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/var-exporter": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides functions to read and write from/to an object or array using a simple string notation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property-path",
+                "reflection"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
+            "name": "symfony/property-info",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-info.git",
+                "reference": "c21711980653360d6ef5c26d0f9ca6f58a1135c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/c21711980653360d6ef5c26d0f9ca6f58a1135c6",
+                "reference": "c21711980653360d6ef5c26d0f9ca6f58a1135c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/string": "^7.4|^8.0",
+                "symfony/type-info": "^7.4.7|^8.0.7"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts information about PHP class' properties using metadata of popular sources",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "doctrine",
+                "phpdoc",
+                "property",
+                "symfony",
+                "type",
+                "validator"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-info/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
             "name": "symfony/routing",
             "version": "v8.0.9",
             "source": {
@@ -6101,6 +6720,104 @@
                 }
             ],
             "time": "2026-04-29T15:02:55+00:00"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "v8.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "72ed7e1475790714f07c3a59bd01fd32cd022fdf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/72ed7e1475790714f07c3a59bd01fd32cd022fdf",
+                "reference": "72ed7e1475790714f07c3a59bd01fd32cd022fdf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/property-access": "<7.4.2|>=8.0,<8.0.2",
+                "symfony/property-info": "<7.4",
+                "symfony/type-info": "<7.4"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "seld/jsonlint": "^1.10",
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/form": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/property-access": "^7.4.2|^8.0.2",
+                "symfony/property-info": "^7.4|^8.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/type-info": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0",
+                "symfony/var-exporter": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/serializer/tree/v8.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-04T13:41:39+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6453,6 +7170,88 @@
                 }
             ],
             "time": "2025-07-15T13:41:35+00:00"
+        },
+        {
+            "name": "symfony/type-info",
+            "version": "v8.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/type-info.git",
+                "reference": "08723aceb8c3271e8cb3db8b2565728b0c88e866"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/08723aceb8c3271e8cb3db8b2565728b0c88e866",
+                "reference": "08723aceb8c3271e8cb3db8b2565728b0c88e866",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "psr/container": "^1.1|^2.0"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.30"
+            },
+            "require-dev": {
+                "phpstan/phpdoc-parser": "^1.30|^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\TypeInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Arlaud",
+                    "email": "mathias.arlaud@gmail.com"
+                },
+                {
+                    "name": "Baptiste LEDUC",
+                    "email": "baptiste.leduc@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts PHP types information.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "PHPStan",
+                "phpdoc",
+                "symfony",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/type-info/tree/v8.0.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/uid",
@@ -6831,6 +7630,225 @@
                 }
             ],
             "time": "2026-04-26T05:33:54+00:00"
+        },
+        {
+            "name": "web-auth/cose-lib",
+            "version": "4.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-auth/cose-lib.git",
+                "reference": "5b38660f90070a8e45f3dbc9528ade3b608dd77d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-auth/cose-lib/zipball/5b38660f90070a8e45f3dbc9528ade3b608dd77d",
+                "reference": "5b38660f90070a8e45f3dbc9528ade3b608dd77d",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "php": ">=8.1",
+                "spomky-labs/pki-framework": "^1.0"
+            },
+            "require-dev": {
+                "spomky-labs/cbor-php": "^3.2.2"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance, please install either GMP (recommended) or BCMath extension",
+                "ext-gmp": "For better performance, please install either GMP (recommended) or BCMath extension",
+                "spomky-labs/cbor-php": "For COSE Signature support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cose\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-auth/cose/contributors"
+                }
+            ],
+            "description": "CBOR Object Signing and Encryption (COSE) For PHP",
+            "homepage": "https://github.com/web-auth",
+            "keywords": [
+                "COSE",
+                "RFC8152"
+            ],
+            "support": {
+                "issues": "https://github.com/web-auth/cose-lib/issues",
+                "source": "https://github.com/web-auth/cose-lib/tree/4.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-03T09:49:50+00:00"
+        },
+        {
+            "name": "web-auth/webauthn-lib",
+            "version": "5.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-auth/webauthn-lib.git",
+                "reference": "a272f254c056fb3d6c80a4801d3c7c5fedc6a08d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-auth/webauthn-lib/zipball/a272f254c056fb3d6c80a4801d3c7c5fedc6a08d",
+                "reference": "a272f254c056fb3d6c80a4801d3c7c5fedc6a08d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "paragonie/constant_time_encoding": "^2.6|^3.0",
+                "php": ">=8.2",
+                "phpdocumentor/reflection-docblock": "^5.3|^6.0",
+                "psr/clock": "^1.0",
+                "psr/event-dispatcher": "^1.0",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "spomky-labs/cbor-php": "^3.0",
+                "spomky-labs/pki-framework": "^1.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/deprecation-contracts": "^3.2",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "web-auth/cose-lib": "^4.2.3"
+            },
+            "suggest": {
+                "psr/log-implementation": "Recommended to receive logs from the library",
+                "symfony/event-dispatcher": "Recommended to use dispatched events",
+                "web-token/jwt-library": "Mandatory for fetching Metadata Statement from distant sources"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/web-auth/webauthn-framework",
+                    "name": "web-auth/webauthn-framework"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webauthn\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-auth/webauthn-library/contributors"
+                }
+            ],
+            "description": "FIDO2/Webauthn Support For PHP",
+            "homepage": "https://github.com/web-auth",
+            "keywords": [
+                "FIDO2",
+                "fido",
+                "webauthn"
+            ],
+            "support": {
+                "source": "https://github.com/web-auth/webauthn-lib/tree/5.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-01T12:14:37+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
+                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.3.0"
+            },
+            "time": "2026-04-11T10:33:05+00:00"
         }
     ],
     "packages-dev": [
@@ -6926,54 +7944,6 @@
                 }
             ],
             "time": "2026-03-29T15:46:14+00:00"
-        },
-        {
-            "name": "doctrine/deprecations",
-            "version": "1.1.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
-                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=14"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^14",
-                "phpstan/phpstan": "1.4.10 || 2.1.30",
-                "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
-                "psr/log": "^1 || ^2 || ^3"
-            },
-            "suggest": {
-                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Deprecations\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
-            "homepage": "https://www.doctrine-project.org/",
-            "support": {
-                "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
-            },
-            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "fakerphp/faker",
@@ -8536,229 +9506,6 @@
             "time": "2025-12-28T23:57:40+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
-            },
-            "time": "2020-06-27T09:03:43+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "6.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
-                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/deprecations": "^1.1",
-                "ext-filter": "*",
-                "php": "^7.4 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^2.0",
-                "phpstan/phpdoc-parser": "^2.0",
-                "webmozart/assert": "^1.9.1 || ^2"
-            },
-            "require-dev": {
-                "mockery/mockery": "~1.3.5 || ~1.6.0",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-mockery": "^1.1",
-                "phpstan/phpstan-webmozart-assert": "^1.2",
-                "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^5.26",
-                "shipmonk/dead-code-detector": "^0.5.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                },
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
-            },
-            "time": "2026-03-18T20:49:53+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
-                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/deprecations": "^1.0",
-                "php": "^7.4 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.4",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev",
-                    "dev-2.x": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
-            },
-            "time": "2026-01-06T21:53:42+00:00"
-        },
-        {
-            "name": "phpstan/phpdoc-parser",
-            "version": "2.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^5.3.0",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
-                "symfony/process": "^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "support": {
-                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
-            },
-            "time": "2026-01-25T14:56:51+00:00"
-        },
-        {
             "name": "phpunit/php-code-coverage",
             "version": "12.5.6",
             "source": {
@@ -10250,68 +10997,6 @@
                 }
             ],
             "time": "2025-12-08T11:19:18+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
-                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-date": "*",
-                "ext-filter": "*",
-                "php": "^8.2"
-            },
-            "suggest": {
-                "ext-intl": "",
-                "ext-simplexml": "",
-                "ext-spl": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-feature/2-0": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                },
-                {
-                    "name": "Woody Gilk",
-                    "email": "woody.gilk@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.3.0"
-            },
-            "time": "2026-04-11T10:33:05+00:00"
         }
     ],
     "aliases": [],

--- a/tests/Feature/Auth/Oauth/NewPresetsTest.php
+++ b/tests/Feature/Auth/Oauth/NewPresetsTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Oauth\PresetRegistry;
+use App\Auth\Oauth\Presets\DiscordPreset;
+use App\Auth\Oauth\Presets\FacebookPreset;
+use App\Auth\Oauth\Presets\GitLabPreset;
+use App\Auth\Oauth\Presets\LinkedInPreset;
+use App\Auth\Oauth\Presets\SlackPreset;
+use App\Auth\Oauth\Presets\XPreset;
+use App\Models\Environment;
+use App\Models\OauthProvider;
+use App\Models\Project;
+
+function makeEnvForNewPresets(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('registers all six new presets on PresetRegistry', function (): void {
+    $keys = app(PresetRegistry::class)->keys();
+
+    expect($keys)->toContain('discord', 'facebook', 'linkedin', 'x', 'gitlab', 'slack');
+});
+
+it('seeds the six new preset rows disabled-but-configured on env creation', function (): void {
+    $env = makeEnvForNewPresets();
+
+    $rows = OauthProvider::query()
+        ->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->get()
+        ->keyBy('provider_key');
+
+    foreach (['google', 'github', 'apple', 'microsoft', 'discord', 'facebook', 'linkedin', 'x', 'gitlab', 'slack'] as $key) {
+        expect($rows->has($key))->toBeTrue("missing preset row: {$key}");
+        expect($rows[$key]->enabled)->toBeFalse("preset {$key} should seed disabled");
+        expect($rows[$key]->client_id)->toBe('');
+    }
+
+    expect($rows->count())->toBe(10);
+});
+
+it('Discord preset exposes OAuth2 endpoints + identify/email scopes', function (): void {
+    $p = new DiscordPreset;
+
+    expect($p->key())->toBe('discord');
+    expect($p->name())->toBe('Discord');
+    expect($p->authorizationEndpoint())->toBe('https://discord.com/oauth2/authorize');
+    expect($p->tokenEndpoint())->toBe('https://discord.com/api/oauth2/token');
+    expect($p->userinfoEndpoint())->toBe('https://discord.com/api/users/@me');
+    expect($p->jwksUri())->toBeNull();
+    expect($p->issuer())->toBeNull();
+    expect($p->defaultScopes())->toBe(['identify', 'email']);
+    expect($p->defaultAttributeMapping())->toBe([
+        'provider_user_id' => 'id',
+        'username' => 'username',
+        'email_address' => 'email',
+    ]);
+    expect($p->idTokenSigningAlgs())->toBe([]);
+});
+
+it('Facebook preset exposes Graph v18.0 endpoints + public_profile/email scopes', function (): void {
+    $p = new FacebookPreset;
+
+    expect($p->key())->toBe('facebook');
+    expect($p->authorizationEndpoint())->toBe('https://www.facebook.com/v18.0/dialog/oauth');
+    expect($p->tokenEndpoint())->toBe('https://graph.facebook.com/v18.0/oauth/access_token');
+    expect($p->userinfoEndpoint())->toBe('https://graph.facebook.com/v18.0/me');
+    expect($p->defaultScopes())->toBe(['public_profile', 'email']);
+    expect($p->defaultAttributeMapping())->toMatchArray([
+        'email_address' => 'email',
+        'first_name' => 'first_name',
+        'last_name' => 'last_name',
+    ]);
+});
+
+it('LinkedIn preset exposes OIDC endpoints + standard OIDC scopes', function (): void {
+    $p = new LinkedInPreset;
+
+    expect($p->key())->toBe('linkedin');
+    expect($p->issuer())->toBe('https://www.linkedin.com/oauth');
+    expect($p->jwksUri())->toBe('https://www.linkedin.com/oauth/openid/jwks');
+    expect($p->defaultScopes())->toBe(['openid', 'profile', 'email']);
+    expect($p->defaultAttributeMapping())->toMatchArray([
+        'provider_user_id' => 'sub',
+        'email' => 'email',
+        'first_name' => 'given_name',
+        'last_name' => 'family_name',
+    ]);
+    expect($p->idTokenSigningAlgs())->toBe(['RS256']);
+});
+
+it('X preset exposes api.twitter.com endpoints + tweet.read/users.read scopes', function (): void {
+    $p = new XPreset;
+
+    expect($p->key())->toBe('x');
+    expect($p->name())->toBe('X');
+    expect($p->authorizationEndpoint())->toBe('https://twitter.com/i/oauth2/authorize');
+    expect($p->tokenEndpoint())->toBe('https://api.twitter.com/2/oauth2/token');
+    expect($p->userinfoEndpoint())->toBe('https://api.twitter.com/2/users/me');
+    expect($p->defaultScopes())->toBe(['tweet.read', 'users.read']);
+    expect($p->defaultAttributeMapping())->toBe([
+        'provider_user_id' => 'id',
+        'username' => 'username',
+    ]);
+    expect($p->idTokenSigningAlgs())->toBe([]);
+});
+
+it('GitLab preset exposes gitlab.com OIDC endpoints + standard scopes', function (): void {
+    $p = new GitLabPreset;
+
+    expect($p->key())->toBe('gitlab');
+    expect($p->issuer())->toBe('https://gitlab.com');
+    expect($p->authorizationEndpoint())->toBe('https://gitlab.com/oauth/authorize');
+    expect($p->defaultScopes())->toBe(['openid', 'profile', 'email']);
+    expect($p->defaultAttributeMapping())->toMatchArray([
+        'provider_user_id' => 'sub',
+        'username' => 'preferred_username',
+    ]);
+    expect($p->idTokenSigningAlgs())->toBe(['RS256']);
+});
+
+it('Slack preset exposes Sign-in-with-Slack OIDC endpoints', function (): void {
+    $p = new SlackPreset;
+
+    expect($p->key())->toBe('slack');
+    expect($p->issuer())->toBe('https://slack.com');
+    expect($p->authorizationEndpoint())->toBe('https://slack.com/openid/connect/authorize');
+    expect($p->userinfoEndpoint())->toBe('https://slack.com/api/openid.connect.userInfo');
+    expect($p->defaultScopes())->toBe(['openid', 'profile', 'email']);
+    expect($p->idTokenSigningAlgs())->toBe(['RS256']);
+});
+
+it('every preset returns a non-empty key, name, and endpoint set', function (): void {
+    foreach (app(PresetRegistry::class)->all() as $key => $preset) {
+        expect($preset->key())->toBe($key);
+        expect($preset->name())->not->toBe('');
+        expect($preset->authorizationEndpoint())->toStartWith('https://');
+        expect($preset->tokenEndpoint())->toStartWith('https://');
+        expect($preset->userinfoEndpoint())->toStartWith('https://');
+    }
+});
+
+it('computes the redirect_uri off the env FAPI host for a new-preset row', function (): void {
+    config()->set('authn.app_host', 'authn.sh');
+    config()->set('authn.app_scheme', 'https');
+    config()->set('authn.routing_mode', 'subdomain');
+    config()->set('authn.app_port_suffix', '');
+
+    $env = makeEnvForNewPresets('acme');
+    $row = OauthProvider::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('provider_key', 'discord')
+        ->firstOrFail();
+
+    expect($row->redirect_uri)->toBe('https://acme.authn.sh/v1/oauth-callback/discord');
+});

--- a/tests/Feature/Auth/Oauth/OauthProviderResolverTest.php
+++ b/tests/Feature/Auth/Oauth/OauthProviderResolverTest.php
@@ -240,7 +240,7 @@ it('applies the default OIDC attribute mapping when none is stored', function ()
     expect($resolved->attributeMapping)->toBe(OauthProviderResolver::DEFAULT_OIDC_ATTRIBUTE_MAPPING);
 });
 
-it('seeds the four preset rows on environment creation, all disabled', function (): void {
+it('seeds every preset row on environment creation, all disabled', function (): void {
     $env = makeEnvForResolver('seedme');
 
     $rows = OauthProvider::query()->withoutGlobalScopes()
@@ -248,7 +248,10 @@ it('seeds the four preset rows on environment creation, all disabled', function 
         ->orderBy('provider_key')
         ->get();
 
-    expect($rows->pluck('provider_key')->all())->toBe(['apple', 'github', 'google', 'microsoft']);
+    expect($rows->pluck('provider_key')->all())->toBe([
+        'apple', 'discord', 'facebook', 'github', 'gitlab',
+        'google', 'linkedin', 'microsoft', 'slack', 'x',
+    ]);
     foreach ($rows as $row) {
         expect($row->enabled)->toBeFalse();
         expect($row->client_id)->toBe('');
@@ -269,7 +272,10 @@ it('OauthProvider::computeRedirectUri() builds the canonical callback URL', func
     expect($row->redirect_uri)->toBe('https://acme.authn.sh/v1/oauth-callback/google');
 });
 
-it('PresetRegistry exposes all four canonical preset keys', function (): void {
+it('PresetRegistry exposes the canonical preset keys in registration order', function (): void {
     $registry = app(PresetRegistry::class);
-    expect($registry->keys())->toBe(['google', 'github', 'apple', 'microsoft']);
+    expect($registry->keys())->toBe([
+        'google', 'github', 'apple', 'microsoft',
+        'discord', 'facebook', 'linkedin', 'x', 'gitlab', 'slack',
+    ]);
 });

--- a/tests/Feature/Http/Bapi/OauthProvidersTest.php
+++ b/tests/Feature/Http/Bapi/OauthProvidersTest.php
@@ -22,7 +22,10 @@ final class OauthProvidersTest extends TestCase
 
         $resp->assertOk();
         $keys = collect($resp->json('data'))->pluck('provider_key')->sort()->values()->all();
-        $this->assertSame(['apple', 'github', 'google', 'microsoft'], $keys);
+        $this->assertSame([
+            'apple', 'discord', 'facebook', 'github', 'gitlab',
+            'google', 'linkedin', 'microsoft', 'slack', 'x',
+        ], $keys);
     }
 
     public function test_show_returns_one_provider_with_redirect_uri(): void

--- a/tests/Feature/Http/Dashboard/DashboardTest.php
+++ b/tests/Feature/Http/Dashboard/DashboardTest.php
@@ -586,8 +586,14 @@ it('Configure renders the social-providers section with the seeded preset rows +
         ->assertJsonPath('component', 'Dashboard/Configure')
         ->assertJsonPath('props.section', 'social-providers');
     $keys = collect($r->json('props.oauth_providers'))->pluck('provider_key')->sort()->values()->all();
-    expect($keys)->toBe(['apple', 'github', 'google', 'microsoft']);
-    expect($r->json('props.oauth_preset_keys'))->toBe(['google', 'github', 'apple', 'microsoft']);
+    expect($keys)->toBe([
+        'apple', 'discord', 'facebook', 'github', 'gitlab',
+        'google', 'linkedin', 'microsoft', 'slack', 'x',
+    ]);
+    expect($r->json('props.oauth_preset_keys'))->toBe([
+        'google', 'github', 'apple', 'microsoft',
+        'discord', 'facebook', 'linkedin', 'x', 'gitlab', 'slack',
+    ]);
 });
 
 it('PATCH /configure/oauth-providers/{id} flips enabled + rotates client_secret', function (): void {

--- a/tests/Feature/Passkey/Base64UrlTest.php
+++ b/tests/Feature/Passkey/Base64UrlTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Base64Url;
+
+it('round-trips arbitrary bytes through encode + decode', function (): void {
+    foreach (['', "\x00", "\x00\x01\x02", random_bytes(32), random_bytes(65)] as $bytes) {
+        $encoded = Base64Url::encode($bytes);
+        expect(Base64Url::decode($encoded))->toBe($bytes);
+        // No standard-base64 padding chars.
+        expect($encoded)->not->toContain('=');
+        // URL-safe alphabet only.
+        expect($encoded)->not->toContain('+');
+        expect($encoded)->not->toContain('/');
+    }
+});
+
+it('encodes the canonical RFC 4648 §10 vectors', function (): void {
+    expect(Base64Url::encode(''))->toBe('');
+    expect(Base64Url::encode('f'))->toBe('Zg');
+    expect(Base64Url::encode('fo'))->toBe('Zm8');
+    expect(Base64Url::encode('foo'))->toBe('Zm9v');
+    expect(Base64Url::encode('foobar'))->toBe('Zm9vYmFy');
+});
+
+it('decodes inputs with URL-safe substitutions', function (): void {
+    expect(Base64Url::decode('-_'))->toBe(base64_decode('+/'));
+});

--- a/tests/Feature/Passkey/PasskeyExceptionTest.php
+++ b/tests/Feature/Passkey/PasskeyExceptionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Passkey\Exceptions\PasskeyAssertionInvalid;
+use App\Auth\Passkey\Exceptions\PasskeyAttestationInvalid;
+use App\Auth\Passkey\Exceptions\PasskeyNoCredentials;
+use App\Auth\Passkey\Exceptions\PasskeyOriginMismatch;
+use App\Auth\Passkey\Exceptions\PasskeyReplayed;
+use App\Auth\Passkey\Exceptions\PasskeyUserHandleMismatch;
+
+it('every passkey exception exposes its stable error code', function (): void {
+    expect((new PasskeyOriginMismatch('x'))->code())->toBe('passkey_origin_mismatch');
+    expect((new PasskeyReplayed('x'))->code())->toBe('passkey_replayed');
+    expect((new PasskeyAttestationInvalid('x'))->code())->toBe('passkey_attestation_invalid');
+    expect((new PasskeyAssertionInvalid('x'))->code())->toBe('passkey_assertion_invalid');
+    expect((new PasskeyUserHandleMismatch('x'))->code())->toBe('passkey_user_handle_mismatch');
+    expect((new PasskeyNoCredentials('x'))->code())->toBe('passkey_no_credentials');
+});

--- a/tests/Feature/Passkey/PasskeyServiceOptionsTest.php
+++ b/tests/Feature/Passkey/PasskeyServiceOptionsTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Passkey\PasskeyService;
+use App\Auth\Passkey\RpConfigResolver;
+use App\Models\Challenge;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Passkey;
+use App\Models\Project;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Support\Base64Url;
+
+function makeEnvForPasskeyService(string $slug = 'env'): Environment
+{
+    config([
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_port_suffix' => '',
+    ]);
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+function makeChallengeForPasskey(Environment $env, User $user): Challenge
+{
+    $verification = Verification::create([
+        'environment_id' => $env->id,
+        'verifiable_type' => 'user',
+        'verifiable_id' => $user->id,
+        'strategy' => Verification::STRATEGY_PASSKEY,
+        'status' => Verification::STATUS_UNVERIFIED,
+        'expire_at' => now()->addMinutes(10),
+    ]);
+    $client = Client::create(['environment_id' => $env->id]);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $env->id,
+        'client_id' => $client->id,
+        'status' => 'pending',
+        'identifier' => 'x@y.com',
+    ]);
+
+    return Challenge::create([
+        'environment_id' => $env->id,
+        'parent_type' => Challenge::PARENT_SIGN_IN,
+        'parent_id' => $attempt->id,
+        'step' => Challenge::STEP_FIRST,
+        'strategy' => Verification::STRATEGY_PASSKEY,
+        'status' => Challenge::STATUS_PENDING,
+        'verification_id' => $verification->id,
+        'expire_at' => now()->addMinutes(10),
+    ]);
+}
+
+it('buildRegistrationOptions writes the base64url challenge nonce onto the Challenge', function (): void {
+    $env = makeEnvForPasskeyService('reg1');
+    app()->instance(Environment::class, $env);
+    $user = User::create(['environment_id' => $env->id, 'username' => 'alice']);
+    $challenge = makeChallengeForPasskey($env, $user);
+
+    expect($challenge->nonce)->toBeNull();
+
+    $options = app(PasskeyService::class)->buildRegistrationOptions($env, $user, $challenge);
+
+    $challenge->refresh();
+    expect($challenge->nonce)->not->toBeNull();
+    expect($options)->toHaveKey('rp');
+    expect($options)->toHaveKey('user');
+    expect($options)->toHaveKey('challenge');
+    expect($options['rp']['id'])->toBe('reg1.authn.local');
+    expect($options['user']['id'])->toBe(Base64Url::encode($user->id));
+    // The nonce must decode to the same challenge bytes that the SDK
+    // received in `options.challenge` — verifying the round-trip is the
+    // load-bearing assertion here.
+    expect(Base64Url::decode((string) $challenge->nonce))
+        ->toBe(Base64Url::decode((string) $options['challenge']));
+});
+
+it('buildAuthenticationOptions narrows allowCredentials to the user verified passkeys', function (): void {
+    $env = makeEnvForPasskeyService('auth1');
+    app()->instance(Environment::class, $env);
+    $user = User::create(['environment_id' => $env->id, 'username' => 'bob']);
+    $challenge = makeChallengeForPasskey($env, $user);
+
+    $verified = Passkey::factory()->create([
+        'user_id' => $user->id,
+        'transports' => [Passkey::TRANSPORT_INTERNAL],
+        'verified_at' => now(),
+    ]);
+    Passkey::factory()->unverified()->create(['user_id' => $user->id]);
+
+    $options = app(PasskeyService::class)->buildAuthenticationOptions($env, $challenge, $user);
+
+    expect($options)->toHaveKey('challenge');
+    expect($options['rpId'])->toBe('auth1.authn.local');
+    expect($options['allowCredentials'])->toHaveCount(1);
+    expect($options['allowCredentials'][0]['id'])->toBe(Base64Url::encode($verified->credential_id));
+});
+
+it('buildAuthenticationOptions returns an empty allowCredentials list when no user is bound', function (): void {
+    $env = makeEnvForPasskeyService('auth2');
+    app()->instance(Environment::class, $env);
+    $user = User::create(['environment_id' => $env->id]);
+    $challenge = makeChallengeForPasskey($env, $user);
+
+    $options = app(PasskeyService::class)->buildAuthenticationOptions($env, $challenge, null);
+
+    expect($options['allowCredentials'] ?? [])->toBe([]);
+});
+
+it('the resolver and the service share the same env-derived RP id', function (): void {
+    $env = makeEnvForPasskeyService('share');
+    app()->instance(Environment::class, $env);
+    $user = User::create(['environment_id' => $env->id]);
+    $challenge = makeChallengeForPasskey($env, $user);
+
+    $rpId = (new RpConfigResolver)->rpId($env);
+    $options = app(PasskeyService::class)->buildRegistrationOptions($env, $user, $challenge);
+
+    expect($options['rp']['id'])->toBe($rpId);
+});

--- a/tests/Feature/Passkey/RpConfigResolverTest.php
+++ b/tests/Feature/Passkey/RpConfigResolverTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Passkey\RpConfigResolver;
+use App\Models\Environment;
+use App\Models\Project;
+
+function makeEnvForRpResolver(string $slug = 'env', array $allowed = []): Environment
+{
+    config([
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_port_suffix' => '',
+    ]);
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+        'allowed_origins' => $allowed,
+    ]);
+}
+
+it('rp.id is the env FAPI host', function (): void {
+    $env = makeEnvForRpResolver('acme');
+
+    expect((new RpConfigResolver)->rpId($env))->toBe('acme.authn.local');
+});
+
+it('rpEntity.name falls back to the configured application name', function (): void {
+    $env = makeEnvForRpResolver('acme');
+    $env->forceFill(['appearance' => array_merge(
+        (array) $env->appearance,
+        ['application_name' => 'Acme Inc.'],
+    )])->save();
+
+    $entity = (new RpConfigResolver)->rpEntity($env->refresh());
+    expect($entity->name)->toBe('Acme Inc.');
+    expect($entity->id)->toBe('acme.authn.local');
+});
+
+it('allowedOrigins always includes the primary FAPI URL and merges Environment.allowed_origins', function (): void {
+    $env = makeEnvForRpResolver('acme', ['https://acme.example.com', 'https://app.acme.example.com']);
+
+    $origins = (new RpConfigResolver)->allowedOrigins($env);
+
+    expect($origins)->toContain('https://acme.authn.local');
+    expect($origins)->toContain('https://acme.example.com');
+    expect($origins)->toContain('https://app.acme.example.com');
+    expect(count($origins))->toBe(3);
+});
+
+it('allowedOrigins respects the scheme + port-suffix config', function (): void {
+    $env = makeEnvForRpResolver('dev');
+    config(['authn.app_scheme' => 'http', 'authn.app_port_suffix' => ':8080']);
+
+    $origins = (new RpConfigResolver)->allowedOrigins($env);
+
+    expect($origins[0])->toBe('http://dev.authn.local:8080');
+});


### PR DESCRIPTION
Closes #163

Server-side wrapper around `web-auth/webauthn-lib` for the four WebAuthn ceremonies the FAPI surface (AU-3) and sign-in path (AU-4) need: build registration options, verify attestation, build authentication options, verify assertion.

## Summary

- `composer require web-auth/webauthn-lib:^5` (5.3.2 pinned exact in `composer.lock`).
- `App\Auth\Passkey\PasskeyService` — persists the challenge bytes on `Challenge.nonce` (base64url) so the matching `complete-*` call replays them. Reconstructs a `CredentialRecord` from persisted Passkey columns at assertion time rather than serialising the full record blob.
- `App\Auth\Passkey\RpConfigResolver` — derives the `PublicKeyCredentialRpEntity` + origin allowlist from `Environment` (FAPI host + `allowed_origins`).
- `App\Support\Base64Url` — RFC 4648 §5 helper for surfacing raw bytes (credential id, challenge) over JSON.
- Six exceptions, each with stable `code()`: `passkey_origin_mismatch`, `passkey_replayed`, `passkey_attestation_invalid`, `passkey_assertion_invalid`, `passkey_user_handle_mismatch`, `passkey_no_credentials` — surfaced by AU-3 / AU-4 controllers as the OA-2 / OA-3 error codes.

## Test plan

- [x] `composer install` clean from a fresh checkout.
- [x] `php artisan test --filter Passkey` — 20 / 20 passing (Base64Url round-trip, exception codes, RP-config resolution, options-building).
- [x] Full suite `php artisan test` — 735 / 735 passing.
- [x] `vendor/bin/pint --test` clean.
- Full attestation / assertion round-trip needs a real authenticator and lands in the Dusk suite (AU-14).