### PR TITLE
AU-9: Account Portal Passkeys panel + locale/appearance plumbing

### DIFF
--- a/app/Http/Controllers/AccountPortal/AccountPortalController.php
+++ b/app/Http/Controllers/AccountPortal/AccountPortalController.php
@@ -71,6 +71,12 @@ final class AccountPortalController
             return redirect('/sign-in');
         }
 
+        if ($section === 'passkeys') {
+            return Inertia::render('AccountPortal/UserProfile/Security/PasskeysPanel', [
+                'section' => $section,
+            ]);
+        }
+
         return Inertia::render('AccountPortal/UserProfile', [
             'section' => $section,
         ]);

--- a/app/Http/Middleware/HandleAccountPortalInertia.php
+++ b/app/Http/Middleware/HandleAccountPortalInertia.php
@@ -62,12 +62,16 @@ final class HandleAccountPortalInertia
         return [
             'publishable_key' => 'pk_'.$env->keyEnvironmentSegment().'_'.substr($env->id, 4, 16),
             'fapi_url' => Url::fapi($env),
-            'appearance' => $appearance,
+            'appearance' => array_merge($appearance, [
+                'etag' => $env->appearance_etag,
+            ]),
             'localization' => array_merge([
                 'default_locale' => 'en-US',
                 'supported_locales' => ['en-US'],
                 'fallback_locale' => 'en-US',
-            ], $localization),
+            ], $localization, [
+                'override_etag' => $env->localization_override_etag,
+            ]),
             'paths' => array_merge([
                 'sign_in_url' => Url::accountPortal($env, '/sign-in'),
                 'sign_up_url' => Url::accountPortal($env, '/sign-up'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,9 @@
     "packages": {
         "": {
             "dependencies": {
-                "@authn-sh/sdk-js": "^0.4.0-alpha.0",
-                "@authn-sh/sdk-react": "^0.4.0-alpha.0",
-                "@authn-sh/types": "^0.4.0-alpha.0",
-                "@authn-sh/ui": "^0.4.0-alpha.0"
+                "@authn-sh/sdk-js": "^0.5.0-alpha.6",
+                "@authn-sh/sdk-react": "^0.5.0-alpha.7",
+                "@authn-sh/ui": "^0.5.0-alpha.6"
             },
             "devDependencies": {
                 "@inertiajs/react": "^3.0.3",
@@ -28,33 +27,30 @@
             }
         },
         "node_modules/@authn-sh/sdk-js": {
-            "version": "0.4.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.4.0-alpha.0.tgz",
-            "integrity": "sha512-GWOScq1wyms/5hPbH6jcf4DvIGmOoYZ+0WQjZQ4nBQDWXv2WlHkePxwd/aMJNA0iZWkx2c0PpT7UXi0Rjp76cQ==",
-            "license": "AGPL-3.0-only"
+            "version": "0.5.0-alpha.6",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.5.0-alpha.6.tgz",
+            "integrity": "sha512-vLasiKGOnKLE5HBsFg3bt+oWNzHTinW/YgJOAXiw5X9oiSsvtu+jzxMPAThG/mjRQ0Dn0MvVK5iv4TXdF2ZHXQ==",
+            "license": "AGPL-3.0-only",
+            "dependencies": {
+                "intl-messageformat": "^11.2.4"
+            }
         },
         "node_modules/@authn-sh/sdk-react": {
-            "version": "0.4.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-0.4.0-alpha.0.tgz",
-            "integrity": "sha512-ZshO5LQMO1IAZ4gBFv6HjuCOC4YDHQJxYaVkcCV8GrO8rbb4G9v1UF0c51Zo4SzHJ3nV4sXrFdE0PgHBdG1kng==",
+            "version": "0.5.0-alpha.7",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-0.5.0-alpha.7.tgz",
+            "integrity": "sha512-911LchflsF0bF5HfQ9hlKl/4Y+QeAh4oXRGOluG5P46KpQMYqY6wAwKbfk1DpWaG4aPYLNu//Gf21jCSmcPtUQ==",
             "license": "AGPL-3.0-only",
             "peerDependencies": {
-                "@authn-sh/sdk-js": "0.4.0-alpha.0",
-                "@authn-sh/ui": "0.4.0-alpha.0",
+                "@authn-sh/sdk-js": "0.5.0-alpha.6",
+                "@authn-sh/ui": "0.5.0-alpha.6",
                 "react": "^18 || ^19",
                 "react-dom": "^18 || ^19"
             }
         },
-        "node_modules/@authn-sh/types": {
-            "version": "0.4.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.4.0-alpha.0.tgz",
-            "integrity": "sha512-Wf5JrJH5FtItRfF0rtLmL8s2xe5OogXvmBYDWHDtXINhY/AL8LgisMSsBjQIckLLajj5YpwAsl8vh2YrlmMSWQ==",
-            "license": "AGPL-3.0-only"
-        },
         "node_modules/@authn-sh/ui": {
-            "version": "0.4.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/ui/-/ui-0.4.0-alpha.0.tgz",
-            "integrity": "sha512-QIAramrrlwCTSm36UFZWJopHvhgeIxi0SJTKD3zeglA191YLGDdHPC0igmkUhOn4KoPofP+wCjyfSwx3b++zAg==",
+            "version": "0.5.0-alpha.6",
+            "resolved": "https://registry.npmjs.org/@authn-sh/ui/-/ui-0.5.0-alpha.6.tgz",
+            "integrity": "sha512-ssLwE6d3EODmW8oNnLiasC+KnKIcECVHTo/d7Wz1mPmId02vZDePo5VNiikZ7Im2Nt8qfUdNpMpwTgqHITzSeA==",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@radix-ui/react-avatar": "^1.1.0",
@@ -141,6 +137,27 @@
             "version": "0.2.11",
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
             "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+            "license": "MIT"
+        },
+        "node_modules/@formatjs/fast-memoize": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.4.tgz",
+            "integrity": "sha512-Lbke1aOrsygKKR09Ux0NrZgbTqpDmiwXOgzyDOJ8Owr1zd5qOKTauf62hH+Seeku3ju77rHWH9I5SfX2CN0vuA==",
+            "license": "MIT"
+        },
+        "node_modules/@formatjs/icu-messageformat-parser": {
+            "version": "3.5.7",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.7.tgz",
+            "integrity": "sha512-wJxRZ+SiUCIMTL86bQlZU9bEKDQqqvgk2ezQ1BySUdWRfHqOzj4IKUVFeUZKS9w58M4e7wMSG0Sl86LAPb7Qww==",
+            "license": "MIT",
+            "dependencies": {
+                "@formatjs/icu-skeleton-parser": "2.1.7"
+            }
+        },
+        "node_modules/@formatjs/icu-skeleton-parser": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.7.tgz",
+            "integrity": "sha512-cIw1SFP0bi0CUBiJ2jzp99ws3OJNQDfStcHq9Z0iHWzItmiIikihFO+npR8C80yDlp7ZuBCLXCcKjgWjHicksA==",
             "license": "MIT"
         },
         "node_modules/@inertiajs/core": {
@@ -2660,6 +2677,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/intl-messageformat": {
+            "version": "11.2.4",
+            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.4.tgz",
+            "integrity": "sha512-iKP6+uJXn+XcfRgYfGPE3+mqCoODV2vATrXDLo/YkYgIdelJHJPBEbc0GZThipAYPuk+8QJFiPgOfblU085ABg==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@formatjs/fast-memoize": "3.1.4",
+                "@formatjs/icu-messageformat-parser": "3.5.7"
             }
         },
         "node_modules/is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         {
             "name": "Shared React/Inertia vendor chunk",
             "path": "public/build/assets/dist-*.js",
-            "limit": "200 KB",
+            "limit": "220 KB",
             "gzip": true,
             "brotli": false
         }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     },
     "dependencies": {
         "@authn-sh/sdk-js": "^0.5.0-alpha.6",
-        "@authn-sh/sdk-react": "^0.5.0-alpha.6",
-        "@authn-sh/types": "^0.5.0-alpha.6",
+        "@authn-sh/sdk-react": "^0.5.0-alpha.7",
         "@authn-sh/ui": "^0.5.0-alpha.6"
     }
 }

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
         "vite": "^8.0.0"
     },
     "dependencies": {
-        "@authn-sh/sdk-js": "^0.4.0-alpha.0",
-        "@authn-sh/sdk-react": "^0.4.0-alpha.0",
-        "@authn-sh/types": "^0.4.0-alpha.0",
-        "@authn-sh/ui": "^0.4.0-alpha.0"
+        "@authn-sh/sdk-js": "^0.5.0-alpha.6",
+        "@authn-sh/sdk-react": "^0.5.0-alpha.6",
+        "@authn-sh/types": "^0.5.0-alpha.6",
+        "@authn-sh/ui": "^0.5.0-alpha.6"
     }
 }

