### PR TITLE
Add ScimToken + ScimAttributeMapping models (AU-2)

### DIFF
--- a/app/Models/ScimAttributeMapping.php
+++ b/app/Models/ScimAttributeMapping.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use App\Scim\DefaultAttributeMappings;
+use Database\Factories\ScimAttributeMappingFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * One row per per-org override of a SCIM <-> internal attribute mapping.
+ * Defaults are NOT stored — they live in `DefaultAttributeMappings` and
+ * are merged at read time via `resolveFor()`. Storing only overrides keeps
+ * the table small and lets us evolve defaults without backfill.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $organization_id
+ * @property ?string $enterprise_connection_id
+ * @property string $source_attribute
+ * @property string $target_attribute
+ * @property ?string $transform
+ */
+class ScimAttributeMapping extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    protected string $idPrefix = 'scimm_';
+
+    protected $fillable = [
+        'environment_id',
+        'organization_id',
+        'enterprise_connection_id',
+        'source_attribute',
+        'target_attribute',
+        'transform',
+    ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    protected static function newFactory(): ScimAttributeMappingFactory
+    {
+        return ScimAttributeMappingFactory::new();
+    }
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function enterpriseConnection(): BelongsTo
+    {
+        return $this->belongsTo(EnterpriseConnection::class);
+    }
+
+    /**
+     * Effective mapping for `$organization` as a flat
+     * `[source_attribute => ['target' => string, 'transform' => ?string]]`
+     * map. Built by overlaying the org's stored overrides on top of
+     * `DefaultAttributeMappings::DEFAULTS`. Per-connection rows scope
+     * further — `null` connection means "any connection in the org".
+     *
+     * @return array<string, array{target: string, transform: ?string}>
+     */
+    public static function resolveFor(Organization $organization, ?EnterpriseConnection $connection = null): array
+    {
+        $resolved = [];
+        foreach (DefaultAttributeMappings::DEFAULTS as $source => $target) {
+            $resolved[$source] = ['target' => $target, 'transform' => null];
+        }
+
+        $query = self::query()->where('organization_id', $organization->id);
+        if ($connection !== null) {
+            $query->where(function ($q) use ($connection): void {
+                $q->whereNull('enterprise_connection_id')
+                    ->orWhere('enterprise_connection_id', $connection->id);
+            });
+        }
+
+        foreach ($query->get() as $row) {
+            $resolved[$row->source_attribute] = [
+                'target' => $row->target_attribute,
+                'transform' => $row->transform,
+            ];
+        }
+
+        return $resolved;
+    }
+}

