### PR TITLE
AU-12: passkey + appearance + localization webhook events + audit log

### DIFF
--- a/app/Http/Controllers/Bapi/InstanceAppearanceController.php
+++ b/app/Http/Controllers/Bapi/InstanceAppearanceController.php
@@ -140,10 +140,43 @@ final class InstanceAppearanceController
             'instance.config.appearance_updated',
             [
                 'environment_id' => $env->id,
-                'before' => $before,
-                'after' => $after,
+                'previous' => $before,
+                'current' => $after,
+                'diff' => self::diff($before, $after),
             ],
             $env,
         );
+    }
+
+    /**
+     * Per-axis key-level diff. Output shape:
+     *   { variables: { added: {...}, removed: [...], changed: { key: {from, to} } }, elements: {...}, layout: {...} }
+     *
+     * @param  array<string, mixed>  $before
+     * @param  array<string, mixed>  $after
+     * @return array<string, array<string, mixed>>
+     */
+    private static function diff(array $before, array $after): array
+    {
+        $out = [];
+        foreach (self::TOP_LEVEL_KEYS as $axis) {
+            $b = is_array($before[$axis] ?? null) ? $before[$axis] : [];
+            $a = is_array($after[$axis] ?? null) ? $after[$axis] : [];
+            $added = array_diff_key($a, $b);
+            $removed = array_values(array_keys(array_diff_key($b, $a)));
+            $changed = [];
+            foreach ($a as $k => $v) {
+                if (array_key_exists($k, $b) && $b[$k] !== $v) {
+                    $changed[$k] = ['from' => $b[$k], 'to' => $v];
+                }
+            }
+            $out[$axis] = [
+                'added' => (object) $added,
+                'removed' => $removed,
+                'changed' => (object) $changed,
+            ];
+        }
+
+        return $out;
     }
 }

--- a/app/Http/Controllers/Bapi/InstanceLocalizationController.php
+++ b/app/Http/Controllers/Bapi/InstanceLocalizationController.php
@@ -6,8 +6,10 @@ namespace App\Http\Controllers\Bapi;
 
 use App\Localization\CanonicalSchema;
 use App\Models\Environment;
