### PR TITLE
Add EnterpriseConnection + EnterpriseAccount models (AU-1)

### DIFF
--- a/app/Models/EnterpriseAccount.php
+++ b/app/Models/EnterpriseAccount.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Database\Factories\EnterpriseAccountFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * One row per (User, EnterpriseConnection, provider_user_id). `id_token`
+ * column holds the encrypted OIDC ID token when present; SAML connections
+ * leave it null. Unique on `(enterprise_connection_id, provider_user_id)`
+ * prevents the same IdP subject linking twice.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $user_id
+ * @property string $enterprise_connection_id
+ * @property string $provider_user_id
+ * @property ?string $email_address
+ * @property bool $verified
+ * @property array<string, mixed> $public_metadata
+ * @property ?string $id_token
+ * @property \DateTimeInterface $linked_at
+ * @property ?\DateTimeInterface $last_signed_in_at
+ * @property ?\DateTimeInterface $removed_at
+ */
+class EnterpriseAccount extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+    use SoftDeletes;
+
+    public const DELETED_AT = 'removed_at';
+
+    protected string $idPrefix = 'entacc_';
+
+    protected $fillable = [
+        'environment_id',
+        'user_id',
+        'enterprise_connection_id',
+        'provider_user_id',
+        'email_address',
+        'verified',
+        'public_metadata',
+        'id_token',
+        'linked_at',
+        'last_signed_in_at',
+    ];
+
+    protected $hidden = [
+        'id_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'verified' => 'boolean',
+            'public_metadata' => 'array',
+            'id_token' => 'encrypted',
+            'linked_at' => 'immutable_datetime',
+            'last_signed_in_at' => 'immutable_datetime',
+            'removed_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    protected static function newFactory(): EnterpriseAccountFactory
+    {
+        return EnterpriseAccountFactory::new();
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function enterpriseConnection(): BelongsTo
+    {
+        return $this->belongsTo(EnterpriseConnection::class);
+    }
+}

--- a/app/Models/EnterpriseConnection.php
+++ b/app/Models/EnterpriseConnection.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Database\Factories\EnterpriseConnectionFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * v0.6 enterprise IdP connection. Single shape carries both SAML and OIDC
+ * (`protocol` discriminator). Instance-wide when `organization_id` is null;
+ * org-scoped otherwise. `domains[]` is the list of verified domains routed
+ * to this connection for domain-based sign-in dispatch.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $protocol
+ * @property string $name
+ * @property bool $enabled
+ * @property ?string $organization_id
+ * @property array<int, string> $domains
+ * @property ?string $default_role
+ * @property array<string, mixed> $attribute_mapping
+ * @property ?string $saml_idp_entity_id
+ * @property ?string $saml_sso_url
+ * @property ?string $saml_idp_certificate
+ * @property ?string $saml_signing_algorithm
+ * @property ?string $saml_audience_uri
+ * @property ?string $saml_signing_key
+ * @property ?string $oidc_issuer
+ * @property ?string $oidc_discovery_endpoint
+ * @property ?string $oidc_client_id
+ * @property ?string $oidc_client_secret
+ * @property array<int, string> $oidc_scopes
+ * @property ?\DateTimeInterface $removed_at
+ */
+class EnterpriseConnection extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+    use SoftDeletes;
+
+    public const PROTOCOL_SAML = 'saml';
+
+    public const PROTOCOL_OIDC = 'oidc';
+
+    public const PROTOCOLS = [
+        self::PROTOCOL_SAML,
+        self::PROTOCOL_OIDC,
+    ];
+
+    public const DELETED_AT = 'removed_at';
+
+    protected string $idPrefix = 'entcon_';
+
+    protected $fillable = [
+        'environment_id',
+        'protocol',
+        'name',
+        'enabled',
+        'organization_id',
+        'domains',
+        'default_role',
+        'attribute_mapping',
+        'saml_idp_entity_id',
+        'saml_sso_url',
+        'saml_idp_certificate',
+        'saml_signing_algorithm',
+        'saml_audience_uri',
+        'saml_signing_key',
+        'oidc_issuer',
+        'oidc_discovery_endpoint',
+        'oidc_client_id',
+        'oidc_client_secret',
+        'oidc_scopes',
+    ];
+
+    protected $hidden = [
+        'saml_signing_key',
+        'oidc_client_secret',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+            'domains' => 'array',
+            'attribute_mapping' => 'array',
+            'oidc_scopes' => 'array',
+            'saml_signing_key' => 'encrypted',
+            'oidc_client_secret' => 'encrypted',
+            'removed_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    protected static function newFactory(): EnterpriseConnectionFactory
+    {
+        return EnterpriseConnectionFactory::new();
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function enterpriseAccounts(): HasMany
+    {
+        return $this->hasMany(EnterpriseAccount::class);
+    }
+
+    public function isSaml(): bool
+    {
+        return $this->protocol === self::PROTOCOL_SAML;
+    }
+
+    public function isOidc(): bool
+    {
+        return $this->protocol === self::PROTOCOL_OIDC;
+    }
+
+    /**
+     * @param  Builder<EnterpriseConnection>  $query
+     * @return Builder<EnterpriseConnection>
+     */
+    public function scopeEnabled(Builder $query): Builder
+    {
+        return $query->where('enabled', true);
+    }
+
+    /**
+     * @param  Builder<EnterpriseConnection>  $query
+     * @return Builder<EnterpriseConnection>
+     */
+    public function scopeInstanceWide(Builder $query): Builder
+    {
+        return $query->whereNull('organization_id');
+    }
+}

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -99,6 +99,11 @@ class Organization extends Model
         return $this->hasMany(OrganizationDomain::class);
     }
 
+    public function enterpriseConnections(): HasMany
+    {
+        return $this->hasMany(EnterpriseConnection::class);
+    }
+
     public function membershipRequests(): HasMany
     {
         return $this->hasMany(OrganizationMembershipRequest::class);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -149,6 +149,11 @@ class User extends Model implements AuthenticatableContract
         return $this->hasMany(ExternalAccount::class);
     }
 
+    public function enterpriseAccounts(): HasMany
+    {
+        return $this->hasMany(EnterpriseAccount::class);
+    }
+
     public function passkeys(): HasMany
     {
         return $this->hasMany(Passkey::class);

--- a/app/Models/Verification.php
+++ b/app/Models/Verification.php
@@ -85,6 +85,10 @@ class Verification extends Model
 
     public const STRATEGY_PASSKEY = 'passkey';
 
+    public const STRATEGY_ENTERPRISE_SSO = 'enterprise_sso';
+
+    public const STRATEGY_SAML = 'saml';
+
     public const STRATEGIES = [
         self::STRATEGY_PASSWORD,
         self::STRATEGY_EMAIL_CODE,
@@ -96,6 +100,8 @@ class Verification extends Model
         self::STRATEGY_BACKUP_CODE,
         self::STRATEGY_PHONE_CODE,
         self::STRATEGY_PASSKEY,
+        self::STRATEGY_ENTERPRISE_SSO,
+        self::STRATEGY_SAML,
     ];
 
     /**

--- a/database/factories/EnterpriseAccountFactory.php
+++ b/database/factories/EnterpriseAccountFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\EnterpriseAccount;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EnterpriseAccount>
+ */
+class EnterpriseAccountFactory extends Factory
+{
+    /**
+     * @var class-string<EnterpriseAccount>
+     */
+    protected $model = EnterpriseAccount::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            // environment_id, user_id, enterprise_connection_id supplied by caller.
+            'provider_user_id' => 'idp-'.$this->faker->bothify('????????????????'),
+            'email_address' => $this->faker->safeEmail(),
+            'verified' => true,
+            'public_metadata' => [],
+            'id_token' => null,
+            'linked_at' => now(),
+            'last_signed_in_at' => now(),
+        ];
+    }
+}