--- a/app/Models/ScimToken.php
+++ b/app/Models/ScimToken.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use App\Support\Base64Url;
+use Database\Factories\ScimTokenFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * SCIM bearer token. Plaintext (`scim_<base64url>`) is shown once at
+ * issue time; only `hashed_token` (sha256 of the plaintext) is persisted.
+ * `prefix` is the visible leading slug used in the dashboard / SDKs
+ * ("scim_XX…") to help operators distinguish rows without revealing the
+ * full secret.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $hashed_token
+ * @property string $prefix
+ * @property ?string $organization_id
+ * @property ?string $enterprise_connection_id
+ * @property string $name
+ * @property string $created_by_user_id
+ * @property ?\DateTimeInterface $last_used_at
+ * @property ?\DateTimeInterface $expires_at
+ * @property ?\DateTimeInterface $revoked_at
+ */
+class ScimToken extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    public const TOKEN_PREFIX = 'scim_';
+
+    public const PLAINTEXT_BYTES = 32;
+
+    protected string $idPrefix = 'scimt_';
+
+    protected $fillable = [
+        'environment_id',
+        'hashed_token',
+        'prefix',
+        'organization_id',
+        'enterprise_connection_id',
+        'name',
+        'created_by_user_id',
+        'last_used_at',
+        'expires_at',
+        'revoked_at',
+    ];
+
+    protected $hidden = [
+        'hashed_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'last_used_at' => 'immutable_datetime',
+            'expires_at' => 'immutable_datetime',
+            'revoked_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    protected static function newFactory(): ScimTokenFactory
+    {
+        return ScimTokenFactory::new();
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function enterpriseConnection(): BelongsTo
+    {
+        return $this->belongsTo(EnterpriseConnection::class);
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+
+    /**
+     * Generate a fresh plaintext token and return both it and its sha256 hash.
+     * Callers persist the hash + prefix; the plaintext is shown to the user
+     * exactly once at issue time.
+     *
+     * @return array{plaintext: string, hash: string, prefix: string}
+     */
+    public static function mintPlaintext(): array
+    {
+        $body = Base64Url::encode(random_bytes(self::PLAINTEXT_BYTES));
+        $plaintext = self::TOKEN_PREFIX.$body;
+
+        return [
+            'plaintext' => $plaintext,
+            'hash' => hash('sha256', $plaintext, true),
+            'prefix' => substr($plaintext, 0, 12),
+        ];
+    }
+
+    /**
+     * Locate the (env-scoped) ScimToken row matching the supplied plaintext
+     * bearer. Returns null when no row matches, when the row was revoked,
+     * or when the row's `expires_at` is in the past.
+     */
+    public static function verify(string $plaintext): ?self
+    {
+        if (! str_starts_with($plaintext, self::TOKEN_PREFIX)) {
+            return null;
+        }
+
+        $hash = hash('sha256', $plaintext, true);
+        $row = self::query()->where('hashed_token', $hash)->first();
+        if ($row === null) {
+            return null;
+        }
+
+        return $row->isUsable() ? $row : null;
+    }
+
+    public function isUsable(): bool
+    {
+        if ($this->revoked_at !== null) {
+            return false;
+        }
+
+        return $this->expires_at === null || ! $this->expires_at->isPast();
+    }
+
+    public function revoke(): void
+    {
+        if ($this->revoked_at === null) {
+            $this->revoked_at = now();
+            $this->save();
+        }
+    }
+
+    /**
+     * @param  Builder<ScimToken>  $query
+     * @return Builder<ScimToken>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->whereNull('revoked_at')->where(function (Builder $q): void {
+            $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
+        });
+    }
+}

--- a/app/Scim/DefaultAttributeMappings.php
+++ b/app/Scim/DefaultAttributeMappings.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scim;
+
+/**
+ * Canonical SCIM 2.0 → internal User attribute defaults. `ScimAttributeMapping`
+ * rows override these per-org; the merge happens at read time so we can ship
+ * new defaults without backfill.
+ */
+final class DefaultAttributeMappings
+{
+    /**
+     * Map of SCIM source attribute path → internal User column.
+     *
+     * @var array<string, string>
+     */
+    public const DEFAULTS = [
+        'userName' => 'email_address',
+        'name.givenName' => 'first_name',
+        'name.familyName' => 'last_name',
+        'emails[primary eq true].value' => 'email_address',
+        'externalId' => 'external_id',
+        'displayName' => 'username',
+        'active' => 'banned',
+        'locale' => 'locale',
+    ];
+}

--- a/database/factories/ScimAttributeMappingFactory.php
+++ b/database/factories/ScimAttributeMappingFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\ScimAttributeMapping;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ScimAttributeMapping>
+ */
+class ScimAttributeMappingFactory extends Factory
+{
+    /**
+     * @var class-string<ScimAttributeMapping>
+     */
+    protected $model = ScimAttributeMapping::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            // environment_id + organization_id supplied by caller.
+            'enterprise_connection_id' => null,
+            'source_attribute' => 'userName',
+            'target_attribute' => 'email_address',
+            'transform' => null,
+        ];
+    }
+}

--- a/database/factories/ScimTokenFactory.php
+++ b/database/factories/ScimTokenFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\ScimToken;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ScimToken>
+ */
+class ScimTokenFactory extends Factory
+{
+    /**
+     * @var class-string<ScimToken>
+     */
+    protected $model = ScimToken::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $minted = ScimToken::mintPlaintext();
+
+        return [
+            // environment_id + created_by_user_id supplied by caller.
+            'hashed_token' => $minted['hash'],
+            'prefix' => $minted['prefix'],
+            'organization_id' => null,
+            'enterprise_connection_id' => null,
+            'name' => 'CI sync token',
+            'last_used_at' => null,
+            'expires_at' => null,
+            'revoked_at' => null,
+        ];
+    }
+
+    public function revoked(): self
+    {
+        return $this->state(fn (array $attributes): array => ['revoked_at' => now()]);
+    }
+
+    public function expired(): self
+    {
+        return $this->state(fn (array $attributes): array => ['expires_at' => now()->subDay()]);
+    }
+}

