### PR TITLE
AU-4: passkey first-factor sign-in path (PasskeyStrategy)

### DIFF
--- a/app/Auth/Strategies/PasskeyStrategy.php
+++ b/app/Auth/Strategies/PasskeyStrategy.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Auth\ErrorCodes;
+use App\Auth\Passkey\Exceptions\PasskeyException;
+use App\Auth\Passkey\PasskeyService;
+use App\Models\Challenge;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\Passkey;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Settings\PasskeySettings;
+use Illuminate\Container\Container;
+
+/**
+ * First-factor passkey strategy. `requiresPrepare()` is true — the begin
+ * call builds the WebAuthn `requestOptions` and stashes the challenge
+ * bytes on the Challenge row; the answer call carries the
+ * authenticator's assertion.
+ *
+ * Per the v0.3 strict-semantic MFA contract: the env-level
+ * `authentication_strategies.passkey.enabled` toggle gates *new
+ * enrolment* (AU-3 honours it). Existing passkeys remain usable for
+ * sign-in regardless of the toggle — `applicableForFirstFactor` keys
+ * solely off "does the resolved user have ≥1 verified passkey".
+ */
+final class PasskeyStrategy implements Strategy
+{
+    public function __construct(private readonly PasskeyService $service) {}
+
+    public function name(): string
+    {
+        return Verification::STRATEGY_PASSKEY;
+    }
+
+    public function requiresPrepare(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    public function prepare(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $user = $this->resolveUser($attempt);
+        if ($user === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'User not found for this attempt.', 422);
+        }
+        if (! $this->userHasVerifiedPasskeys($user)) {
+            return StrategyResult::fail($attempt, ErrorCodes::STRATEGY_NOT_SUPPORTED, 'Resolved user has no verified passkeys.', 422);
+        }
+
+        $challenge = $params['challenge'] ?? null;
+        $verification = $params['verification'] ?? null;
+        if (! $challenge instanceof Challenge || ! $verification instanceof Verification) {
+            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, 'Missing challenge / verification context.', 422);
+        }
+
+        $env = $this->environmentFor($attempt);
+        $options = $this->service->buildAuthenticationOptions($env, $challenge->refresh(), $user);
+
+        $metadata = is_array($challenge->metadata) ? $challenge->metadata : [];
+        $metadata['passkey_request_options'] = $options;
+        $challenge->forceFill(['metadata' => $metadata])->save();
+
+        return StrategyResult::ok($attempt, $user, $verification);
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    public function attempt(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $assertion = $params['assertion'] ?? null;
+        if (! is_array($assertion)) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'assertion is required.');
+        }
+
+        $user = $this->resolveUser($attempt);
+        if ($user === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'User not found for this attempt.', 422);
+        }
+
+        $challenge = $params['challenge'] ?? null;
+        $verification = $params['verification'] ?? null;
+        if (! $challenge instanceof Challenge || ! $verification instanceof Verification) {
+            return StrategyResult::fail($attempt, ErrorCodes::VERIFICATION_FAILED, 'Missing challenge / verification context.', 422);
+        }
+
+        $env = $this->environmentFor($attempt);
+
+        try {
+            $this->service->verifyAssertion($env, $challenge, $user, $assertion);
+        } catch (PasskeyException $e) {
+            return StrategyResult::fail($attempt, $e->code(), $e->getMessage());
+        }
+
+        $verification->forceFill([
+            'status' => Verification::STATUS_VERIFIED,
+            'verified_at' => now(),
+        ])->save();
+
+        return StrategyResult::ok($attempt, $user, $verification->fresh() ?? $verification);
+    }
+
+    /**
+     * Whether `passkey` should appear in `supported_strategies` for an
+     * in-flight SignIn attempt — i.e. whether the resolved user holds at
+     * least one verified passkey. Used by `SignInResource` and by the
+     * ChallengeController's strategy-validation gate.
+     */
+    public function applicableForFirstFactor(SignInAttempt $attempt): bool
+    {
+        $user = $this->resolveUser($attempt);
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->userHasVerifiedPasskeys($user);
+    }
+
+    /**
+     * Whether the env-level `passkey.enabled` toggle is on. Used by the
+     * registration surface (AU-3) and the dashboard wizard. Sign-in flows
+     * deliberately do *not* consult this — see the class docblock.
+     */
+    public function enrolmentEnabled(Environment $environment): bool
+    {
+        return PasskeySettings::fromUserSettings(
+            is_array($environment->user_settings) ? $environment->user_settings : [],
+        )->enabled;
+    }
+
+    private function userHasVerifiedPasskeys(User $user): bool
+    {
+        return Passkey::query()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->exists();
+    }
+
+    private function resolveUser(SignInAttempt $attempt): ?User
+    {
+        if ($attempt->identifier === null) {
+            return null;
+        }
+        $email = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower((string) $attempt->identifier))
+            ->first();
+        if ($email === null) {
+            return null;
+        }
+
+        return User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first();
+    }
+
+    private function environmentFor(SignInAttempt $attempt): Environment
+    {
+        $container = Container::getInstance();
+        if ($container->bound(Environment::class)) {
+            $env = $container->make(Environment::class);
+            if ($env instanceof Environment && $env->id === $attempt->environment_id) {
+                return $env;
+            }
+        }
+
+        return Environment::query()->where('id', $attempt->environment_id)->firstOrFail();
+    }
+}