--- a/database/factories/EnterpriseConnectionFactory.php
+++ b/database/factories/EnterpriseConnectionFactory.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\EnterpriseConnection;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EnterpriseConnection>
+ */
+class EnterpriseConnectionFactory extends Factory
+{
+    /**
+     * @var class-string<EnterpriseConnection>
+     */
+    protected $model = EnterpriseConnection::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            // environment_id supplied by the caller — Environment has no factory.
+            'protocol' => EnterpriseConnection::PROTOCOL_SAML,
+            'name' => $this->faker->company().' SSO',
+            'enabled' => true,
+            'organization_id' => null,
+            'domains' => [],
+            'default_role' => null,
+            'attribute_mapping' => [],
+            'saml_idp_entity_id' => 'https://idp.example.com/saml/metadata',
+            'saml_sso_url' => 'https://idp.example.com/saml/sso',
+            'saml_idp_certificate' => "-----BEGIN CERTIFICATE-----\nMIIBfake\n-----END CERTIFICATE-----",
+            'saml_signing_algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+            'saml_audience_uri' => null,
+            'saml_signing_key' => null,
+            'oidc_issuer' => null,
+            'oidc_discovery_endpoint' => null,
+            'oidc_client_id' => null,
+            'oidc_client_secret' => null,
+            'oidc_scopes' => [],
+        ];
+    }
+
+    public function oidc(): self
+    {
+        return $this->state(fn (array $attributes): array => [
+            'protocol' => EnterpriseConnection::PROTOCOL_OIDC,
+            'saml_idp_entity_id' => null,
+            'saml_sso_url' => null,
+            'saml_idp_certificate' => null,
+            'saml_signing_algorithm' => null,
+            'oidc_issuer' => 'https://idp.example.com',
+            'oidc_discovery_endpoint' => 'https://idp.example.com/.well-known/openid-configuration',
+            'oidc_client_id' => 'client-'.$this->faker->bothify('????????'),
+            'oidc_client_secret' => 'secret-'.$this->faker->bothify('????????????'),
+            'oidc_scopes' => ['openid', 'email', 'profile'],
+        ]);
+    }
+
+    public function disabled(): self
+    {
+        return $this->state(fn (array $attributes): array => ['enabled' => false]);
+    }
+}