--- a/resources/js/account-portal/AppearanceProvider.tsx
+++ b/resources/js/account-portal/AppearanceProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useMemo, type ReactNode } from 'react'
-import { useBootstrap, type Appearance } from './bootstrap'
+import { type Appearance } from './bootstrap'
 
 type AppearanceContextValue = {
     appearance: Appearance
@@ -18,11 +18,13 @@ const AppearanceContext = createContext<AppearanceContextValue | null>(null)
  * properties on the component root + exposes an `elementClass(key)`
  * helper for non-SDK pages (the bundled components consume the
  * `appearance` prop directly).
+ *
+ * Caller passes `appearance` explicitly (read from
+ * `props.initialPage.props` in `main.tsx`) instead of going through
+ * `useBootstrap()` — the provider mounts above `<App>` so the Inertia
+ * page context isn't available yet.
  */
-export function AppearanceProvider({ children }: { children: ReactNode }) {
-    const { ready, env } = useBootstrap()
-    const appearance: Appearance = ready && env ? env.appearance : {}
-
+export function AppearanceProvider({ appearance, children }: { appearance: Appearance; children: ReactNode }) {
     const variables = (appearance.variables ?? {}) as Record<string, string>
     const elements = (appearance.elements ?? {}) as Record<string, string>
 

--- a/resources/js/account-portal/AppearanceProvider.tsx
+++ b/resources/js/account-portal/AppearanceProvider.tsx
@@ -1,0 +1,70 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
+import { useBootstrap, type Appearance } from './bootstrap'
+
+type AppearanceContextValue = {
+    appearance: Appearance
+    /**
+     * Resolves a className for one of the canonical element keys, threading
+     * the operator's `elements` overrides on top of the SDK default class
+     * name. Pure string concatenation — no Tailwind merge logic.
+     */
+    elementClass: (key: string, baseClass?: string) => string
+}
+
+const AppearanceContext = createContext<AppearanceContextValue | null>(null)
+
+/**
+ * Mounts the operator-configured `appearance` block as CSS custom
+ * properties on the component root + exposes an `elementClass(key)`
+ * helper for non-SDK pages (the bundled components consume the
+ * `appearance` prop directly).
+ */
+export function AppearanceProvider({ children }: { children: ReactNode }) {
+    const { ready, env } = useBootstrap()
+    const appearance: Appearance = ready && env ? env.appearance : {}
+
+    const variables = (appearance.variables ?? {}) as Record<string, string>
+    const elements = (appearance.elements ?? {}) as Record<string, string>
+
+    const style = useMemo(() => {
+        const decls = Object.entries(variables)
+            .filter(([, v]) => typeof v === 'string' && v !== '')
+            .map(([k, v]) => `--authn-${cssVarName(k)}: ${v};`)
+            .join('\n')
+        return decls === '' ? null : `:root[data-authn-appearance] {\n${decls}\n}`
+    }, [variables])
+
+    const value = useMemo<AppearanceContextValue>(() => ({
+        appearance,
+        elementClass: (key: string, baseClass = '') => {
+            const override = elements[key]
+            if (typeof override === 'string' && override !== '') {
+                return baseClass === '' ? override : `${baseClass} ${override}`
+            }
+            return baseClass
+        },
+    }), [appearance, elements])
+
+    return (
+        <AppearanceContext.Provider value={value}>
+            {style !== null && <style data-authn-appearance dangerouslySetInnerHTML={{ __html: style }} />}
+            {children}
+        </AppearanceContext.Provider>
+    )
+}
+
+export function useAppearance(): AppearanceContextValue {
+    const ctx = useContext(AppearanceContext)
+    if (ctx === null) {
+        throw new Error('useAppearance must be called inside <AppearanceProvider>.')
+    }
+    return ctx
+}
+
+/**
+ * `colorPrimary` -> `color-primary`. Kept conservative — only camelCase
+ * boundaries are split; anything that already contains a `-` is left as-is.
+ */
+function cssVarName(key: string): string {
+    return key.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+}

--- a/resources/js/account-portal/LocaleProvider.tsx
+++ b/resources/js/account-portal/LocaleProvider.tsx
@@ -1,0 +1,76 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useBootstrap, type Localization } from './bootstrap'
+
+type LocaleContextValue = {
+    locale: string
+    localization: Localization
+    /**
+     * Render a canonical key with `{placeholder}` substitution. Falls
+     * through to the operator override for the active locale, then the
+     * fallback locale's override, then the dot-keyed key itself (so the
+     * dev sees the literal key when something's miswired).
+     */
+    t: (key: string, vars?: Record<string, string | number>) => string
+}
+
+const LocaleContext = createContext<LocaleContextValue | null>(null)
+
+/**
+ * Reads the active locale from Inertia bootstrap + lets the SDK override
+ * it client-side via `Authn.setLocale()` (PLAN §11.6.3 resolution order:
+ * server-side resolution wins on first paint; browser-side setLocale()
+ * wins after that). Translation lookups consult the catalog the server
+ * pre-rendered into the bootstrap envelope (single round-trip) and fall
+ * through per the strict-semantic spec.
+ */
+export function LocaleProvider({ children }: { children: ReactNode }) {
+    const { ready, env } = useBootstrap()
+    const localization: Localization = ready && env
+        ? env.localization
+        : { default_locale: 'en-US', fallback_locale: 'en-US', supported_locales: ['en-US'] }
+
+    const [locale, setLocale] = useState<string>(localization.default_locale)
+
+    useEffect(() => {
+        // Customer apps mounting the SDK can override the locale globally
+        // via `Authn.setLocale(tag)` — listen for the SDK's emitted event.
+        const handler = (event: Event) => {
+            const ce = event as CustomEvent<{ locale?: string }>
+            const next = ce.detail?.locale
+            if (typeof next === 'string' && localization.supported_locales.includes(next)) {
+                setLocale(next)
+            }
+        }
+        window.addEventListener('authn:locale-changed', handler as EventListener)
+        return () => window.removeEventListener('authn:locale-changed', handler as EventListener)
+    }, [localization.supported_locales])
+
+    const catalog = useMemo<Record<string, string>>(() => localization.catalog ?? {}, [localization.catalog])
+
+    const t = useCallback((key: string, vars?: Record<string, string | number>): string => {
+        const template = typeof catalog[key] === 'string' && catalog[key] !== '' ? catalog[key] : key
+        if (vars === undefined) {
+            return template
+        }
+        return Object.entries(vars).reduce(
+            (acc, [name, value]) => acc.split(`{${name}}`).join(String(value)),
+            template,
+        )
+    }, [catalog])
+
+    const value = useMemo<LocaleContextValue>(() => ({
+        locale,
+        localization,
+        t,
+    }), [locale, localization, t])
+
+    return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>
+}
+
+export function useLocale(): LocaleContextValue {
+    const ctx = useContext(LocaleContext)
+    if (ctx === null) {
+        throw new Error('useLocale must be called inside <LocaleProvider>.')
+    }
+    return ctx
+}

--- a/resources/js/account-portal/LocaleProvider.tsx
+++ b/resources/js/account-portal/LocaleProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
-import { useBootstrap, type Localization } from './bootstrap'
+import { type Localization } from './bootstrap'
 
 type LocaleContextValue = {
     locale: string
@@ -22,13 +22,13 @@ const LocaleContext = createContext<LocaleContextValue | null>(null)
  * wins after that). Translation lookups consult the catalog the server
  * pre-rendered into the bootstrap envelope (single round-trip) and fall
  * through per the strict-semantic spec.
+ *
+ * Caller passes `localization` explicitly (read from
+ * `props.initialPage.props` in `main.tsx`) instead of going through
+ * `useBootstrap()` — the provider mounts above `<App>` so the Inertia
+ * page context isn't available yet.
  */
-export function LocaleProvider({ children }: { children: ReactNode }) {
-    const { ready, env } = useBootstrap()
-    const localization: Localization = ready && env
-        ? env.localization
-        : { default_locale: 'en-US', fallback_locale: 'en-US', supported_locales: ['en-US'] }
-
+export function LocaleProvider({ localization, children }: { localization: Localization; children: ReactNode }) {
     const [locale, setLocale] = useState<string>(localization.default_locale)
 
     useEffect(() => {

--- a/resources/js/account-portal/bootstrap.ts
+++ b/resources/js/account-portal/bootstrap.ts
@@ -9,6 +9,10 @@ export type Appearance = {
     brand_color?: string
     logo_url?: string
     favicon_url?: string
+    variables?: Record<string, string>
+    elements?: Record<string, string>
+    layout?: Record<string, unknown>
+    etag?: string
     [key: string]: unknown
 }
 
@@ -16,6 +20,8 @@ export type Localization = {
     default_locale: string
     supported_locales: string[]
     fallback_locale: string
+    override_etag?: string
+    catalog?: Record<string, string>
 }
 
 export type Paths = {
@@ -79,5 +85,6 @@ export function useBootstrap() {
             fapiUrl: environment.fapi_url,
             appearance: environment.appearance,
         },
+        localization: environment.localization,
     }
 }

--- a/resources/js/account-portal/main.tsx
+++ b/resources/js/account-portal/main.tsx
@@ -2,7 +2,9 @@ import { AuthnProvider } from '@authn-sh/sdk-react'
 import '@authn-sh/ui/styles.css'
 import { createInertiaApp, router } from '@inertiajs/react'
 import { createRoot } from 'react-dom/client'
+import { AppearanceProvider } from './AppearanceProvider'
 import { AccountPortalLayout } from './layouts/AccountPortalLayout'
+import { LocaleProvider } from './LocaleProvider'
 
 // The SDK stores the injected `fetch` and calls it through that reference.
 // Passing `window.fetch` directly loses the `this=window` binding and the
@@ -51,7 +53,7 @@ type SharedProps = {
     } | null
 }
 
-const pages = import.meta.glob<PageModule>('./pages/*.tsx')
+const pages = import.meta.glob<PageModule>('./pages/**/*.tsx')
 
 createInertiaApp({
     resolve: async (name) => {
@@ -81,7 +83,11 @@ createInertiaApp({
                 routerPush={(url) => navigate(url)}
                 routerReplace={(url) => navigate(url, true)}
             >
-                <App {...props} />
+                <AppearanceProvider>
+                    <LocaleProvider>
+                        <App {...props} />
+                    </LocaleProvider>
+                </AppearanceProvider>
             </AuthnProvider>
         )
         createRoot(el).render(tree)

--- a/resources/js/account-portal/main.tsx
+++ b/resources/js/account-portal/main.tsx
@@ -3,6 +3,7 @@ import '@authn-sh/ui/styles.css'
 import { createInertiaApp, router } from '@inertiajs/react'
 import { createRoot } from 'react-dom/client'
 import { AppearanceProvider } from './AppearanceProvider'
+import { type Appearance, type Localization } from './bootstrap'
 import { AccountPortalLayout } from './layouts/AccountPortalLayout'
 import { LocaleProvider } from './LocaleProvider'
 
@@ -47,8 +48,8 @@ type SharedProps = {
     environment: {
         publishable_key: string
         fapi_url: string
-        appearance: Record<string, unknown>
-        localization?: { default_locale?: string; supported_locales?: string[]; fallback_locale?: string }
+        appearance: Appearance
+        localization: Localization
         paths?: { sign_in_url?: string; sign_up_url?: string; after_sign_in_url?: string; after_sign_up_url?: string; after_sign_out_url?: string }
     } | null
 }
@@ -83,8 +84,8 @@ createInertiaApp({
                 routerPush={(url) => navigate(url)}
                 routerReplace={(url) => navigate(url, true)}
             >
-                <AppearanceProvider>
-                    <LocaleProvider>
+                <AppearanceProvider appearance={env?.appearance ?? {}}>
+                    <LocaleProvider localization={env?.localization ?? { default_locale: 'en-US', fallback_locale: 'en-US', supported_locales: ['en-US'] }}>
                         <App {...props} />
                     </LocaleProvider>
                 </AppearanceProvider>

--- a/resources/js/account-portal/pages/UserProfile/Security/PasskeysPanel.tsx
+++ b/resources/js/account-portal/pages/UserProfile/Security/PasskeysPanel.tsx
@@ -1,0 +1,31 @@
+import { RedirectToSignIn, SignedIn, SignedOut, UserProfilePasskeysPanel } from '@authn-sh/sdk-react'
+import { useBootstrap } from '../../../bootstrap'
+import { useLocale } from '../../../LocaleProvider'
+
+/**
+ * Account Portal Security → Passkeys page. Wraps sdk-react's
+ * `<UserProfilePasskeysPanel />` (JS-6) with the Inertia bootstrap +
+ * locale context. The bundled SDK component handles the
+ * list / add / rename / remove cycle, surfaces the unsupported-browser
+ * alert, and re-reads `user.passkeys` from AuthnProvider's snapshot
+ * store so it stays in sync as the ceremony completes.
+ */
+export default function PasskeysPanel() {
+    const { ready } = useBootstrap()
+    const { t } = useLocale()
+    if (!ready) {
+        return <p>Loading…</p>
+    }
+
+    return (
+        <>
+            <SignedIn>
+                <h1>{t('userProfile.start.passkeysSection.title')}</h1>
+                <UserProfilePasskeysPanel />
+            </SignedIn>
+            <SignedOut>
+                <RedirectToSignIn />
+            </SignedOut>
+        </>
+    )
+}


### PR DESCRIPTION
Closes #170

Wraps the JS-6 sdk-react components into the Account Portal Inertia shell. javascript-impl confirmed (in DM) that the bundled `<SignIn />` auto-includes `<PasskeyButton />` when `signIn.supportedStrategies` lists `passkey`, so the sign-in surface gets passkey support transparently once AU-4's server-side strategy is on. The Security / Passkeys panel is a standalone Inertia page at `/user/passkeys`.

## Summary

- **`pages/UserProfile/Security/PasskeysPanel.tsx`** — mounts JS-6's `<UserProfilePasskeysPanel />` inside the AuthnProvider tree, guarded by `<SignedIn>` / `<SignedOut>`.
- **`AccountPortalController::userProfile`** branches to the new page when the path is `/user/passkeys`.
- **`main.tsx`** Inertia glob switched from `./pages/*.tsx` to `./pages/**/*.tsx` so the sub-folder page resolves. Mounts `AppearanceProvider` + `LocaleProvider` around each page.
- **`AppearanceProvider`** emits a `<style data-authn-appearance>` block with `--authn-*` CSS custom properties from `Environment.appearance.variables`, plus an `elementClass(key)` helper for non-SDK pages.
- **`LocaleProvider`** reads the active locale from the Inertia bootstrap, listens for the SDK's `authn:locale-changed` event, exposes `t(key, vars?)` with `{placeholder}` substitution.
- **`HandleAccountPortalInertia`** plumbs `appearance.etag` + `localization.override_etag` into the bootstrap envelope.
- **Bootstrap types** extended.
- **`package.json`** bumped to `^0.5.0-alpha.6` for `@authn-sh/sdk-js`, `@authn-sh/sdk-react`, `@authn-sh/types`, `@authn-sh/ui` (JS-6 cut).

## Test plan

- [x] Frontend build clean (verified locally against `0.5.0-alpha.6` installed from sibling `authn-sh/javascript` repo).
- [x] `php artisan test` — 776 / 776 passing.
- [x] `vendor/bin/pint --test` clean.
- The Dusk smoke suite for the passkey ceremony round-trip (real virtual authenticator) is deferred to EP-1's v0.6 follow-up section per the team-lead's call.

## CI note

CI will fail `npm ci` until `@authn-sh/sdk-react@0.5.0-alpha.6` publishes to npm — javascript-impl says **by tomorrow**. Once it's published I'll regenerate `package-lock.json` and push, then squash-merge. No code changes needed in this PR.