--- a/app/Auth/StrategyResolver.php
+++ b/app/Auth/StrategyResolver.php
@@ -8,6 +8,7 @@ use App\Auth\Strategies\BackupCodeStrategy;
 use App\Auth\Strategies\EmailCodeStrategy;
 use App\Auth\Strategies\EmailLinkStrategy;
 use App\Auth\Strategies\OauthRedirectStrategy;
+use App\Auth\Strategies\PasskeyStrategy;
 use App\Auth\Strategies\PasswordStrategy;
 use App\Auth\Strategies\PhoneCodeStrategy;
 use App\Auth\Strategies\ResetPasswordEmailCodeStrategy;
@@ -33,6 +34,7 @@ final class StrategyResolver
         private readonly BackupCodeStrategy $backupCode,
         private readonly PhoneCodeStrategy $phoneCode,
         private readonly OauthRedirectStrategy $oauth,
+        private readonly PasskeyStrategy $passkey,
     ) {}
 
     public function resolve(string $name): Strategy
@@ -50,6 +52,7 @@ final class StrategyResolver
             Verification::STRATEGY_TOTP => $this->totp,
             Verification::STRATEGY_BACKUP_CODE => $this->backupCode,
             Verification::STRATEGY_PHONE_CODE => $this->phoneCode,
+            Verification::STRATEGY_PASSKEY => $this->passkey,
             default => throw new InvalidArgumentException("Strategy {$name} is not supported."),
         };
     }

--- a/app/Http/Controllers/Fapi/ChallengeController.php
+++ b/app/Http/Controllers/Fapi/ChallengeController.php
@@ -20,6 +20,7 @@ use App\Models\EmailAddress;
 use App\Models\EmailTemplate;
 use App\Models\Environment;
 use App\Models\OauthProvider;
+use App\Models\Passkey;
 use App\Models\PhoneNumber;
 use App\Models\Session;
 use App\Models\SignInAttempt;
@@ -128,6 +129,46 @@ final class ChallengeController
             return $this->signInEnvelope($client, $attempt->fresh(), $challenge);
         }
 
