### PR TITLE
Add enterprise_connection_id to ChallengeResource

### DIFF
--- a/app/Http/Resources/ChallengeResource.php
+++ b/app/Http/Resources/ChallengeResource.php
@@ -34,6 +34,7 @@ final class ChallengeResource
             'expire_at' => $challenge->expire_at->getTimestampMs(),
             'nonce' => $challenge->nonce,
             'external_verification_redirect_url' => $challenge->external_verification_redirect_url,
+            'enterprise_connection_id' => $metadata['enterprise_connection_id'] ?? null,
             'error' => $challenge->error_code !== null ? [
                 'code' => $challenge->error_code,
                 'message' => (string) $challenge->error_message,


### PR DESCRIPTION
The openapi spec change in OA-3 (#84 upstream) marks `enterprise_connection_id` as required on the Challenge resource. The field will be populated by the enterprise-SSO strategy (AU-7) via `Challenge.metadata`; until then it's emitted as `null`, which satisfies the contract test.

Unblocks the v0.6 PRs (#211, #212, #214) inheriting the pre-existing contract failure currently on `main`.

## Test plan

- [x] `vendor/bin/pint --test`
- [x] Local: existing Challenge-emitting endpoints render `"enterprise_connection_id": null` in the snapshot.