--- a/database/migrations/2026_05_12_000001_create_scim_tokens_and_attribute_mappings.php
+++ b/database/migrations/2026_05_12_000001_create_scim_tokens_and_attribute_mappings.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * v0.6 SCIM 2.0 directory sync. `scim_tokens` stores rotating bearer rows
+ * (one-time plaintext at create, hash on disk). `scim_attribute_mappings`
+ * stores per-org overrides — defaults live in app/Scim/DefaultAttributeMappings.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('scim_tokens', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->binary('hashed_token');
+            $table->string('prefix', 16);
+
+            $table->string('organization_id', 64)->nullable();
+            $table->string('enterprise_connection_id', 64)->nullable();
+            $table->string('name');
+            $table->string('created_by_user_id', 64);
+
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('revoked_at')->nullable();
+
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+            $table->foreign('enterprise_connection_id')->references('id')->on('enterprise_connections')->cascadeOnDelete();
+            $table->foreign('created_by_user_id')->references('id')->on('users')->cascadeOnDelete();
+
+            $table->unique('hashed_token');
+            $table->index(['organization_id', 'revoked_at']);
+        });
+
+        Schema::create('scim_attribute_mappings', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('organization_id', 64);
+            $table->string('enterprise_connection_id', 64)->nullable();
+
+            $table->string('source_attribute');
+            $table->string('target_attribute');
+            $table->text('transform')->nullable();
+
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+            $table->foreign('enterprise_connection_id')->references('id')->on('enterprise_connections')->cascadeOnDelete();
+
+            $table->unique(['organization_id', 'enterprise_connection_id', 'source_attribute'], 'scim_mappings_unique_source');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('scim_attribute_mappings');
+        Schema::dropIfExists('scim_tokens');
+    }
+};

