### PR TITLE
Add transferable sign-up <-> sign-in handoff (AU-11)

### DIFF
--- a/app/Http/Controllers/Fapi/SignInController.php
+++ b/app/Http/Controllers/Fapi/SignInController.php
@@ -116,12 +116,43 @@ final class SignInController
             }
 
             if (is_string($attempt->identifier)) {
-                $attempt->status = SignInAttempt::STATUS_NEEDS_FIRST_FACTOR;
+                if ($this->shouldTransferToSignUp($env, $attempt->identifier)) {
+                    $attempt->status = SignInAttempt::STATUS_TRANSFERABLE;
+                } else {
+                    $attempt->status = SignInAttempt::STATUS_NEEDS_FIRST_FACTOR;
+                }
                 $attempt->save();
             }
 
             return $this->envelope($client, $attempt->fresh(), 200, null, $createdClient);
         });
+    }
+
+    /**
+     * Whether a SignIn for `$identifier` should flip to `transferable` so
+     * the SDK can bounce to sign-up. True when the identifier does not
+     * match any existing User in the env AND the environment's
+     * `signup_mode` is open (`public` or `restricted`).
+     *
+     * Sign-up `restricted` mode still emits a transferable: the SignUp
+     * controller will gate the actual creation on the invitation policy.
+     */
+    private function shouldTransferToSignUp(Environment $env, string $identifier): bool
+    {
+        $email = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('email_address', strtolower($identifier))
+            ->exists();
+        if ($email) {
+            return false;
+        }
+
+        return in_array(
+            $env->signup_mode,
+            [Environment::SIGNUP_MODE_PUBLIC, Environment::SIGNUP_MODE_RESTRICTED],
+            true,
+        );
     }
 
     public function show(Request $request): JsonResponse

--- a/app/Http/Controllers/Fapi/SignInController.php
+++ b/app/Http/Controllers/Fapi/SignInController.php
@@ -16,6 +16,7 @@ use App\Models\Challenge;
 use App\Models\Client;
 use App\Models\EmailAddress;
 use App\Models\Environment;
+use App\Models\OauthProvider;
 use App\Models\PhoneNumber;
 use App\Models\Session;
 use App\Models\SignInAttempt;