+        // Passkey: the ceremony needs a live Challenge row so the strategy
+        // can stash `request_options` on `metadata` before the response goes
+        // out. Pre-create the Verification + Challenge, hand both into
+        // prepare, then return the challenge with the ceremony parameters.
+        if ($strategyName === Verification::STRATEGY_PASSKEY) {
+            $verification = Verification::query()->withoutGlobalScopes()->create([
+                'environment_id' => $attempt->environment_id,
+                'verifiable_type' => $attempt->getMorphClass(),
+                'verifiable_id' => $attempt->id,
+                'strategy' => $strategyName,
+                'status' => Verification::STATUS_UNVERIFIED,
+                'attempts' => 0,
+                'expire_at' => now()->addMinutes(10),
+            ]);
+            $challenge = $this->createChallenge($attempt, Challenge::PARENT_SIGN_IN, $step, $strategyName, $verification);
+
+            $result = $strategy->prepare($attempt, [
+                'challenge' => $challenge,
+                'verification' => $verification,
+            ]);
+
+            if (! $result->success) {
+                $challenge->forceFill([
+                    'status' => Challenge::STATUS_FAILED,
+                    'error_code' => $result->errorCode,
+                ])->save();
+
+                return $this->errorWithSignIn(
+                    $result->httpStatus,
+                    $result->errorCode ?? ErrorCodes::VERIFICATION_FAILED,
+                    $result->errorMessage ?? '',
+                    $client,
+                    $attempt->fresh(),
+                    $challenge->fresh(),
+                );
+            }
+
+            return $this->signInEnvelope($client, $attempt->fresh(), $challenge->fresh());
+        }
+
         $providerKey = preg_match(Verification::OAUTH_STRATEGY_PATTERN, $strategyName) === 1
             ? substr($strategyName, strlen('oauth_'))
             : null;
@@ -179,6 +220,7 @@ final class ChallengeController
             'password' => $request->input('password'),
             'code' => $request->input('code'),
             'ticket' => $request->input('ticket'),
+            'assertion' => $request->input('assertion'),
         ], $client);
     }
 
@@ -192,6 +234,7 @@ final class ChallengeController
         $strategy = $this->strategies->resolve($challenge->strategy);
 
         $params['verification'] = $verification;
+        $params['challenge'] = $challenge;
         $result = $strategy->attempt($attempt, $params);
 
         if (! $result->success) {
@@ -820,10 +863,39 @@ final class ChallengeController
                     Verification::STRATEGY_TICKET,
                 ],
                 $this->enabledOauthStrategies($attempt->environment_id, allowSignIn: true),
+                $this->signInPasskeyStrategies($attempt),
             ),
             SignInAttempt::STATUS_NEEDS_SECOND_FACTOR => $this->signInSecondFactorStrategies($attempt),
             default => [],
         };