--- a/database/migrations/2026_05_12_000000_create_enterprise_connections_and_accounts.php
+++ b/database/migrations/2026_05_12_000000_create_enterprise_connections_and_accounts.php
@@ -1,0 +1,81 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * v0.6 Enterprise SSO spine. EnterpriseConnection rows model one IdP per
+ * (SAML or OIDC) — instance-wide when `organization_id` is null, per-org
+ * otherwise. EnterpriseAccount rows link a User to a successful sign-in
+ * via one of those connections.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('enterprise_connections', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('protocol', 8);
+            $table->string('name');
+            $table->boolean('enabled')->default(true);
+            $table->string('organization_id', 64)->nullable();
+
+            $table->jsonb('domains')->default(json_encode([]));
+            $table->string('default_role')->nullable();
+            $table->jsonb('attribute_mapping')->default(json_encode((object) []));
+
+            $table->string('saml_idp_entity_id')->nullable();
+            $table->string('saml_sso_url')->nullable();
+            $table->text('saml_idp_certificate')->nullable();
+            $table->string('saml_signing_algorithm', 64)->nullable();
+            $table->string('saml_audience_uri')->nullable();
+            $table->text('saml_signing_key')->nullable();
+
+            $table->string('oidc_issuer')->nullable();
+            $table->string('oidc_discovery_endpoint')->nullable();
+            $table->string('oidc_client_id')->nullable();
+            $table->text('oidc_client_secret')->nullable();
+            $table->jsonb('oidc_scopes')->default(json_encode([]));
+
+            $table->timestamps();
+            $table->softDeletes('removed_at');
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+            $table->index(['organization_id', 'enabled']);
+            $table->index(['environment_id', 'protocol']);
+        });
+
+        Schema::create('enterprise_accounts', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('user_id', 64);
+            $table->string('enterprise_connection_id', 64);
+
+            $table->string('provider_user_id');
+            $table->string('email_address')->nullable();
+            $table->boolean('verified')->default(false);
+            $table->jsonb('public_metadata')->default(json_encode((object) []));
+            $table->text('id_token')->nullable();
+
+            $table->timestamp('linked_at');
+            $table->timestamp('last_signed_in_at')->nullable();
+            $table->timestamps();
+            $table->softDeletes('removed_at');
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->foreign('enterprise_connection_id')->references('id')->on('enterprise_connections')->cascadeOnDelete();
+            $table->unique(['enterprise_connection_id', 'provider_user_id']);
+            $table->index(['user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('enterprise_accounts');
+        Schema::dropIfExists('enterprise_connections');
+    }
+};

--- a/tests/Feature/Models/EnterpriseConnectionTest.php
+++ b/tests/Feature/Models/EnterpriseConnectionTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\EnterpriseAccount;
+use App\Models\EnterpriseConnection;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Verification;
+use Illuminate\Database\QueryException;
+
+function makeEnvForEnterprise(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('mints an entcon_ prefixed id and casts JSON columns to arrays', function (): void {
+    $env = makeEnvForEnterprise();
+
+    $conn = EnterpriseConnection::factory()->create([
+        'environment_id' => $env->id,
+        'domains' => ['acme.test', 'corp.acme.test'],
+        'attribute_mapping' => ['email' => 'email_address'],
+    ]);
+
+    expect($conn->id)->toStartWith('entcon_');
+    expect($conn->domains)->toBe(['acme.test', 'corp.acme.test']);
+    expect($conn->attribute_mapping)->toBe(['email' => 'email_address']);
+    expect($conn->enabled)->toBeTrue();
+    expect($conn->isSaml())->toBeTrue();
+    expect($conn->isOidc())->toBeFalse();
+});
+
+it('encrypts saml_signing_key + oidc_client_secret and hides them from arrays', function (): void {
+    $env = makeEnvForEnterprise();
+
+    $conn = EnterpriseConnection::factory()->oidc()->create([
+        'environment_id' => $env->id,
+        'oidc_client_secret' => 'super-secret-oidc',
+        'saml_signing_key' => "-----BEGIN PRIVATE KEY-----\nMIIBfake\n-----END PRIVATE KEY-----",
+    ]);
+
+    expect($conn->oidc_client_secret)->toBe('super-secret-oidc');
+    expect($conn->saml_signing_key)->toContain('BEGIN PRIVATE KEY');
+
+    $rawOidc = (string) DB::table('enterprise_connections')->where('id', $conn->id)->value('oidc_client_secret');
+    expect($rawOidc)->not->toBe('super-secret-oidc');
+    expect(strlen($rawOidc))->toBeGreaterThan(20);
+
+    $arr = $conn->toArray();
+    expect(array_key_exists('oidc_client_secret', $arr))->toBeFalse();
+    expect(array_key_exists('saml_signing_key', $arr))->toBeFalse();
+});
+
+it('belongs to an Organization when org-scoped, null when instance-wide', function (): void {
+    $env = makeEnvForEnterprise();
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => 'acme']);
+
+    $orgConn = EnterpriseConnection::factory()->create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+    ]);
+    $instanceConn = EnterpriseConnection::factory()->create([
+        'environment_id' => $env->id,
+        'organization_id' => null,
+    ]);
+
+    expect($orgConn->organization?->id)->toBe($org->id);
+    expect($instanceConn->organization)->toBeNull();
+    expect(EnterpriseConnection::query()->instanceWide()->pluck('id')->all())->toBe([$instanceConn->id]);
+    expect($org->refresh()->enterpriseConnections->pluck('id')->all())->toBe([$orgConn->id]);
+});
+
+it('cascades enterprise_connections deletion when the parent organization is deleted', function (): void {
+    $env = makeEnvForEnterprise();
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => 'acme']);
+    $conn = EnterpriseConnection::factory()->create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+    ]);
+
+    DB::table('organizations')->where('id', $org->id)->delete();
+
+    expect(DB::table('enterprise_connections')->where('id', $conn->id)->exists())->toBeFalse();
+});
+
+it('soft-deletes via removed_at and the enabled() scope filters disabled rows', function (): void {
+    $env = makeEnvForEnterprise();
+    $enabled = EnterpriseConnection::factory()->create(['environment_id' => $env->id]);
+    EnterpriseConnection::factory()->disabled()->create(['environment_id' => $env->id]);
+    $removed = EnterpriseConnection::factory()->create(['environment_id' => $env->id]);
+    $removed->delete();
+
+    expect(EnterpriseConnection::query()->enabled()->pluck('id')->all())->toBe([$enabled->id]);
+    expect(EnterpriseConnection::withTrashed()->find($removed->id)?->removed_at)->not->toBeNull();
+});
+
+it('mints an entacc_ prefixed id, encrypts id_token, and exposes user + connection relations', function (): void {
+    $env = makeEnvForEnterprise();
+    $user = User::create(['environment_id' => $env->id]);
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $env->id]);
+
+    $account = EnterpriseAccount::factory()->create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'enterprise_connection_id' => $conn->id,
+        'id_token' => 'cleartext-id-token',
+    ]);
+
+    expect($account->id)->toStartWith('entacc_');
+    expect($account->id_token)->toBe('cleartext-id-token');
+    expect($account->enterpriseConnection->id)->toBe($conn->id);
+    expect($account->user->id)->toBe($user->id);
+    expect($user->refresh()->enterpriseAccounts->pluck('id')->all())->toBe([$account->id]);
+    expect(array_key_exists('id_token', $account->toArray()))->toBeFalse();
+
+    $raw = (string) DB::table('enterprise_accounts')->where('id', $account->id)->value('id_token');
+    expect($raw)->not->toBe('cleartext-id-token');
+});
+
+it('enforces unique (enterprise_connection_id, provider_user_id) on EnterpriseAccount', function (): void {
+    $env = makeEnvForEnterprise();
+    $user = User::create(['environment_id' => $env->id]);
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $env->id]);
+
+    EnterpriseAccount::factory()->create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'enterprise_connection_id' => $conn->id,
+        'provider_user_id' => 'subject-1',
+    ]);
+
+    expect(fn () => EnterpriseAccount::factory()->create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'enterprise_connection_id' => $conn->id,
+        'provider_user_id' => 'subject-1',
+    ]))->toThrow(QueryException::class);
+});
+
+it('cascades enterprise_accounts when the parent connection is deleted hard', function (): void {
+    $env = makeEnvForEnterprise();
+    $user = User::create(['environment_id' => $env->id]);
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $env->id]);
+    $account = EnterpriseAccount::factory()->create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'enterprise_connection_id' => $conn->id,
+    ]);
+
+    DB::table('enterprise_connections')->where('id', $conn->id)->delete();
+
+    expect(DB::table('enterprise_accounts')->where('id', $account->id)->exists())->toBeFalse();
+});
+
+it('extends Verification::strategies() with enterprise_sso and saml', function (): void {
+    expect(Verification::strategies())->toContain(Verification::STRATEGY_ENTERPRISE_SSO);
+    expect(Verification::strategies())->toContain(Verification::STRATEGY_SAML);
+    expect(Verification::isValidStrategy('enterprise_sso'))->toBeTrue();
+    expect(Verification::isValidStrategy('saml'))->toBeTrue();
+});