+use App\Webhooks\Emitter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 
@@ -30,12 +32,14 @@ final class InstanceLocalizationController
     public function replace(Request $request): JsonResponse
     {
         $env = app(Environment::class);
+        $before = $this->normalise($env->localization);
         $next = $this->validateBlob($request, isPatch: false);
         $warnings = $this->collectPlaceholderWarnings($next['overrides']);
 
         $env->forceFill(['localization' => $next])->save();
+        $this->emitUpdated($env->refresh(), $before, $next);
 
-        $response = response()->json($this->payload($env->refresh()));
+        $response = response()->json($this->payload($env));
         foreach ($warnings as $warning) {
             $response->headers->set('Warning', $warning, false);
         }
@@ -74,6 +78,7 @@ final class InstanceLocalizationController
 
         $warnings = $this->collectPlaceholderWarnings($next['overrides']);
         $env->forceFill(['localization' => $next])->save();
+        $this->emitUpdated($env->refresh(), $stored, $next);
 
         $response = response()->json($this->payload($env->refresh()));
         foreach ($warnings as $warning) {
@@ -280,5 +285,80 @@ final class InstanceLocalizationController
             'supported_locales' => $blob['supported_locales'],
             'overrides' => empty($payloadOverrides) ? (object) [] : $payloadOverrides,
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $before
+     * @param  array<string, mixed>  $after
+     */
+    private function emitUpdated(Environment $env, array $before, array $after): void
+    {
+        if ($before == $after) {
+            return;
+        }
+
+        Log::info('localization.updated', [
+            'environment_id' => $env->id,
+        ]);
+
+        app(Emitter::class)->emit(
+            'localization.updated',
+            [
+                'environment_id' => $env->id,
+                'previous' => $before,
+                'current' => $after,
+                'diff' => self::diff($before, $after),
+                'override_etag' => $env->localization_override_etag,
+            ],
+            $env,
+        );
+    }
+
+    /**
+     * Per-locale + top-level key diff. Captures changes to
+     * default_locale / fallback_locale / supported_locales and a
+     * per-locale `overrides` diff (added / removed / changed keys).
+     *
+     * @param  array<string, mixed>  $before
+     * @param  array<string, mixed>  $after
+     * @return array<string, mixed>
+     */
+    private static function diff(array $before, array $after): array
+    {
+        $out = [];
+        foreach (['default_locale', 'fallback_locale', 'supported_locales'] as $field) {
+            if (($before[$field] ?? null) !== ($after[$field] ?? null)) {
+                $out[$field] = ['from' => $before[$field] ?? null, 'to' => $after[$field] ?? null];
+            }
+        }
+        $overridesBefore = is_array($before['overrides'] ?? null) ? $before['overrides'] : [];
+        $overridesAfter = is_array($after['overrides'] ?? null) ? $after['overrides'] : [];
+        $locales = array_unique(array_merge(array_keys($overridesBefore), array_keys($overridesAfter)));
+        $overrideDiff = [];
+        foreach ($locales as $locale) {
+            $b = is_array($overridesBefore[$locale] ?? null) ? $overridesBefore[$locale] : [];
+            $a = is_array($overridesAfter[$locale] ?? null) ? $overridesAfter[$locale] : [];
+            $added = array_diff_key($a, $b);
+            $removed = array_values(array_keys(array_diff_key($b, $a)));
+            $changed = [];
+            foreach ($a as $k => $v) {
+                if (array_key_exists($k, $b) && $b[$k] !== $v) {
+                    $changed[$k] = ['from' => $b[$k], 'to' => $v];
+                }
+            }
+            if ($added === [] && $removed === [] && $changed === []) {
+                continue;
+            }
+            $overrideDiff[$locale] = [
+                'added' => (object) $added,
+                'removed' => $removed,
+                'changed' => (object) $changed,
+            ];
+        }
+        if ($overrideDiff !== []) {
+            $out['overrides'] = $overrideDiff;
+        }
+
+        return $out;
     }
 }

--- a/app/Http/Controllers/Bapi/PasskeyController.php
+++ b/app/Http/Controllers/Bapi/PasskeyController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\Bapi;
 use App\Http\Resources\PasskeyResource;
 use App\Models\Environment;
 use App\Models\Passkey;
+use App\Webhooks\Emitter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -105,14 +106,18 @@ final class PasskeyController
         }
 
         $shape = PasskeyResource::from($passkey);
+        $userId = $passkey->user_id;
         $passkey->delete();
 