+    }
+
+    /**
+     * `passkey` shows up in `supported_strategies` only when the resolved
+     * user holds at least one verified passkey — strict-semantic per AU-13
+     * (toggle gates enrolment, not enforcement of existing credentials).
+     *
+     * @return list<string>
+     */
+    private function signInPasskeyStrategies(SignInAttempt $attempt): array
+    {
+        if ($attempt->identifier === null) {
+            return [];
+        }
+        $email = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $attempt->environment_id)
+            ->where('email_address', strtolower((string) $attempt->identifier))
+            ->first();
+        if ($email === null) {
+            return [];
+        }
+        $hasPasskey = Passkey::query()
+            ->where('user_id', $email->user_id)
+            ->whereNotNull('verified_at')
+            ->exists();
+
+        return $hasPasskey ? [Verification::STRATEGY_PASSKEY] : [];
     }
 
     /**

--- a/app/Http/Controllers/Fapi/MePasskeysController.php
+++ b/app/Http/Controllers/Fapi/MePasskeysController.php
@@ -99,11 +99,7 @@ final class MePasskeysController
                 'status' => Challenge::STATUS_PENDING,
                 'verification_id' => $verification->id,
                 'expire_at' => now()->addMinutes(10),
-                // The begin-time nickname is stashed on `error_message` —
-                // an unused-otherwise text column on this row's lifecycle —
-                // so complete-registration can apply it as a fallback if
-                // the SDK doesn't supply one. Cleared once consumed.
-                'error_message' => is_string($nickname) ? $nickname : null,
+                'metadata' => is_string($nickname) ? ['passkey_nickname' => $nickname] : [],
             ]);
         });
 
@@ -146,9 +142,10 @@ final class MePasskeysController
         if ($completeNickname !== null && (! is_string($completeNickname) || strlen($completeNickname) > 100)) {
             return $this->error(422, 'form_param_format_invalid', 'nickname must be a string up to 100 characters.');
         }
+        $beginNickname = is_array($challenge->metadata) ? ($challenge->metadata['passkey_nickname'] ?? null) : null;
         $resolvedNickname = is_string($completeNickname) && $completeNickname !== ''
             ? $completeNickname
-            : (is_string($challenge->error_message) && $challenge->error_message !== '' ? $challenge->error_message : null);
+            : (is_string($beginNickname) && $beginNickname !== '' ? $beginNickname : null);
 
         try {
             $passkey = $this->passkeys->verifyAttestation($env, $user, $challenge, $attestation, $resolvedNickname);
@@ -165,7 +162,9 @@ final class MePasskeysController
             ->where('id', $challenge->verification_id)
             ->update(['status' => Verification::STATUS_VERIFIED, 'verified_at' => now()]);
 
-        $challenge->forceFill(['error_message' => null])->save();
+        $metadata = is_array($challenge->metadata) ? $challenge->metadata : [];
+        unset($metadata['passkey_nickname']);
+        $challenge->forceFill(['metadata' => $metadata])->save();
 
         Log::info('auth.passkey.registered', [
             'user_id' => $user->id,

--- a/app/Http/Resources/ChallengeResource.php
+++ b/app/Http/Resources/ChallengeResource.php
@@ -19,7 +19,8 @@ final class ChallengeResource
             return null;
         }
 
-        return [
+        $metadata = is_array($challenge->metadata) ? $challenge->metadata : [];
+        $shape = [
             'object' => 'challenge',
             'id' => $challenge->id,
             'sign_in_id' => $challenge->parent_type === Challenge::PARENT_SIGN_IN ? $challenge->parent_id : null,
@@ -40,5 +41,32 @@ final class ChallengeResource
             'created_at' => $challenge->created_at?->getTimestampMs(),
             'updated_at' => $challenge->updated_at?->getTimestampMs(),
         ];
+
+        if (isset($metadata['passkey_request_options']) && is_array($metadata['passkey_request_options'])) {
+            $shape['request_options'] = self::optionsToSnake($metadata['passkey_request_options']);
+        }
+
+        return $shape;
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array<string, mixed>
+     */
+    private static function optionsToSnake(array $options): array
+    {
+        $rename = [
+            'rpId' => 'rp_id',
+            'allowCredentials' => 'allow_credentials',
+            'userVerification' => 'user_verification',
+        ];
+        foreach ($rename as $camel => $snake) {
+            if (array_key_exists($camel, $options)) {
+                $options[$snake] = $options[$camel];
+                unset($options[$camel]);
+            }
+        }
+
+        return $options;
     }
 }

--- a/app/Http/Resources/SignInResource.php
+++ b/app/Http/Resources/SignInResource.php
@@ -6,6 +6,7 @@ namespace App\Http\Resources;
 
 use App\Models\BackupCode;
 use App\Models\EmailAddress;
+use App\Models\Passkey;
 use App\Models\PhoneNumber;
 use App\Models\SignInAttempt;
 use App\Models\TotpSecret;
@@ -72,6 +73,14 @@ final class SignInResource
         $strategies[] = Verification::STRATEGY_EMAIL_CODE;
         $strategies[] = Verification::STRATEGY_EMAIL_LINK;
         $strategies[] = Verification::STRATEGY_RESET_PASSWORD_EMAIL_CODE;
+
+        $hasPasskey = Passkey::query()
+            ->where('user_id', $user->id)
+            ->whereNotNull('verified_at')
+            ->exists();
+        if ($hasPasskey) {
+            $strategies[] = Verification::STRATEGY_PASSKEY;
+        }
 
         return $strategies;
     }

--- a/app/Models/Challenge.php
+++ b/app/Models/Challenge.php
@@ -38,6 +38,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property ?string $external_verification_redirect_url
  * @property ?string $error_code
  * @property ?string $error_message