### PR DESCRIPTION
Closes #192.

## Summary

- Adds `EnterpriseConnection` model (`entcon_` prefix). Single shape carries both `protocol: saml` and `protocol: oidc`. Encrypts `saml_signing_key` + `oidc_client_secret` at rest; hides both from array serialization. JSON columns for `domains[]`, `attribute_mapping`, `oidc_scopes[]`. Soft-deletes via `removed_at`. Scopes: `enabled()`, `instanceWide()`. FK to `organizations` is nullable (instance-wide when null).
- Adds `EnterpriseAccount` model (`entacc_` prefix). Per-user link to a connection. Encrypts the OIDC `id_token` blob. Unique on `(enterprise_connection_id, provider_user_id)`.
- Extends `Verification::STRATEGIES` with `enterprise_sso` + `saml`.
- Adds `User->enterpriseAccounts()` and `Organization->enterpriseConnections()` relations.
- Adds factories for both models (including `oidc()` + `disabled()` states).
- Pest coverage: id prefixes, JSON casts, secret encryption + hiding, FK cascades, soft-delete + scope behaviour, unique constraints, Verification strategy enum.

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `php artisan test tests/Feature/Models/EnterpriseConnectionTest.php` — 9 passed
- [x] `php artisan migrate` clean on a fresh DB

## Dependencies

- OA-1, OA-2 (spec) — already merged.

## Out of scope

- SAML library wiring (AU-3).
- OIDC engine wiring (AU-4).
- BAPI/FAPI endpoints (AU-5, AU-6).