--- a/tests/Feature/Models/ScimTokenTest.php
+++ b/tests/Feature/Models/ScimTokenTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\ScimAttributeMapping;
+use App\Models\ScimToken;
+use App\Models\User;
+use App\Scim\DefaultAttributeMappings;
+
+function makeEnvForScim(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('mints a plaintext scim_ token with a 32-byte body and a hash separable from the plaintext', function (): void {
+    $minted = ScimToken::mintPlaintext();
+
+    expect($minted['plaintext'])->toStartWith('scim_');
+    expect(strlen($minted['plaintext']))->toBeGreaterThan(40); // scim_ + base64url(32)
+    expect(strlen($minted['hash']))->toBe(32); // raw sha256
+    expect($minted['prefix'])->toStartWith('scim_');
+    expect(strlen($minted['prefix']))->toBe(12);
+    expect(hash('sha256', $minted['plaintext'], true))->toBe($minted['hash']);
+});
+
+it('persists the hash + prefix and hides hashed_token from arrays', function (): void {
+    $env = makeEnvForScim();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $token = ScimToken::factory()->create([
+        'environment_id' => $env->id,
+        'created_by_user_id' => $user->id,
+    ]);
+
+    expect($token->id)->toStartWith('scimt_');
+    expect($token->prefix)->toStartWith('scim_');
+    expect(array_key_exists('hashed_token', $token->toArray()))->toBeFalse();
+});
+
+it('verifies a freshly-minted plaintext and rejects revoked/expired/unknown tokens', function (): void {
+    $env = makeEnvForScim();
+    app()->instance(Environment::class, $env);
+    $user = User::create(['environment_id' => $env->id]);
+
+    $minted = ScimToken::mintPlaintext();
+    $row = ScimToken::create([
+        'environment_id' => $env->id,
+        'hashed_token' => $minted['hash'],
+        'prefix' => $minted['prefix'],
+        'name' => 't',
+        'created_by_user_id' => $user->id,
+    ]);
+
+    expect(ScimToken::verify($minted['plaintext'])?->id)->toBe($row->id);
+    expect(ScimToken::verify('scim_unknown-value-x'))->toBeNull();
+    expect(ScimToken::verify('not-a-scim-token'))->toBeNull();
+
+    $row->revoke();
+    expect(ScimToken::verify($minted['plaintext']))->toBeNull();
+    expect($row->fresh()->revoked_at)->not->toBeNull();
+    app()->forgetInstance(Environment::class);
+});
+
+it('treats expires_at in the past as unusable', function (): void {
+    $env = makeEnvForScim();
+    app()->instance(Environment::class, $env);
+    $user = User::create(['environment_id' => $env->id]);
+
+    $minted = ScimToken::mintPlaintext();
+    ScimToken::create([
+        'environment_id' => $env->id,
+        'hashed_token' => $minted['hash'],
+        'prefix' => $minted['prefix'],
+        'name' => 't',
+        'created_by_user_id' => $user->id,
+        'expires_at' => now()->subDay(),
+    ]);
+
+    expect(ScimToken::verify($minted['plaintext']))->toBeNull();
+    app()->forgetInstance(Environment::class);
+});
+
+it('active() scope returns only non-revoked, non-expired rows', function (): void {
+    $env = makeEnvForScim();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $active = ScimToken::factory()->create([
+        'environment_id' => $env->id,
+        'created_by_user_id' => $user->id,
+    ]);
+    ScimToken::factory()->revoked()->create([
+        'environment_id' => $env->id,
+        'created_by_user_id' => $user->id,
+    ]);
+    ScimToken::factory()->expired()->create([
+        'environment_id' => $env->id,
+        'created_by_user_id' => $user->id,
+    ]);
+
+    expect(ScimToken::query()->active()->pluck('id')->all())->toBe([$active->id]);
+});
+
+it('resolves SCIM mappings as defaults merged with per-org overrides', function (): void {
+    $env = makeEnvForScim();
+    $user = User::create(['environment_id' => $env->id]);
+    $org = Organization::create([
+        'environment_id' => $env->id,
+        'name' => 'Acme',
+        'slug' => 'acme',
+    ]);
+
+    ScimAttributeMapping::factory()->create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'source_attribute' => 'userName',
+        'target_attribute' => 'username',
+        'transform' => 'lower(value)',
+    ]);
+    ScimAttributeMapping::factory()->create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'source_attribute' => 'custom.dept',
+        'target_attribute' => 'public_metadata.dept',
+    ]);
+
+    $resolved = ScimAttributeMapping::resolveFor($org);
+
+    expect($resolved['userName'])->toBe(['target' => 'username', 'transform' => 'lower(value)']);
+    expect($resolved['custom.dept'])->toBe(['target' => 'public_metadata.dept', 'transform' => null]);
+    expect($resolved['name.givenName'])->toBe([
+        'target' => DefaultAttributeMappings::DEFAULTS['name.givenName'],
+        'transform' => null,
+    ]);
+});


### PR DESCRIPTION
Closes #193.

> Base branch is `feat/au-1-enterprise-connection-models` because the SCIM token table references `enterprise_connections` via nullable FK. Will rebase onto `main` after #210 lands.

## Summary

- `ScimToken` (`scimt_` prefix). Plaintext (`scim_<base64url>`) shown once at issue; only sha256 hash + visible 12-char prefix persisted. Helpers: `mintPlaintext()`, `verify()`, `revoke()`, `active()` scope.
- `ScimAttributeMapping` (`scimm_` prefix). Stores only per-org overrides. Defaults live in `App\Scim\DefaultAttributeMappings::DEFAULTS` and merge at read time via `resolveFor()`.
- Pest covers: mint shape (length/hash/prefix), persist + hidden field, verify roundtrip + revoked/expired rejection, active scope, default + override merge.

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `php artisan test tests/Feature/Models/ScimTokenTest.php` — 6 passed
- [x] Together with #210 — 15 passed

## Dependencies

- Code references `EnterpriseConnection` only via a nullable FK; PR #210 (AU-1) introduces that table.

## Out of scope

- SCIM endpoints (AU-9, AU-10).