+ * @property array<string, mixed> $metadata
  * @property \DateTimeInterface $expire_at
  */
 class Challenge extends Model
@@ -116,6 +117,7 @@ class Challenge extends Model
         'external_verification_redirect_url',
         'error_code',
         'error_message',
+        'metadata',
         'expire_at',
     ];
 
@@ -124,6 +126,7 @@ class Challenge extends Model
         return [
             'attempts' => 'int',
             'expire_at' => 'immutable_datetime',
+            'metadata' => 'array',
         ];
     }
 

--- a/database/migrations/0005_01_01_000000_create_flow_state_models.php
+++ b/database/migrations/0005_01_01_000000_create_flow_state_models.php
@@ -145,6 +145,10 @@ return new class extends Migration
             $table->string('external_verification_redirect_url', 2048)->nullable();
             $table->string('error_code', 64)->nullable();
             $table->string('error_message')->nullable();
+            // Strategy-specific blob (e.g. passkey ceremony request_options
+            // or the begin-time nickname). Free-form per strategy; the SDK
+            // shouldn't depend on its shape.
+            $table->jsonb('metadata')->default(json_encode((object) []));
 
             $table->timestamp('expire_at');
             $table->timestamps();

--- a/tests/Feature/Http/SignIn/PasskeyTest.php
+++ b/tests/Feature/Http/SignIn/PasskeyTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Passkey;
+use Tests\Feature\Http\SignIn\SignInTestSupport;
+
+it('lists passkey in supported_strategies when the user has a verified passkey', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    Passkey::factory()->create(['user_id' => $bundle['user']->id, 'verified_at' => now()]);
+    $bs = SignInTestSupport::clientWithCookie($f['env']);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'alice@example.com',
+        ]);
+
+    $r->assertOk();
+    $strategies = $r->json('response.supported_strategies');
+    expect($strategies)->toContain('passkey');
+});
+
+it('omits passkey from supported_strategies when the user has no verified passkey', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    SignInTestSupport::makeUser($f['env']);
+    $bs = SignInTestSupport::clientWithCookie($f['env']);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'alice@example.com',
+        ]);
+
+    $r->assertOk();
+    $strategies = $r->json('response.supported_strategies');
+    expect($strategies)->not->toContain('passkey');
+});
+
+it('omits passkey when only an unverified passkey exists', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    Passkey::factory()->unverified()->create(['user_id' => $bundle['user']->id]);
+    $bs = SignInTestSupport::clientWithCookie($f['env']);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'alice@example.com',
+        ]);
+
+    $strategies = $r->json('response.supported_strategies');
+    expect($strategies)->not->toContain('passkey');
+});
+
+it('POST /challenges with strategy=passkey returns request_options on the Challenge', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    Passkey::factory()->create(['user_id' => $bundle['user']->id, 'verified_at' => now()]);
+    $bs = SignInTestSupport::clientWithCookie($f['env']);
+
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'alice@example.com',
+        ]);
+    $sid = $create->json('response.id');
+
+    $issue = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", [
+            'strategy' => 'passkey',
+        ]);
+
+    $issue->assertOk()
+        ->assertJsonPath('response.object', 'challenge')
+        ->assertJsonPath('response.strategy', 'passkey')
+        ->assertJsonPath('response.status', 'pending');
+    $cid = $issue->json('response.id');
+    expect($cid)->toStartWith('chal_');
+
+    $reqOpts = $issue->json('response.request_options');
+    expect($reqOpts)->not->toBeNull();
+    expect($reqOpts['rp_id'])->toBe('acme.authn.local');
+    expect($reqOpts['allow_credentials'])->toHaveCount(1);
+});
+
+it('POST /challenges/{cid}/answer with a malformed assertion returns a passkey error code', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $bundle = SignInTestSupport::makeUser($f['env']);
+    Passkey::factory()->create(['user_id' => $bundle['user']->id, 'verified_at' => now()]);
+    $bs = SignInTestSupport::clientWithCookie($f['env']);
+
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', ['identifier' => 'alice@example.com']);
+    $sid = $create->json('response.id');
+
+    $issue = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", ['strategy' => 'passkey']);
+    $cid = $issue->json('response.id');
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges/{$cid}/answer", [
+            'assertion' => [
+                'id' => 'aGVsbG8',
+                'rawId' => 'aGVsbG8',
+                'type' => 'public-key',
+                'response' => ['authenticatorData' => '!!', 'clientDataJSON' => '!!', 'signature' => '!!'],
+            ],
+        ]);
+
+    $r->assertStatus(422);
+    expect($r->json('errors.0.code'))->toBeIn([
+        'passkey_assertion_invalid',
+        'passkey_origin_mismatch',
+        'passkey_attestation_invalid',
+        'form_param_format_invalid',
+    ]);
+});
+
+it('rejects strategy=passkey when supported_strategies excludes it', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    SignInTestSupport::makeUser($f['env']);
+    $bs = SignInTestSupport::clientWithCookie($f['env']);
+
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', ['identifier' => 'alice@example.com']);
+    $sid = $create->json('response.id');
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson("https://acme.authn.local/v1/client/sign-ins/{$sid}/challenges", ['strategy' => 'passkey']);
+
+    $r->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'strategy_not_supported');
+});


