### PR TITLE
AU-14: Pest coverage for Localizer fallback + passkey test-mode contract

### DIFF
--- a/tests/Feature/Http/SignIn/PasskeyTestModeTest.php
+++ b/tests/Feature/Http/SignIn/PasskeyTestModeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Passkey;
+use Tests\Feature\Http\SignIn\SignInTestSupport;
+
+it('does not advertise passkey on supported_strategies for a test_mode identifier without passkeys', function (): void {
+    // Strict-semantic: passkey requires the resolved user to actually hold a
+    // verified passkey. Test-mode shortcuts don't synthesize a user with
+    // passkey credentials, so the strategy should never be on the menu for
+    // the +authn_test bypass path. A real user *without* a passkey under a
+    // test-mode email proves the negative cleanly.
+    $f = SignInTestSupport::bootEnv();
+    $f['env']->forceFill([
+        'user_settings' => array_merge(
+            (array) $f['env']->user_settings,
+            ['test_mode' => Environment::TEST_MODE_ENABLED],
+        ),
+    ])->save();
+    SignInTestSupport::makeUser($f['env'], 'reserved+authn_test@example.com');
+    $bs = SignInTestSupport::clientWithCookie($f['env']);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'reserved+authn_test@example.com',
+        ]);
+
+    expect($r->json('response.supported_strategies') ?? [])->not->toContain('passkey');
+});
+
+it('lists passkey for a real user even when test_mode is enabled (no false negative for non-reserved identifiers)', function (): void {
+    $f = SignInTestSupport::bootEnv();
+    $f['env']->forceFill([
+        'user_settings' => array_merge(
+            (array) $f['env']->user_settings,
+            ['test_mode' => Environment::TEST_MODE_ENABLED],
+        ),
+    ])->save();
+    $bundle = SignInTestSupport::makeUser($f['env'], 'alice@example.com');
+    Passkey::factory()->create(['user_id' => $bundle['user']->id, 'verified_at' => now()]);
+    $bs = SignInTestSupport::clientWithCookie($f['env']);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'alice@example.com',
+        ]);
+
+    expect($r->json('response.supported_strategies'))->toContain('passkey');
+});

--- a/tests/Feature/Localization/MissingKeyFallthroughTest.php
+++ b/tests/Feature/Localization/MissingKeyFallthroughTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Localization\Localizer;
+use App\Models\Environment;
+use App\Models\Project;
+
+function makeEnvForMissingKey(string $slug = 'mke'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('returns the dot-keyed name when the key is not in any catalog', function (): void {
+    $env = makeEnvForMissingKey('mk1');
+
+    $rendered = (new Localizer)->localize($env, 'en-US', 'this.key.does.not.exist');
+
+    expect($rendered)->toBe('this.key.does.not.exist');
+});
+
+it('falls through canonical-locale → fallback-locale → key', function (): void {
+    $env = makeEnvForMissingKey('mk2');
+    // ja-JP isn't a shipped locale; the fallback is en-US, which has the key.
+    $rendered = (new Localizer)->localize($env, 'ja-JP', 'signIn.start.actionLink');
+
+    expect($rendered)->toBe('Sign up');
+});
+
+it('falls through operator overrides for the active locale first', function (): void {
+    $env = makeEnvForMissingKey('mk3');
+    $env->forceFill([
+        'localization' => [
+            'default_locale' => 'en-US',
+            'fallback_locale' => 'en-US',
+            'supported_locales' => ['en-US', 'pt-BR'],
+            'overrides' => [
+                'pt-BR' => ['formButtonPrimary' => 'Vamos lá'],
+            ],
+        ],
+    ])->save();
+
+    $rendered = (new Localizer)->localize($env->refresh(), 'pt-BR', 'formButtonPrimary');
+
+    expect($rendered)->toBe('Vamos lá');
+});


### PR DESCRIPTION
Closes #175

Adds the v0.5 coverage gaps the earlier waves didn't already hit. Most of the issue's coverage targets already landed alongside their feature PRs; this PR fills in two specific contracts.

## Summary

**New tests:**
- `Localization/MissingKeyFallthroughTest` — dot-keyed key returned when no catalog provides it (no crash, per PLAN §11.6.3); canonical fallback when the active locale isn't shipped; operator overrides win against canonical defaults.
- `SignIn/PasskeyTestModeTest` — strict-semantic contract for the passkey strategy:
  - Never appears in `supported_strategies` for a test-mode identifier without an enrolled passkey.
  - Still surfaces for real users with verified passkeys even when `test_mode = enabled` (no false negative for non-reserved identifiers).

**Already covered by prior PRs:**
- `Oauth/NewPresetsTest` — landed with AU-5 (#178).
- `Customization/AppearancePatchTest` — landed with AU-6 (#179) as `InstanceAppearanceTest`.
- `Customization/LocalizationOverrideTest` — landed with AU-7 (#180) as `InstanceLocalizationTest`.
- `Customization/PublicLocalizationEndpointTest` — landed with AU-7 (#180) as `LocalizationCatalogTest`.

## Scope note

The full WebAuthn ceremony round-trip (`Passkey/RegistrationTest` + `Passkey/SignInTest` happy paths) requires a real authenticator to generate the fixture attestation / assertion payloads. Those land with the Dusk smoke suite — a real browser + virtual authenticator covers the crypto round-trip much more honestly than hand-fabricated CBOR blobs would, and lets the AU-9 portal panel exercise the same path.

## Test plan

- [x] `php artisan test --filter MissingKeyFallthroughTest|PasskeyTestModeTest` — 5 / 5 passing.
- [x] Full suite — 776 / 776 passing.
- [x] `vendor/bin/pint --test` clean.