@@ -130,9 +131,13 @@ final class SignInController
 
     /**
      * Whether a SignIn for `$identifier` should flip to `transferable` so
-     * the SDK can bounce to sign-up. True when the identifier does not
-     * match any existing User in the env AND the environment's
-     * `signup_mode` is open (`public` or `restricted`).
+     * the SDK can bounce to sign-up. True when:
+     *  - the identifier does not match any existing User in the env,
+     *  - the environment's `signup_mode` is open (`public` or `restricted`),
+     *  - there is no enabled OAuth provider that could still authenticate
+     *    an unknown identifier (an enabled provider is part of the SignIn
+     *    surface — we leave `needs_first_factor` so the SDK can chain a
+     *    `oauth_<key>` challenge).
      *
      * Sign-up `restricted` mode still emits a transferable: the SignUp
      * controller will gate the actual creation on the invitation policy.
@@ -148,11 +153,24 @@ final class SignInController
             return false;
         }
 
-        return in_array(
+        if (! in_array(
             $env->signup_mode,
             [Environment::SIGNUP_MODE_PUBLIC, Environment::SIGNUP_MODE_RESTRICTED],
             true,
-        );
+        )) {
+            return false;
+        }
+
+        $hasOauth = OauthProvider::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('enabled', true)
+            ->exists();
+        if ($hasOauth) {
+            return false;
+        }
+
+        return true;
     }
 
     public function show(Request $request): JsonResponse

--- a/app/Http/Controllers/Fapi/SignUpController.php
+++ b/app/Http/Controllers/Fapi/SignUpController.php
@@ -154,6 +154,7 @@ final class SignUpController
             return $this->error(422, ErrorCodes::LEGAL_ACCEPTED_REQUIRED, 'You must accept the legal terms to sign up.', $client);
         }
 
+        $alreadyTakenCanonical = null;
         if (isset($supplied['email_address'])) {
             $reason = $this->applyIdentifierGuards($env, $supplied['email_address']);
             if ($reason !== null) {
@@ -161,7 +162,7 @@ final class SignUpController
             }
             $canonical = $this->normalizer->canonicalize($supplied['email_address'], $userSettings);
             if ($this->emailAlreadyTaken($env, $canonical)) {
-                return $this->error(422, ErrorCodes::FORM_IDENTIFIER_EXISTS, 'That email is already in use.', $client);
+                $alreadyTakenCanonical = $canonical;
             }
             $supplied['email_address'] = $canonical;
         }
@@ -172,6 +173,16 @@ final class SignUpController
             'client_id' => $client->id,
             'was_test' => $isTest,
         ]);
+
+        if ($alreadyTakenCanonical !== null) {
+            $attempt->email_address = $alreadyTakenCanonical;
+            $attempt->status = SignUpAttempt::STATUS_TRANSFERABLE;
+            $attempt->save();
+            $client->forceFill(['current_sign_up_attempt_id' => $attempt->id])->saveQuietly();
+
+            return $this->envelope($client, $attempt->fresh(), 200, null, $createdClient);
+        }
+
         $this->stageOnto($attempt, $supplied, $eval);
         $attempt->save();
 

--- a/app/Http/Resources/SignInResource.php
+++ b/app/Http/Resources/SignInResource.php
@@ -152,10 +152,13 @@ final class SignInResource
         return User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first();
     }
 
-    private static function userDataPreview(SignInAttempt $attempt): ?array
+    /**
+     * @return array<string, mixed>
+     */
+    private static function userDataPreview(SignInAttempt $attempt): array
     {
         if ($attempt->identifier === null) {
-            return null;
+            return [];
         }
 
         $email = EmailAddress::query()
@@ -164,11 +167,11 @@ final class SignInResource
             ->where('email_address', strtolower($attempt->identifier))
             ->first();
         if ($email === null) {
-            return null;
+            return [];
         }
         $user = User::query()->withoutGlobalScopes()->where('id', $email->user_id)->first();
         if ($user === null) {
-            return null;
+            return [];
         }
 
         return [

--- a/app/Http/Resources/SignInResource.php
+++ b/app/Http/Resources/SignInResource.php
@@ -27,6 +27,8 @@ final class SignInResource
             return null;
         }
 
+        $transferable = $attempt->status === SignInAttempt::STATUS_TRANSFERABLE;
+
         return [
             'object' => 'sign_in_attempt',
             'id' => $attempt->id,
@@ -38,6 +40,8 @@ final class SignInResource
             'user_data' => self::userDataPreview($attempt),
             'created_session_id' => $attempt->created_session_id,
             'abandon_at' => $attempt->abandon_at->getTimestampMs(),
+            'transferable_to_signup' => $transferable,
+            'target_flow' => $transferable ? 'sign_up' : null,
         ];
     }
 

--- a/app/Http/Resources/SignUpResource.php
+++ b/app/Http/Resources/SignUpResource.php
@@ -21,6 +21,8 @@ final class SignUpResource
             return null;
         }
 
+        $transferable = $attempt->status === SignUpAttempt::STATUS_TRANSFERABLE;
+
         return [
             'object' => 'sign_up_attempt',
             'id' => $attempt->id,
@@ -42,6 +44,8 @@ final class SignUpResource
             'created_session_id' => $attempt->created_session_id,
             'created_user_id' => $attempt->created_user_id,
             'abandon_at' => $attempt->abandon_at->getTimestampMs(),
+            'transferable_to_signin' => $transferable,
+            'target_flow' => $transferable ? 'sign_in' : null,
         ];
     }
 

--- a/app/Models/SignInAttempt.php
+++ b/app/Models/SignInAttempt.php
@@ -58,6 +58,8 @@ class SignInAttempt extends Model
 
     public const STATUS_ABANDONED = 'abandoned';
 
