### PR TITLE
AU-15: emit pkv + pkc claims on session JWTs

### DIFF
--- a/app/Services/Sessions/SessionTokenIssuer.php
+++ b/app/Services/Sessions/SessionTokenIssuer.php
@@ -6,10 +6,13 @@ namespace App\Services\Sessions;
 
 use App\Models\Environment;
 use App\Models\OrganizationMembership;
+use App\Models\Passkey;
 use App\Models\PhoneNumber;
 use App\Models\Session;
+use App\Models\SignInAttempt;
 use App\Models\SigningKey;
 use App\Models\TotpSecret;
+use App\Models\Verification;
 use App\Support\Url;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
@@ -85,6 +88,8 @@ final class SessionTokenIssuer
         }
 
         $builder = $builder->withClaim('pnv', $this->phoneNumberVerified($session));
+        $builder = $builder->withClaim('pkv', $this->passkeyVerified($session));
+        $builder = $builder->withClaim('pkc', $this->passkeyCount($session));
 
         $dsf = $this->defaultSecondFactor($session);
         if ($dsf !== null) {
@@ -202,6 +207,42 @@ final class SessionTokenIssuer
             ->where('user_id', $session->user_id)
             ->whereNotNull('verified_at')
             ->exists();
+    }
+
+    /**
+     * Whether the SignInAttempt that produced this Session was verified via
+     * the `passkey` first-factor strategy. SDK consumers (sdk-php SP-3 /
+     * sdk-php-laravel SPL-1) use this to gate "require a passkey for this
+     * resource" middleware without an extra /v1/me round-trip.
+     */
+    private function passkeyVerified(Session $session): bool
+    {
+        $attempt = SignInAttempt::query()
+            ->withoutGlobalScopes()
+            ->where('created_session_id', $session->id)
+            ->first();
+        if ($attempt === null) {
+            return false;
+        }
+
+        return Verification::query()
+            ->withoutGlobalScopes()
+            ->where('verifiable_type', $attempt->getMorphClass())
+            ->where('verifiable_id', $attempt->id)
+            ->where('strategy', Verification::STRATEGY_PASSKEY)
+            ->where('status', Verification::STATUS_VERIFIED)
+            ->exists();
+    }
+
+    /**
+     * Snapshot of the user's verified passkey count at JWT mint time.
+     */
+    private function passkeyCount(Session $session): int
+    {
+        return Passkey::query()
+            ->where('user_id', $session->user_id)
+            ->whereNotNull('verified_at')
+            ->count();
     }
 
     /**

--- a/tests/Feature/Services/Sessions/SessionTokenIssuerPasskeyClaimsTest.php
+++ b/tests/Feature/Services/Sessions/SessionTokenIssuerPasskeyClaimsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Passkey;
+use App\Models\SignInAttempt;
+use App\Models\Verification;
+use App\Services\Sessions\SessionTokenIssuer;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function decodePasskeyClaims(string $jwt): array
+{
+    $config = Configuration::forSymmetricSigner(
+        new Sha256,
+        InMemory::plainText(str_repeat('x', 64)),
+    );
+
+    return $config->parser()->parse($jwt)->claims()->all();
+}
+
+it('emits pkv: false + pkc: 0 when the user has no passkeys and no passkey SignInAttempt', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodePasskeyClaims($minted['jwt']);
+
+    expect($claims)->toHaveKey('pkv');
+    expect($claims['pkv'])->toBeFalse();
+    expect($claims)->toHaveKey('pkc');
+    expect($claims['pkc'])->toBe(0);
+});
+
+it('emits pkc as a snapshot of the user verified passkey count', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    Passkey::factory()->create(['user_id' => $auth['user']->id, 'verified_at' => now()]);
+    Passkey::factory()->create(['user_id' => $auth['user']->id, 'verified_at' => now()]);
+    Passkey::factory()->unverified()->create(['user_id' => $auth['user']->id]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodePasskeyClaims($minted['jwt']);
+
+    expect($claims['pkc'])->toBe(2);
+});
+
+it('emits pkv: true when the SignInAttempt that produced this session has a verified passkey Verification', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    // Wire the SignInAttempt that "produced" this session and attach a
+    // verified passkey Verification to it.
+    $attempt = SignInAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $auth['client']->id,
+        'status' => 'complete',
+        'identifier' => 'alice@example.com',
+        'created_session_id' => $auth['session']->id,
+    ]);
+    Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => Verification::STRATEGY_PASSKEY,
+        'status' => Verification::STATUS_VERIFIED,
+        'expire_at' => now()->addMinutes(10),
+        'verified_at' => now(),
+    ]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodePasskeyClaims($minted['jwt']);
+
+    expect($claims['pkv'])->toBeTrue();
+});
+
+it('emits pkv: false when the SignInAttempt was resolved via a non-passkey strategy', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $attempt = SignInAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $auth['client']->id,
+        'status' => 'complete',
+        'identifier' => 'alice@example.com',
+        'created_session_id' => $auth['session']->id,
+    ]);
+    Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => Verification::STRATEGY_PASSWORD,
+        'status' => Verification::STATUS_VERIFIED,
+        'expire_at' => now()->addMinutes(10),
+        'verified_at' => now(),
+    ]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodePasskeyClaims($minted['jwt']);
+
+    expect($claims['pkv'])->toBeFalse();
+});
+
+it('emits pkv: false when the SignInAttempt has an unverified passkey Verification', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $attempt = SignInAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $auth['client']->id,
+        'status' => 'pending',
+        'identifier' => 'alice@example.com',
+        'created_session_id' => $auth['session']->id,
+    ]);
+    Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => Verification::STRATEGY_PASSKEY,
+        'status' => Verification::STATUS_UNVERIFIED,
+        'expire_at' => now()->addMinutes(10),
+    ]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodePasskeyClaims($minted['jwt']);
+
+    expect($claims['pkv'])->toBeFalse();
+});


### PR DESCRIPTION
Closes #189

Two compact claims so consumers branch on passkey state without a `/v1/me` round-trip. The v0.5 `sdk-php` SP-3 already parses both defensively (silently defaults to `false` / `0`), so `sdk-php-laravel` SPL-1's `RequiresPasskey` middleware + `@authnHasPasskey` Blade directive were no-ops until this lands.

## Summary

- `pkv` (bool) — `true` when the SignInAttempt that produced this Session has a `passkey`-strategy Verification in `verified` status. Joined via `SignInAttempt.created_session_id = Session.id`.
- `pkc` (int) — snapshot of `User.passkey_count` (verified-only) at JWT mint time. Always emitted, defaults to `0` to keep TS narrowing branch-free.

## Test plan

- [x] `php artisan test tests/Feature/Services/Sessions/SessionTokenIssuerPasskeyClaimsTest.php` — 5 / 5 passing. Covers the four-quadrant matrix:
  - No passkey + no attempt → `pkv: false`, `pkc: 0`.
  - Verified passkey + non-passkey strategy attempt → `pkv: false`.
  - Verified passkey + verified passkey attempt → `pkv: true`.
  - Verified passkey + unverified passkey attempt → `pkv: false`.
  - `pkc` reflects the verified-only count.
- [x] Full suite — 781 / 781 passing.
- [x] `vendor/bin/pint --test` clean.

## SDK alignment

- `sdk-php` SP-3 (#35 — already merged on `sdk-php`) parses both keys with safe defaults; `RequiresPasskey` will start gating real requests as soon as this merges.
- `sdk-node` SN-1 (in flight on `javascript-impl`) mirrors the same parsing.
- No openapi spec change needed — JWT claims are an internal contract; the SDKs document the claim shape inline.