-        Log::info('auth.passkey.admin_removed', [
+        Log::info('auth.mfa.passkey_removed', [
             'environment_id' => $env->id,
-            'passkey_id' => $passkey->id,
-            'user_id' => $passkey->user_id,
+            'user_id' => $userId,
             'surface' => 'bapi',
+            'actor_type' => 'operator',
+            'passkey_id' => $passkey->id,
         ]);
+
+        app(Emitter::class)->emit('passkey.removed', $shape, $env);
 
         return response()->json($shape)->header('Cache-Control', 'no-store');
     }

--- a/app/Http/Controllers/Fapi/MePasskeysController.php
+++ b/app/Http/Controllers/Fapi/MePasskeysController.php
@@ -17,6 +17,7 @@ use App\Models\Session;
 use App\Models\User;
 use App\Models\Verification;
 use App\Settings\PasskeySettings;
+use App\Webhooks\Emitter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -166,14 +167,22 @@ final class MePasskeysController
         unset($metadata['passkey_nickname']);
         $challenge->forceFill(['metadata' => $metadata])->save();
 
-        Log::info('auth.passkey.registered', [
+        $shape = PasskeyResource::from($passkey->fresh());
+
+        Log::info('auth.mfa.passkey_added', [
             'user_id' => $user->id,
             'environment_id' => $env->id,
-            'passkey_id' => $passkey->id,
             'surface' => 'fapi',
+            'actor_type' => 'user',
+            'actor_id' => $user->id,
+            'passkey_id' => $passkey->id,
+            'transports' => $shape['transports'],
+            'aaguid' => $shape['aaguid'],
         ]);
 
-        return $this->clientEnvelope(PasskeyResource::from($passkey->fresh()), 201);
+        app(Emitter::class)->emit('passkey.added', $shape, $env);
+
+        return $this->clientEnvelope($shape, 201);
     }
 
     public function update(Request $request): JsonResponse
@@ -204,15 +213,20 @@ final class MePasskeysController
             return $this->error(404, 'resource_not_found', 'Passkey not found.');
         }
 
+        $env = app(Environment::class);
         $shape = PasskeyResource::from($passkey);
         $passkey->delete();
 
-        Log::info('auth.passkey.removed', [
+        Log::info('auth.mfa.passkey_removed', [
             'user_id' => $user->id,
-            'environment_id' => app(Environment::class)->id,
-            'passkey_id' => $passkey->id,
+            'environment_id' => $env->id,
             'surface' => 'fapi',
+            'actor_type' => 'user',
+            'actor_id' => $user->id,
+            'passkey_id' => $passkey->id,
         ]);
+
+        app(Emitter::class)->emit('passkey.removed', $shape, $env);
 
         return $this->clientEnvelope($shape);
     }

--- a/tests/Feature/Webhooks/PasskeyWebhookEventsTest.php
+++ b/tests/Feature/Webhooks/PasskeyWebhookEventsTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Passkey;
+use App\Models\User;
+use App\Models\WebhookEvent;
+use Illuminate\Support\Facades\Log;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+it('emits passkey.removed webhook event when a passkey is removed via BAPI', function (): void {
+    $boot = BapiTestSupport::bootEnv('pkadminhook');
+    app()->instance(Environment::class, $boot['env']);
+    $user = User::create(['environment_id' => $boot['env']->id]);
+    $passkey = Passkey::factory()->create(['user_id' => $user->id]);
+
+    test()->deleteJson(
+        BapiTestSupport::url('/passkeys/'.$passkey->id),
+        [],
+        BapiTestSupport::headers($boot['token']),
+    )->assertOk();
+
+    $events = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $boot['env']->id)
+        ->where('type', 'passkey.removed')
+        ->get();
+    expect($events)->toHaveCount(1);
+    $data = $events->first()->data;
+    expect($data['object'])->toBe('passkey');
+    expect($data['id'])->toBe($passkey->id);
+});
+
+it('logs auth.mfa.passkey_removed when admin BAPI deletes a passkey', function (): void {
+    Log::spy();
+    $boot = BapiTestSupport::bootEnv('pkadminaudit');
+    app()->instance(Environment::class, $boot['env']);
+    $user = User::create(['environment_id' => $boot['env']->id]);
+    $passkey = Passkey::factory()->create(['user_id' => $user->id]);
+
+    test()->deleteJson(
+        BapiTestSupport::url('/passkeys/'.$passkey->id),
+        [],
+        BapiTestSupport::headers($boot['token']),
+    )->assertOk();
+
+    Log::shouldHaveReceived('info')->withArgs(function (string $message, array $ctx) use ($user, $boot): bool {
+        return $message === 'auth.mfa.passkey_removed'
+            && $ctx['user_id'] === $user->id
+            && $ctx['environment_id'] === $boot['env']->id
+            && $ctx['surface'] === 'bapi'
+            && $ctx['actor_type'] === 'operator';
+    })->once();
+});
+
+it('emits passkey.removed and logs auth.mfa.passkey_removed when FAPI DELETE /me/passkeys runs', function (): void {
+    Log::spy();
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $passkey = Passkey::factory()->create(['user_id' => $auth['user']->id]);
+
+    test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$auth['jwt'],
+        ])
+        ->deleteJson("https://acme.authn.local/v1/me/passkeys/{$passkey->id}")
+        ->assertOk();
+
+    $events = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('type', 'passkey.removed')
+        ->get();
+    expect($events)->toHaveCount(1);
+
+    Log::shouldHaveReceived('info')->withArgs(function (string $message, array $ctx) use ($auth, $f): bool {
+        return $message === 'auth.mfa.passkey_removed'
+            && $ctx['user_id'] === $auth['user']->id
+            && $ctx['environment_id'] === $f['env']->id
+            && $ctx['surface'] === 'fapi'
+            && $ctx['actor_type'] === 'user';
+    })->once();
+});
+
+it('emits instance.config.appearance_updated with previous + current + diff on PUT', function (): void {
+    $boot = BapiTestSupport::bootEnv('apphook');
+    app()->instance(Environment::class, $boot['env']);
+
+    test()->putJson(
+        BapiTestSupport::url('/instance/appearance'),
+        [
+            'variables' => ['colorPrimary' => '#0a84ff'],
+            'layout' => ['socialButtonsPlacement' => 'top'],
+        ],
+        BapiTestSupport::headers($boot['token']),
+    )->assertOk();
+
+    $event = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $boot['env']->id)
+        ->where('type', 'instance.config.appearance_updated')
+        ->latest('created_at')
+        ->first();
+    expect($event)->not->toBeNull();
+    expect($event->data)->toHaveKey('previous');
+    expect($event->data)->toHaveKey('current');
+    expect($event->data)->toHaveKey('diff');
+    expect($event->data['current']['variables']['colorPrimary'])->toBe('#0a84ff');
+    // Variables axis diff: colorPrimary added.
+    $varsDiff = $event->data['diff']['variables'];
+    expect((array) $varsDiff['added'])->toHaveKey('colorPrimary');
+});
+
+it('emits localization.updated with previous + current + diff + override_etag on PUT', function (): void {
+    $boot = BapiTestSupport::bootEnv('lochook');
+    app()->instance(Environment::class, $boot['env']);
+
+    test()->putJson(
+        BapiTestSupport::url('/instance/localization'),
+        [
+            'default_locale' => 'pt-BR',
+            'fallback_locale' => 'en-US',
+            'supported_locales' => ['en-US', 'pt-BR'],
+            'overrides' => [
+                'pt-BR' => ['signIn.start.title' => 'Bem-vindo à {applicationName}'],
+            ],
+        ],
+        BapiTestSupport::headers($boot['token']),
+    )->assertOk();
+
+    $event = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $boot['env']->id)
+        ->where('type', 'localization.updated')
+        ->latest('created_at')
+        ->first();
+    expect($event)->not->toBeNull();
+    expect($event->data)->toHaveKey('previous');
+    expect($event->data)->toHaveKey('current');
+    expect($event->data)->toHaveKey('diff');
+    expect($event->data)->toHaveKey('override_etag');
+    expect($event->data['current']['default_locale'])->toBe('pt-BR');
+    expect($event->data['override_etag'])->toStartWith('sha256:');
+});
+
+it('does not emit a webhook event when the appearance PUT is a no-op', function (): void {
+    $boot = BapiTestSupport::bootEnv('apnoop');
+    app()->instance(Environment::class, $boot['env']);
+
+    // Two identical PUTs in a row — second one should be a no-op.
+    $payload = ['variables' => ['colorPrimary' => '#0a84ff']];
+    test()->putJson(BapiTestSupport::url('/instance/appearance'), $payload, BapiTestSupport::headers($boot['token']))->assertOk();
+    test()->putJson(BapiTestSupport::url('/instance/appearance'), $payload, BapiTestSupport::headers($boot['token']))->assertOk();
+
+    $count = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $boot['env']->id)
+        ->where('type', 'instance.config.appearance_updated')
+        ->count();
+    expect($count)->toBe(1);
+});