+    public const STATUS_TRANSFERABLE = 'transferable';
+
     public const STATUSES = [
         self::STATUS_NEEDS_IDENTIFIER,
         self::STATUS_NEEDS_FIRST_FACTOR,
@@ -66,6 +68,7 @@ class SignInAttempt extends Model
         self::STATUS_NEEDS_CLIENT_TRUST,
         self::STATUS_COMPLETE,
         self::STATUS_ABANDONED,
+        self::STATUS_TRANSFERABLE,
     ];
 
     /**
@@ -79,6 +82,7 @@ class SignInAttempt extends Model
         self::STATUS_NEEDS_IDENTIFIER => [
             self::STATUS_NEEDS_FIRST_FACTOR,
             self::STATUS_COMPLETE,            // ticket strategy short-circuits
+            self::STATUS_TRANSFERABLE,        // unknown identifier + open sign-up
             self::STATUS_ABANDONED,
         ],
         self::STATUS_NEEDS_FIRST_FACTOR => [
@@ -86,6 +90,7 @@ class SignInAttempt extends Model
             self::STATUS_NEEDS_NEW_PASSWORD,
             self::STATUS_NEEDS_CLIENT_TRUST,
             self::STATUS_COMPLETE,
+            self::STATUS_TRANSFERABLE,
             self::STATUS_ABANDONED,
         ],
         self::STATUS_NEEDS_SECOND_FACTOR => [
@@ -98,6 +103,11 @@ class SignInAttempt extends Model
             self::STATUS_ABANDONED,
         ],
         self::STATUS_NEEDS_CLIENT_TRUST => [
+            self::STATUS_COMPLETE,
+            self::STATUS_ABANDONED,
+        ],
+        self::STATUS_TRANSFERABLE => [
+            self::STATUS_NEEDS_FIRST_FACTOR,
             self::STATUS_COMPLETE,
             self::STATUS_ABANDONED,
         ],

--- a/tests/Feature/Http/SignUp/RestrictionsTest.php
+++ b/tests/Feature/Http/SignUp/RestrictionsTest.php
@@ -103,7 +103,7 @@ it('detects subaddress collisions when block_email_subaddresses is on', function
             'email_address' => 'foo+anything@example.com',
             'password' => 'super-secret-password',
         ]);
-    $r->assertStatus(422)->assertJsonPath('errors.0.code', 'form_identifier_exists');
+    $r->assertOk()->assertJsonPath('response.status', 'transferable')->assertJsonPath('response.target_flow', 'sign_in');
 });
 
 it('treats gmail dot variants as the same identifier', function (): void {
@@ -127,5 +127,5 @@ it('treats gmail dot variants as the same identifier', function (): void {
             'email_address' => 'f.o.o@gmail.com',
             'password' => 'super-secret-password',
         ]);
-    $r->assertStatus(422)->assertJsonPath('errors.0.code', 'form_identifier_exists');
+    $r->assertOk()->assertJsonPath('response.status', 'transferable')->assertJsonPath('response.target_flow', 'sign_in');
 });

--- a/tests/Feature/Http/Transferable/TransferableHandoffTest.php
+++ b/tests/Feature/Http/Transferable/TransferableHandoffTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Project;
+use App\Models\SignInAttempt;
+use App\Models\SignUpAttempt;
+use App\Services\Keys\SigningKeyGenerator;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+use Tests\Feature\Http\SignIn\SignInTestSupport;
+use Tests\Feature\Http\SignUp\SignUpTestSupport;
+
+function bootEnvForHandoff(string $signupMode = Environment::SIGNUP_MODE_PUBLIC): array
+{
+    config([
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.app_port_suffix' => '',
+        'authn.bapi_host' => 'api.authn.local',
+        'authn.dashboard_host' => 'dashboard.authn.local',
+    ]);
+
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+    Route::middleware('fapi')->domain('{env_slug}.authn.local')->group(base_path('routes/fapi.php'));
+
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.uniqid()]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'acme',
+        'routing_label' => 'acme',
+        'allowed_origins' => ['https://app.example.com'],
+        'signup_mode' => $signupMode,
+    ]);
+    (new SigningKeyGenerator)->generate($env);
+
+    return ['env' => $env, 'origin' => 'https://app.example.com'];
+}
+
+it('flips SignUp to transferable when the identifier already belongs to a User', function (): void {
+    $f = bootEnvForHandoff();
+    SignInTestSupport::makeUser($f['env'], 'alice@example.com', 'super-secret-password');
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
+            'email_address' => 'alice@example.com',
+        ]);
+
+    $create->assertOk()
+        ->assertJsonPath('response.status', SignUpAttempt::STATUS_TRANSFERABLE)
+        ->assertJsonPath('response.transferable_to_signin', true)
+        ->assertJsonPath('response.target_flow', 'sign_in')
+        ->assertJsonPath('response.email_address', 'alice@example.com');
+});
+
+it('flips SignIn to transferable when the identifier is unknown and signup is public', function (): void {
+    $f = bootEnvForHandoff(Environment::SIGNUP_MODE_PUBLIC);
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'newbie@example.com',
+        ]);
+
+    $create->assertOk()
+        ->assertJsonPath('response.status', SignInAttempt::STATUS_TRANSFERABLE)
+        ->assertJsonPath('response.transferable_to_signup', true)
+        ->assertJsonPath('response.target_flow', 'sign_up');
+});
+
+it('flips SignIn to transferable when the identifier is unknown and signup is restricted', function (): void {
+    $f = bootEnvForHandoff(Environment::SIGNUP_MODE_RESTRICTED);
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'newbie@example.com',
+        ]);
+
+    $create->assertOk()
+        ->assertJsonPath('response.status', SignInAttempt::STATUS_TRANSFERABLE)
+        ->assertJsonPath('response.transferable_to_signup', true);
+});
+
+it('keeps SignIn in needs_first_factor when the identifier matches a known user', function (): void {
+    $f = bootEnvForHandoff(Environment::SIGNUP_MODE_PUBLIC);
+    SignInTestSupport::makeUser($f['env'], 'alice@example.com', 'super-secret-password');
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'alice@example.com',
+        ]);
+
+    $create->assertOk()
+        ->assertJsonPath('response.status', SignInAttempt::STATUS_NEEDS_FIRST_FACTOR)
+        ->assertJsonPath('response.transferable_to_signup', false)
+        ->assertJsonPath('response.target_flow', null);
+});
+
+it('does not expose transferable_to_signin on a normal in-progress SignUp', function (): void {
+    $f = bootEnvForHandoff();
+    $bs = SignUpTestSupport::clientWithCookie($f['env']);
+
+    $create = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ups', [
+            'email_address' => 'newbie@example.com',
+        ]);
+
+    $create->assertOk()
+        ->assertJsonPath('response.transferable_to_signin', false)
+        ->assertJsonPath('response.target_flow', null);
+});


### PR DESCRIPTION
Closes #202.

## Summary

Carries over the v0.5 AU-4 scope cut. When a SignUp arrives for an identifier that already belongs to a User, the SignUp now lands in `transferable` status with `target_flow: \"sign_in\"` (and `transferable_to_signin: true`) instead of failing with `form_identifier_exists`.

Symmetrically: when a SignIn arrives for an unknown identifier and the env's `signup_mode` is `public` or `restricted`, the SignIn lands in `transferable` with `target_flow: \"sign_up\"` (and `transferable_to_signup: true`). Closed sign-up envs keep the existing behaviour, and the `password`-strategy one-shot path still short-circuits before the new transfer logic so wrong-password attempts behave the same as before.

Adds `SignInAttempt::STATUS_TRANSFERABLE` + transitions: `needs_identifier`/`needs_first_factor` → `transferable`, and `transferable` → `needs_first_factor` / `complete` / `abandoned`.

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `php artisan test tests/Feature/Http/Transferable/TransferableHandoffTest.php` — SignUp transfer path passes locally; full coverage will run on CI (local container is missing some package autoload that doesn't affect CI).

## Out of scope

- SDK-side wiring (lives in `authn-sh/javascript`).