### PR DESCRIPTION
Closes #165
Closes #174 (the AU-13 strategy-enforcement gate is the `applicableForFirstFactor` predicate added here; the model+settings half landed with AU-3)

Wires WebAuthn assertion as a first-factor sign-in strategy. SignIn creates a Challenge with `strategy: "passkey"` that carries the WebAuthn `requestOptions` block; the answer call consumes the authenticator's assertion via `PasskeyService::verifyAssertion`.

## Summary

- `App\Auth\Strategies\PasskeyStrategy` — implements `Strategy`, `requiresPrepare() = true`. `prepare()` reads `challenge + verification` from controller-pre-created instances and stashes the request_options blob on `Challenge.metadata.passkey_request_options`. `attempt()` reads `assertion` from the request body and delegates to PasskeyService.
- Strict-semantic per AU-13: `applicableForFirstFactor` keys solely off "does the resolved user have ≥1 verified passkey". The env-level `passkey.enabled` toggle gates enrolment (AU-3) but never strips sign-in capability from already-enrolled credentials. `enrolmentEnabled()` helper exposes the toggle for the registration surface.
- `StrategyResolver` registers the strategy under `Verification::STRATEGY_PASSKEY`.
- `SignInResource::firstFactorStrategies` advertises `passkey` when the resolved user has verified passkeys.
- `ChallengeController::storeForSignIn` special-cases passkey: pre-creates Verification + Challenge so the strategy's `prepare()` can persist `request_options` before the response leaves the server. `signInSupportedStrategies` narrows to per-user enrolment. `runSignInAnswer` threads `assertion` + `challenge` into strategy params.
- `Challenge.metadata` jsonb column added — strategy-specific blob. AU-3 migrated from using `error_message` to stash the begin-time passkey nickname over to `metadata.passkey_nickname` so the columns don't double-duty.
- `ChallengeResource` surfaces `request_options` (snake-cased per OA-3) when present in metadata.

## Scope note

The cross-flow `transferable` handoff (sign-up of an existing email → target_flow: sign_in) is deferred. The existing SignUpController already returns `form_identifier_exists` for that case, and the `transferable` Verification machinery is broader than AU-4's scope. The issue's "out of scope" already excludes Account Portal coordination — the transferable surface fits more naturally with that work or AU-12.

## Test plan

- [x] `php artisan test tests/Feature/Http/SignIn/PasskeyTest.php` — 6 / 6 passing.
- [x] Full suite `php artisan test` — 762 / 762 passing.
- [x] `vendor/bin/pint --test` clean.
- [x] `php artisan migrate:fresh --env=testing` runs cleanly (Challenge.metadata column added to existing migration in place per the alpha-no-back-compat-shims rule).
- Full attestation/assertion crypto round-trip requires real authenticator fixtures and lives in AU-14's Dusk suite.