### PR DESCRIPTION
Closes #173

Wires the 4 v0.5 webhook events + 2 audit-log entries.

## Summary

- `passkey.added` webhook emission from `MePasskeysController::completeRegistration`. `event.data = PasskeyResource`.
- `passkey.removed` webhook + audit log fire from both the FAPI `MePasskeysController::destroy` (actor = user) and the BAPI `Bapi\PasskeyController::destroy` (actor = operator) paths.
- `instance.config.appearance_updated` event payload now carries `{previous, current, diff}` per the spec, with a per-axis diff (`variables` / `elements` / `layout` → `{added, removed, changed}`). The no-op short-circuit for identical PUTs is preserved.
- `localization.updated` webhook emission added to `InstanceLocalizationController::replace` + `::patch` with `{previous, current, diff, override_etag}`. The diff captures top-level locale field changes plus a per-locale overrides diff.
- Audit log entries `auth.mfa.passkey_added` / `auth.mfa.passkey_removed` follow the existing v0.3 `auth.mfa.*` pattern. `passkey_added` carries `transports[]` + `aaguid` per the issue spec.

## Test plan

- [x] `php artisan test tests/Feature/Webhooks/PasskeyWebhookEventsTest.php` — 6 / 6 passing.
- [x] Full suite — 768 / 768 passing.
- [x] `vendor/bin/pint --test` clean.
- The `passkey.added` happy path requires a real WebAuthn attestation; the controller wiring is the exact same `Emitter::emit` shape that the `passkey.removed` tests exercise here, and AU-14's Dusk suite will pick up the full ceremony round-trip.