### PR TITLE
AU-3: FAPI /v1/me/passkeys + BAPI /v1/passkeys admin + AU-13 settings split

### DIFF
--- a/app/Http/Controllers/Bapi/PasskeyController.php
+++ b/app/Http/Controllers/Bapi/PasskeyController.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Http\Resources\PasskeyResource;
+use App\Models\Environment;
+use App\Models\Passkey;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * BAPI admin passkey surface (sdk-php SP-1 wraps this):
+ *
+ *   GET    /v1/passkeys                     — instance-scoped list, filterable by `user_id`
+ *   GET    /v1/passkeys/{id}                — single row
+ *   PATCH  /v1/passkeys/{id}                — admin nickname update
+ *   DELETE /v1/passkeys/{id}                — soft-delete (`removed_at`)
+ *
+ * Operator-side audit lookups go through this surface; user-side flows
+ * use the parallel `/v1/me/passkeys` FAPI controller.
+ */
+final class PasskeyController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $query = Passkey::query()
+            ->whereHas('user', fn ($q) => $q->where('environment_id', $env->id))
+            ->orderByDesc('created_at');
+
+        if (is_string($request->input('user_id'))) {
+            $query->where('user_id', (string) $request->input('user_id'));
+        }
+
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (Passkey $p): array => PasskeyResource::from($p))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function show(string $passkeyId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $passkey = Passkey::query()
+            ->where('id', $passkeyId)
+            ->whereHas('user', fn ($q) => $q->where('environment_id', $env->id))
+            ->first();
+        if ($passkey === null) {
+            return $this->error(404, 'resource_not_found', 'Passkey not found.');
+        }
+
+        return response()->json(PasskeyResource::from($passkey))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function update(Request $request, string $passkeyId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $passkey = Passkey::query()
+            ->where('id', $passkeyId)
+            ->whereHas('user', fn ($q) => $q->where('environment_id', $env->id))
+            ->first();
+        if ($passkey === null) {
+            return $this->error(404, 'resource_not_found', 'Passkey not found.');
+        }
+
+        if (! $request->has('nickname')) {
+            return $this->error(422, 'form_param_nil', 'nickname is required.');
+        }
+        $nickname = $request->input('nickname');
+        if (! is_string($nickname) || strlen($nickname) > 100) {
+            return $this->error(422, 'form_param_format_invalid', 'nickname must be a string up to 100 characters.');
+        }
+
+        $passkey->forceFill(['nickname' => $nickname])->save();
+
+        Log::info('auth.passkey.admin_renamed', [
+            'environment_id' => $env->id,
+            'passkey_id' => $passkey->id,
+            'user_id' => $passkey->user_id,
+            'surface' => 'bapi',
+        ]);
+
+        return response()->json(PasskeyResource::from($passkey->fresh()))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function destroy(string $passkeyId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $passkey = Passkey::query()
+            ->where('id', $passkeyId)
+            ->whereHas('user', fn ($q) => $q->where('environment_id', $env->id))
+            ->first();
+        if ($passkey === null) {
+            return $this->error(404, 'resource_not_found', 'Passkey not found.');
+        }
+
+        $shape = PasskeyResource::from($passkey);
+        $passkey->delete();
+
+        Log::info('auth.passkey.admin_removed', [
+            'environment_id' => $env->id,
+            'passkey_id' => $passkey->id,
+            'user_id' => $passkey->user_id,
+            'surface' => 'bapi',
+        ]);
+
+        return response()->json($shape)->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/app/Http/Controllers/Fapi/MePasskeysController.php
+++ b/app/Http/Controllers/Fapi/MePasskeysController.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Auth\Passkey\Exceptions\PasskeyException;
+use App\Auth\Passkey\PasskeyService;
+use App\Http\Resources\ChallengeResource;
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\PasskeyResource;
+use App\Models\Challenge;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Passkey;
+use App\Models\Session;
+use App\Models\User;
+use App\Models\Verification;
+use App\Settings\PasskeySettings;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * FAPI passkey CRUD per OA-2:
+ *   GET    /v1/me/passkeys
+ *   POST   /v1/me/passkeys/begin-registration
+ *   POST   /v1/me/passkeys/complete-registration/{challenge_id}
+ *   PATCH  /v1/me/passkeys/{passkey_id}
+ *   DELETE /v1/me/passkeys/{passkey_id}
+ *
+ * Per the v0.3 strict-semantic MFA contract, the
+ * `authentication_strategies.passkey.enabled` toggle gates *new
+ * enrolment* only; existing passkeys remain usable for sign-in even
+ * when the toggle is off (AU-4's strategy resolver enforces that).
+ */
+final class MePasskeysController
+{
+    public function __construct(private readonly PasskeyService $passkeys) {}
+
+    public function index(): JsonResponse
+    {
+        $user = app(User::class);
+        $rows = Passkey::query()
+            ->where('user_id', $user->id)
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (Passkey $p): array => PasskeyResource::from($p))->all(),
+            'total_count' => $rows->count(),
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function beginRegistration(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $user = app(User::class);
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, 'actor_session_forbidden', 'Impersonation sessions cannot enrol passkeys.');
+        }
+
+        $settings = PasskeySettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
+        if (! $settings->enabled) {
+            return $this->error(422, 'passkey_not_supported', 'Passkey enrolment is disabled for this environment.');
+        }
+
+        $nickname = $request->input('nickname');
+        if ($nickname !== null && (! is_string($nickname) || strlen($nickname) > 100)) {
+            return $this->error(422, 'form_param_format_invalid', 'nickname must be a string up to 100 characters.');
+        }
+
+        $excludeIds = Passkey::query()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->get()
+            ->map(fn (Passkey $p): string => (string) $p->credential_id)
+            ->all();
+
+        $challenge = DB::transaction(function () use ($env, $user, $nickname) {
+            $verification = Verification::create([
+                'environment_id' => $env->id,
+                'verifiable_type' => Challenge::PARENT_USER,
+                'verifiable_id' => $user->id,
+                'strategy' => Verification::STRATEGY_PASSKEY,
+                'status' => Verification::STATUS_UNVERIFIED,
+                'expire_at' => now()->addMinutes(10),
+            ]);
+
+            return Challenge::create([
+                'environment_id' => $env->id,
+                'parent_type' => Challenge::PARENT_USER,
+                'parent_id' => $user->id,
+                'step' => Challenge::STEP_SINGLE,
+                'strategy' => Verification::STRATEGY_PASSKEY,
+                'status' => Challenge::STATUS_PENDING,
+                'verification_id' => $verification->id,
+                'expire_at' => now()->addMinutes(10),
+                // The begin-time nickname is stashed on `error_message` —
+                // an unused-otherwise text column on this row's lifecycle —
+                // so complete-registration can apply it as a fallback if
+                // the SDK doesn't supply one. Cleared once consumed.
+                'error_message' => is_string($nickname) ? $nickname : null,
+            ]);
+        });
+
+        $options = $this->passkeys->buildRegistrationOptions($env, $user, $challenge->refresh(), $excludeIds);
+
+        $shape = ChallengeResource::from($challenge->fresh());
+        $shape['creation_options'] = self::camelToSnake($options);
+
+        return response()->json($shape, 201)->header('Cache-Control', 'no-store');
+    }
+
+    public function completeRegistration(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $user = app(User::class);
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, 'actor_session_forbidden', 'Impersonation sessions cannot enrol passkeys.');
+        }
+
+        $challengeId = (string) $request->route('challenge_id');
+        $challenge = Challenge::query()
+            ->where('id', $challengeId)
+            ->where('parent_type', Challenge::PARENT_USER)
+            ->where('parent_id', $user->id)
+            ->where('strategy', Verification::STRATEGY_PASSKEY)
+            ->first();
+        if ($challenge === null) {
+            return $this->error(404, 'resource_not_found', 'Challenge not found.');
+        }
+        if ($challenge->status !== Challenge::STATUS_PENDING || $challenge->isExpired()) {
+            return $this->error(422, 'challenge_already_consumed', 'Challenge is no longer live.');
+        }
+
+        $attestation = $request->input('attestation');
+        if (! is_array($attestation)) {
+            return $this->error(422, 'form_param_format_invalid', 'attestation must be an object.');
+        }
+        $completeNickname = $request->input('nickname');
+        if ($completeNickname !== null && (! is_string($completeNickname) || strlen($completeNickname) > 100)) {
+            return $this->error(422, 'form_param_format_invalid', 'nickname must be a string up to 100 characters.');
+        }
+        $resolvedNickname = is_string($completeNickname) && $completeNickname !== ''
+            ? $completeNickname
+            : (is_string($challenge->error_message) && $challenge->error_message !== '' ? $challenge->error_message : null);
+
+        try {
+            $passkey = $this->passkeys->verifyAttestation($env, $user, $challenge, $attestation, $resolvedNickname);
+        } catch (PasskeyException $e) {
+            $challenge->forceFill([
+                'status' => Challenge::STATUS_FAILED,
+                'error_code' => $e->code(),
+            ])->save();
+
+            return $this->error(422, $e->code(), $e->getMessage());
+        }
+
+        Verification::query()
+            ->where('id', $challenge->verification_id)
+            ->update(['status' => Verification::STATUS_VERIFIED, 'verified_at' => now()]);
+
+        $challenge->forceFill(['error_message' => null])->save();
+
+        Log::info('auth.passkey.registered', [
+            'user_id' => $user->id,
+            'environment_id' => $env->id,
+            'passkey_id' => $passkey->id,
+            'surface' => 'fapi',
+        ]);
+
+        return $this->clientEnvelope(PasskeyResource::from($passkey->fresh()), 201);
+    }
+
+    public function update(Request $request): JsonResponse
+    {
+        $passkeyId = (string) $request->route('passkey_id');
+        $user = app(User::class);
+        $passkey = Passkey::query()->where('user_id', $user->id)->where('id', $passkeyId)->first();
+        if ($passkey === null) {
+            return $this->error(404, 'resource_not_found', 'Passkey not found.');
+        }
+
+        $nickname = $request->input('nickname');
+        if (! is_string($nickname) || strlen($nickname) > 100) {
+            return $this->error(422, 'form_param_format_invalid', 'nickname must be a string up to 100 characters.');
+        }
+
+        $passkey->forceFill(['nickname' => $nickname])->save();
+
+        return $this->clientEnvelope(PasskeyResource::from($passkey->fresh()));
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $passkeyId = (string) $request->route('passkey_id');
+        $user = app(User::class);
+        $passkey = Passkey::query()->where('user_id', $user->id)->where('id', $passkeyId)->first();
+        if ($passkey === null) {
+            return $this->error(404, 'resource_not_found', 'Passkey not found.');
+        }
+
+        $shape = PasskeyResource::from($passkey);
+        $passkey->delete();
+
+        Log::info('auth.passkey.removed', [
+            'user_id' => $user->id,
+            'environment_id' => app(Environment::class)->id,
+            'passkey_id' => $passkey->id,
+            'surface' => 'fapi',
+        ]);
+
+        return $this->clientEnvelope($shape);
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    private function clientEnvelope(mixed $body, int $status = 200): JsonResponse
+    {
+        $client = app()->bound(Client::class) ? app(Client::class) : null;
+
+        return response()->json([
+            'response' => $body,
+            'client' => ClientResource::from($client?->fresh()),
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+
+    /**
+     * webauthn-lib serializes options to camelCase JSON; the OA-2
+     * `PasskeyCreationOptions` schema is snake_case. Translate the
+     * known key set without touching nested arrays' values.
+     *
+     * @param  array<string, mixed>  $options
+     * @return array<string, mixed>
+     */
+    private static function camelToSnake(array $options): array
+    {
+        $rename = [
+            'pubKeyCredParams' => 'pub_key_cred_params',
+            'authenticatorSelection' => 'authenticator_selection',
+            'excludeCredentials' => 'exclude_credentials',
+            'allowCredentials' => 'allow_credentials',
+            'rpId' => 'rp_id',
+        ];
+        foreach ($rename as $camel => $snake) {
+            if (array_key_exists($camel, $options)) {
+                $options[$snake] = $options[$camel];
+                unset($options[$camel]);
+            }
+        }
+        if (isset($options['authenticator_selection']) && is_array($options['authenticator_selection'])) {
+            $sel = $options['authenticator_selection'];
+            $selRename = [
+                'residentKey' => 'resident_key',
+                'userVerification' => 'user_verification',
+                'authenticatorAttachment' => 'authenticator_attachment',
+                'requireResidentKey' => 'require_resident_key',
+            ];
+            foreach ($selRename as $camel => $snake) {
+                if (array_key_exists($camel, $sel)) {
+                    $sel[$snake] = $sel[$camel];
+                    unset($sel[$camel]);
+                }
+            }
+            $options['authenticator_selection'] = $sel;
+        }
+        if (isset($options['user']) && is_array($options['user']) && array_key_exists('displayName', $options['user'])) {
+            $options['user']['display_name'] = $options['user']['displayName'];
+            unset($options['user']['displayName']);
+        }
+
+        return $options;
+    }
+}

--- a/app/Http/Resources/PasskeyResource.php
+++ b/app/Http/Resources/PasskeyResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Passkey;
+
+/**
+ * Public Passkey shape per OA-1. The credential id, sha-256 hash, COSE
+ * public key, and counter are server-only — they never leave the database.
+ */
+final class PasskeyResource
+{
+    public static function from(Passkey $passkey): array
+    {
+        return [
+            'object' => 'passkey',
+            'id' => $passkey->id,
+            'nickname' => $passkey->nickname,
+            'transports' => is_array($passkey->transports) ? array_values($passkey->transports) : [],
+            'aaguid' => $passkey->aaguid,
+            'verified' => $passkey->verified_at !== null,
+            'last_used_at' => $passkey->last_used_at?->getTimestampMs(),
+            'created_at' => $passkey->created_at?->getTimestampMs(),
+            'updated_at' => $passkey->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/app/Models/Challenge.php
+++ b/app/Models/Challenge.php
@@ -83,11 +83,14 @@ class Challenge extends Model
 
     public const PARENT_ORGANIZATION_DOMAIN = 'organization_domain';
 
+    public const PARENT_USER = 'user';
+
     public const PARENT_TYPES = [
         self::PARENT_SIGN_IN,
         self::PARENT_SIGN_UP,
         self::PARENT_EMAIL_ADDRESS,
         self::PARENT_ORGANIZATION_DOMAIN,
+        self::PARENT_USER,
     ];
 
     public const MORPH_MAP = [
@@ -95,6 +98,7 @@ class Challenge extends Model
         self::PARENT_SIGN_UP => SignUpAttempt::class,
         self::PARENT_EMAIL_ADDRESS => EmailAddress::class,
         self::PARENT_ORGANIZATION_DOMAIN => OrganizationDomain::class,
+        self::PARENT_USER => User::class,
     ];
 
     protected string $idPrefix = 'chal_';

--- a/app/Settings/PasskeySettings.php
+++ b/app/Settings/PasskeySettings.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Settings;
+
+/**
+ * Per-environment passkey toggles read by the FAPI passkey controller, the
+ * sign-in challenge resolver (AU-4), and the dashboard. Strict-semantic v0.3
+ * MFA contract: `enabled` gates *new enrolment*; existing passkeys remain
+ * usable for sign-in even when the toggle is off (callers — AU-4's strategy
+ * resolver — enforce the distinction).
+ *
+ * Lives on `Environment.user_settings`:
+ *   - `authentication_strategies.passkey.enabled` (bool, default `true`)
+ *   - `multi_factor.passkey_counts_as_mfa` (bool, default `true`)
+ */
+final readonly class PasskeySettings
+{
+    public function __construct(
+        public bool $enabled = true,
+        public bool $passkeyCountsAsMfa = true,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>|null  $userSettings
+     */
+    public static function fromUserSettings(?array $userSettings): self
+    {
+        $userSettings = is_array($userSettings) ? $userSettings : [];
+        $strategies = is_array($userSettings['authentication_strategies'] ?? null)
+            ? $userSettings['authentication_strategies']
+            : [];
+        $passkey = is_array($strategies['passkey'] ?? null) ? $strategies['passkey'] : [];
+
+        $multiFactor = is_array($userSettings['multi_factor'] ?? null) ? $userSettings['multi_factor'] : [];
+
+        return new self(
+            enabled: (bool) ($passkey['enabled'] ?? true),
+            passkeyCountsAsMfa: (bool) ($multiFactor['passkey_counts_as_mfa'] ?? true),
+        );
+    }
+
+    /**
+     * @return array{authentication_strategies: array{passkey: array{enabled: bool}}, multi_factor: array{passkey_counts_as_mfa: bool}}
+     */
+    public function toArray(): array
+    {
+        return [
+            'authentication_strategies' => [
+                'passkey' => ['enabled' => $this->enabled],
+            ],
+            'multi_factor' => [
+                'passkey_counts_as_mfa' => $this->passkeyCountsAsMfa,
+            ],
+        ];
+    }
+}

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\Bapi\OrganizationDomainChallengeController;
 use App\Http\Controllers\Bapi\OrganizationDomainController;
 use App\Http\Controllers\Bapi\OrganizationInvitationController;
 use App\Http\Controllers\Bapi\OrganizationMembershipController;
+use App\Http\Controllers\Bapi\PasskeyController;
 use App\Http\Controllers\Bapi\PermissionController;
 use App\Http\Controllers\Bapi\PhoneNumberController;
 use App\Http\Controllers\Bapi\PingController;
@@ -115,6 +116,12 @@ Route::get('/oauth-providers/{oauth_provider_id}', [OauthProviderController::cla
 Route::patch('/oauth-providers/{oauth_provider_id}', [OauthProviderController::class, 'update'])->middleware(RateLimit::class.':oauth_providers.update,60,60')->name('bapi.oauth_providers.update');
 Route::delete('/oauth-providers/{oauth_provider_id}', [OauthProviderController::class, 'destroy'])->middleware(RateLimit::class.':oauth_providers.destroy,30,60')->name('bapi.oauth_providers.destroy');
 Route::post('/oauth-providers/{oauth_provider_id}/test', [OauthProviderController::class, 'test'])->middleware(RateLimit::class.':oauth_providers.test,30,60')->name('bapi.oauth_providers.test');
+
+// Passkeys (admin) — sdk-php SP-1 wraps this.
+Route::get('/passkeys', [PasskeyController::class, 'index'])->middleware(RateLimit::class.':passkeys.list,300,60')->name('bapi.passkeys.index');
+Route::get('/passkeys/{passkey_id}', [PasskeyController::class, 'show'])->middleware(RateLimit::class.':passkeys.read,300,60')->name('bapi.passkeys.show');
+Route::patch('/passkeys/{passkey_id}', [PasskeyController::class, 'update'])->middleware(RateLimit::class.':passkeys.update,60,60')->name('bapi.passkeys.update');
+Route::delete('/passkeys/{passkey_id}', [PasskeyController::class, 'destroy'])->middleware(RateLimit::class.':passkeys.destroy,30,60')->name('bapi.passkeys.destroy');
 
 // Phone numbers (admin)
 Route::get('/phone-numbers', [PhoneNumberController::class, 'index'])->middleware(RateLimit::class.':phone_numbers.list,300,60')->name('bapi.phone_numbers.index');

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Fapi\MeBackupCodesController;
 use App\Http\Controllers\Fapi\MeController;
 use App\Http\Controllers\Fapi\MeExternalAccountController;
 use App\Http\Controllers\Fapi\MeOrganizationController;
+use App\Http\Controllers\Fapi\MePasskeysController;
 use App\Http\Controllers\Fapi\MePhoneNumberController;
 use App\Http\Controllers\Fapi\MeTotpController;
 use App\Http\Controllers\Fapi\OauthCallbackController;
@@ -148,6 +149,12 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/me/backup-codes', [MeBackupCodesController::class, 'regenerate'])->name('fapi.me.backup_codes.regenerate');
         Route::get('/me/backup-codes', [MeBackupCodesController::class, 'show'])->name('fapi.me.backup_codes.show');
         Route::delete('/me/backup-codes', [MeBackupCodesController::class, 'destroy'])->name('fapi.me.backup_codes.destroy');
+
+        Route::get('/me/passkeys', [MePasskeysController::class, 'index'])->name('fapi.me.passkeys.list');
+        Route::post('/me/passkeys/begin-registration', [MePasskeysController::class, 'beginRegistration'])->name('fapi.me.passkeys.begin');
+        Route::post('/me/passkeys/complete-registration/{challenge_id}', [MePasskeysController::class, 'completeRegistration'])->name('fapi.me.passkeys.complete');
+        Route::patch('/me/passkeys/{passkey_id}', [MePasskeysController::class, 'update'])->name('fapi.me.passkeys.update');
+        Route::delete('/me/passkeys/{passkey_id}', [MePasskeysController::class, 'destroy'])->name('fapi.me.passkeys.destroy');
 
         // Organizations — user-scoped CRUD (PLAN §4.4 / OA-3 / AU-6).
         Route::post('/organizations', [FapiOrganizationController::class, 'store'])->name('fapi.organizations.store');

--- a/tests/Feature/Http/Bapi/PasskeyAdminTest.php
+++ b/tests/Feature/Http/Bapi/PasskeyAdminTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Bapi;
+
+use App\Models\Environment;
+use App\Models\Passkey;
+use App\Models\User;
+use Tests\TestCase;
+
+final class PasskeyAdminTest extends TestCase
+{
+    public function test_index_returns_passkeys_scoped_to_the_environment(): void
+    {
+        $boot = BapiTestSupport::bootEnv('pkadmin');
+        app()->instance(Environment::class, $boot['env']);
+        $user = User::create(['environment_id' => $boot['env']->id]);
+        Passkey::factory()->create(['user_id' => $user->id, 'nickname' => 'A']);
+        Passkey::factory()->create(['user_id' => $user->id, 'nickname' => 'B']);
+
+        $resp = $this->getJson(
+            BapiTestSupport::url('/passkeys'),
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $this->assertSame(2, $resp->json('total_count'));
+        $this->assertCount(2, $resp->json('data'));
+    }
+
+    public function test_index_filters_by_user_id(): void
+    {
+        $boot = BapiTestSupport::bootEnv('pkfilter');
+        app()->instance(Environment::class, $boot['env']);
+        $a = User::create(['environment_id' => $boot['env']->id]);
+        $b = User::create(['environment_id' => $boot['env']->id]);
+        Passkey::factory()->create(['user_id' => $a->id]);
+        Passkey::factory()->create(['user_id' => $a->id]);
+        Passkey::factory()->create(['user_id' => $b->id]);
+
+        $resp = $this->getJson(
+            BapiTestSupport::url('/passkeys?user_id='.$a->id),
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $this->assertSame(2, $resp->json('total_count'));
+    }
+
+    public function test_show_returns_a_single_passkey(): void
+    {
+        $boot = BapiTestSupport::bootEnv('pkshow');
+        app()->instance(Environment::class, $boot['env']);
+        $user = User::create(['environment_id' => $boot['env']->id]);
+        $passkey = Passkey::factory()->create(['user_id' => $user->id, 'nickname' => 'YubiKey']);
+
+        $resp = $this->getJson(
+            BapiTestSupport::url('/passkeys/'.$passkey->id),
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $resp->assertJson(['object' => 'passkey', 'id' => $passkey->id, 'nickname' => 'YubiKey']);
+    }
+
+    public function test_show_404_for_passkey_in_another_env(): void
+    {
+        // Different first-char slugs so the seeded test API keys don't collide.
+        $bootA = BapiTestSupport::bootEnv('alpha');
+        $bootB = BapiTestSupport::bootEnv('bravo');
+        $user = User::create(['environment_id' => $bootB['env']->id]);
+        $passkey = Passkey::factory()->create(['user_id' => $user->id]);
+
+        // Use env A's bearer to read env B's passkey — must 404 (env scoping).
+        $resp = $this->getJson(
+            'http://api.authn.local/v1/passkeys/'.$passkey->id,
+            BapiTestSupport::headers($bootA['token']),
+        );
+
+        $resp->assertStatus(404);
+    }
+
+    public function test_update_renames_the_passkey(): void
+    {
+        $boot = BapiTestSupport::bootEnv('pkrename');
+        app()->instance(Environment::class, $boot['env']);
+        $user = User::create(['environment_id' => $boot['env']->id]);
+        $passkey = Passkey::factory()->create(['user_id' => $user->id, 'nickname' => 'Old']);
+
+        $resp = $this->patchJson(
+            BapiTestSupport::url('/passkeys/'.$passkey->id),
+            ['nickname' => 'Renamed by admin'],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $resp->assertJsonPath('nickname', 'Renamed by admin');
+        $this->assertSame('Renamed by admin', $passkey->fresh()->nickname);
+    }
+
+    public function test_update_422_when_nickname_missing(): void
+    {
+        $boot = BapiTestSupport::bootEnv('pkmissing');
+        app()->instance(Environment::class, $boot['env']);
+        $user = User::create(['environment_id' => $boot['env']->id]);
+        $passkey = Passkey::factory()->create(['user_id' => $user->id]);
+
+        $resp = $this->patchJson(
+            BapiTestSupport::url('/passkeys/'.$passkey->id),
+            [],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertStatus(422);
+    }
+
+    public function test_destroy_soft_removes_the_passkey(): void
+    {
+        $boot = BapiTestSupport::bootEnv('pkdel');
+        app()->instance(Environment::class, $boot['env']);
+        $user = User::create(['environment_id' => $boot['env']->id]);
+        $passkey = Passkey::factory()->create(['user_id' => $user->id]);
+
+        $resp = $this->deleteJson(
+            BapiTestSupport::url('/passkeys/'.$passkey->id),
+            [],
+            BapiTestSupport::headers($boot['token']),
+        );
+
+        $resp->assertOk();
+        $this->assertNull(Passkey::query()->find($passkey->id));
+        $this->assertNotNull(Passkey::withTrashed()->find($passkey->id)?->removed_at);
+    }
+}

--- a/tests/Feature/Http/Me/MePasskeysTest.php
+++ b/tests/Feature/Http/Me/MePasskeysTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Passkey;
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function mePasskeyReq(string $method, string $path, string $jwt, array $body = []): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+it('GET /v1/me/passkeys returns the empty list for a fresh user', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = mePasskeyReq('GET', '/me/passkeys', $auth['jwt']);
+    $r->assertOk()
+        ->assertJsonPath('total_count', 0)
+        ->assertJsonPath('data', []);
+});
+
+it('GET /v1/me/passkeys returns the user verified passkeys', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $verified = Passkey::factory()->create([
+        'user_id' => $auth['user']->id,
+        'nickname' => 'YubiKey 5C',
+    ]);
+    Passkey::factory()->unverified()->create(['user_id' => $auth['user']->id]);
+
+    $r = mePasskeyReq('GET', '/me/passkeys', $auth['jwt']);
+
+    $r->assertOk()
+        ->assertJsonPath('total_count', 2)
+        ->assertJsonPath('data.0.object', 'passkey');
+    $ids = array_column($r->json('data'), 'id');
+    expect($ids)->toContain($verified->id);
+});
+
+it('POST /v1/me/passkeys/begin-registration returns a Challenge with creation_options', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = mePasskeyReq('POST', '/me/passkeys/begin-registration', $auth['jwt'], ['nickname' => 'My laptop']);
+
+    $r->assertCreated();
+    $r->assertJsonPath('object', 'challenge');
+    $r->assertJsonPath('strategy', 'passkey');
+    $r->assertJsonPath('status', 'pending');
+    expect($r->json('creation_options.rp.id'))->toBe('acme.authn.local');
+    expect($r->json('creation_options.pub_key_cred_params'))->not->toBeEmpty();
+    expect($r->json('creation_options.exclude_credentials'))->toBe([]);
+});
+
+it('POST /v1/me/passkeys/begin-registration 422s when passkey strategy is disabled', function (): void {
+    $f = MeTestSupport::bootEnv(['authentication_strategies' => ['passkey' => ['enabled' => false]]]);
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = mePasskeyReq('POST', '/me/passkeys/begin-registration', $auth['jwt']);
+
+    $r->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'passkey_not_supported');
+});
+
+it('POST /v1/me/passkeys/begin-registration 422s when nickname exceeds 100 chars', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = mePasskeyReq('POST', '/me/passkeys/begin-registration', $auth['jwt'], [
+        'nickname' => str_repeat('a', 101),
+    ]);
+
+    $r->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'form_param_format_invalid');
+});
+
+it('POST /v1/me/passkeys/complete-registration/{id} 422s on malformed attestation', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $begin = mePasskeyReq('POST', '/me/passkeys/begin-registration', $auth['jwt']);
+    $challengeId = $begin->json('id');
+
+    $r = mePasskeyReq('POST', "/me/passkeys/complete-registration/{$challengeId}", $auth['jwt'], [
+        'attestation' => ['id' => 'aGVsbG8', 'response' => ['attestationObject' => '!!', 'clientDataJSON' => '!!']],
+    ]);
+
+    $r->assertStatus(422);
+    expect($r->json('errors.0.code'))->toBe('passkey_attestation_invalid');
+});
+
+it('POST /v1/me/passkeys/complete-registration/{id} 404 on unknown challenge', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $r = mePasskeyReq('POST', '/me/passkeys/complete-registration/chal_01HQX0000000000000000000', $auth['jwt'], [
+        'attestation' => ['id' => '', 'response' => []],
+    ]);
+
+    $r->assertStatus(404);
+});
+
+it('PATCH /v1/me/passkeys/{id} renames the row', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $passkey = Passkey::factory()->create([
+        'user_id' => $auth['user']->id,
+        'nickname' => 'Old name',
+    ]);
+
+    $r = mePasskeyReq('PATCH', "/me/passkeys/{$passkey->id}", $auth['jwt'], ['nickname' => 'Work YubiKey']);
+
+    $r->assertOk();
+    expect($r->json('response.nickname'))->toBe('Work YubiKey');
+    expect($passkey->fresh()->nickname)->toBe('Work YubiKey');
+});
+
+it('DELETE /v1/me/passkeys/{id} soft-removes the row', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $passkey = Passkey::factory()->create(['user_id' => $auth['user']->id]);
+
+    $r = mePasskeyReq('DELETE', "/me/passkeys/{$passkey->id}", $auth['jwt']);
+
+    $r->assertOk();
+    expect(Passkey::query()->find($passkey->id))->toBeNull();
+    expect(Passkey::withTrashed()->find($passkey->id)?->removed_at)->not->toBeNull();
+});
+
+it('PATCH /v1/me/passkeys/{id} 404 when the row belongs to another user', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $other = User::create(['environment_id' => $f['env']->id]);
+    $passkey = Passkey::factory()->create(['user_id' => $other->id]);
+
+    $r = mePasskeyReq('PATCH', "/me/passkeys/{$passkey->id}", $auth['jwt'], ['nickname' => 'Try']);
+
+    $r->assertStatus(404);
+});

--- a/tests/Feature/Passkey/PasskeySettingsTest.php
+++ b/tests/Feature/Passkey/PasskeySettingsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Settings\PasskeySettings;
+
+it('defaults to enabled and counts_as_mfa = true when user_settings is empty', function (): void {
+    $settings = PasskeySettings::fromUserSettings(null);
+
+    expect($settings->enabled)->toBeTrue();
+    expect($settings->passkeyCountsAsMfa)->toBeTrue();
+});
+
+it('reads authentication_strategies.passkey.enabled from user_settings', function (): void {
+    $settings = PasskeySettings::fromUserSettings([
+        'authentication_strategies' => ['passkey' => ['enabled' => false]],
+    ]);
+
+    expect($settings->enabled)->toBeFalse();
+});
+
+it('reads multi_factor.passkey_counts_as_mfa from user_settings', function (): void {
+    $settings = PasskeySettings::fromUserSettings([
+        'multi_factor' => ['passkey_counts_as_mfa' => false],
+    ]);
+
+    expect($settings->passkeyCountsAsMfa)->toBeFalse();
+});
+
+it('round-trips through toArray()', function (): void {
+    $settings = new PasskeySettings(enabled: false, passkeyCountsAsMfa: false);
+    $blob = $settings->toArray();
+
+    expect($blob['authentication_strategies']['passkey']['enabled'])->toBeFalse();
+    expect($blob['multi_factor']['passkey_counts_as_mfa'])->toBeFalse();
+
+    $reloaded = PasskeySettings::fromUserSettings($blob);
+    expect($reloaded->enabled)->toBeFalse();
+    expect($reloaded->passkeyCountsAsMfa)->toBeFalse();
+});


### PR DESCRIPTION
Closes #164
Refs #174 (settings model side — strategy gate lands with AU-4)

End-user passkey CRUD on the FAPI surface, plus the operator admin surface on BAPI (per team-lead's SP-1 dependency note, folded into this PR rather than a separate issue). AU-13 is split as authorised: the model + settings side lands here; the strategy-resolver enforcement lands with AU-4.

## Summary

- **FAPI `MePasskeysController`** (`/v1/me/passkeys`):
  - `GET` — list the calling user's verified + unverified passkeys.
  - `POST /begin-registration` — mints a `Challenge` with `parent_type = user`, calls `PasskeyService::buildRegistrationOptions`, returns the challenge wrapped with `creation_options`.
  - `POST /complete-registration/{challenge_id}` — verifies the attestation, creates a verified `Passkey`, flips the parent `Verification` to `verified`.
  - `PATCH /{passkey_id}` — rename (nickname-only mutation).
  - `DELETE /{passkey_id}` — soft-delete via `removed_at`.
- **BAPI `PasskeyController`** (`/v1/passkeys`) — instance-scoped admin surface used by `sdk-php` SP-1. `whereHas('user', fn ($q) => $q->where('environment_id', $env->id))` enforces tenancy.
- **`PasskeyResource`** — public Passkey shape per OA-1; `credential_id` / `public_key` / `sign_count` stay server-only.
- **`PasskeySettings`** — reads `authentication_strategies.passkey.enabled` and `multi_factor.passkey_counts_as_mfa` from `Environment.user_settings`. The strategy-resolver enforcement side of AU-13 lands with AU-4 per the issue split.
- **`Challenge.MORPH_MAP`** gains a `user` parent type so passkey registration challenges have a place to live (not bound to a SignIn/SignUp attempt).
- FAPI route handlers read path params via `$request->route(...)` to avoid clashing with the `{env_slug}` domain placeholder.

## Test plan

- [x] `php artisan test --filter MePasskeysTest|PasskeyAdminTest|PasskeySettingsTest` — 21 / 21 passing.
- [x] Full suite — 756 / 756 passing.
- [x] `vendor/bin/pint --test` clean.