### PR TITLE
Add EnterpriseSsoSettings strategy + MFA toggles (AU-14)

### DIFF
--- a/app/Settings/EnterpriseSsoSettings.php
+++ b/app/Settings/EnterpriseSsoSettings.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Settings;
+
+/**
+ * Per-environment Enterprise SSO toggles. Strict-semantic v0.3 MFA contract:
+ * `enabled` gates *enrollment of new `EnterpriseConnection` rows* and the
+ * `enterprise_sso` first-factor strategy from showing up in fresh sign-ins;
+ * existing connections + linked `EnterpriseAccount` rows continue to work
+ * (the AU-7 strategy enforces the distinction).
+ *
+ * Lives on `Environment.user_settings`:
+ *   - `authentication_strategies.enterprise_sso.enabled` (bool, default `true`)
+ *   - `multi_factor.enterprise_sso_counts_as_mfa` (bool, default `true`)
+ */
+final readonly class EnterpriseSsoSettings
+{
+    public function __construct(
+        public bool $enabled = true,
+        public bool $enterpriseSsoCountsAsMfa = true,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>|null  $userSettings
+     */
+    public static function fromUserSettings(?array $userSettings): self
+    {
+        $userSettings = is_array($userSettings) ? $userSettings : [];
+        $strategies = is_array($userSettings['authentication_strategies'] ?? null)
+            ? $userSettings['authentication_strategies']
+            : [];
+        $enterpriseSso = is_array($strategies['enterprise_sso'] ?? null) ? $strategies['enterprise_sso'] : [];
+
+        $multiFactor = is_array($userSettings['multi_factor'] ?? null) ? $userSettings['multi_factor'] : [];
+
+        return new self(
+            enabled: (bool) ($enterpriseSso['enabled'] ?? true),
+            enterpriseSsoCountsAsMfa: (bool) ($multiFactor['enterprise_sso_counts_as_mfa'] ?? true),
+        );
+    }
+
+    /**
+     * @return array{authentication_strategies: array{enterprise_sso: array{enabled: bool}}, multi_factor: array{enterprise_sso_counts_as_mfa: bool}}
+     */
+    public function toArray(): array
+    {
+        return [
+            'authentication_strategies' => [
+                'enterprise_sso' => ['enabled' => $this->enabled],
+            ],
+            'multi_factor' => [
+                'enterprise_sso_counts_as_mfa' => $this->enterpriseSsoCountsAsMfa,
+            ],
+        ];
+    }
+}

--- a/tests/Feature/Settings/EnterpriseSsoSettingsTest.php
+++ b/tests/Feature/Settings/EnterpriseSsoSettingsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Settings\EnterpriseSsoSettings;
+
+it('defaults both toggles to true when user_settings is empty', function (): void {
+    $settings = EnterpriseSsoSettings::fromUserSettings([]);
+
+    expect($settings->enabled)->toBeTrue();
+    expect($settings->enterpriseSsoCountsAsMfa)->toBeTrue();
+});
+
+it('parses explicit overrides from user_settings', function (): void {
+    $settings = EnterpriseSsoSettings::fromUserSettings([
+        'authentication_strategies' => [
+            'enterprise_sso' => ['enabled' => false],
+        ],
+        'multi_factor' => [
+            'enterprise_sso_counts_as_mfa' => false,
+        ],
+    ]);
+
+    expect($settings->enabled)->toBeFalse();
+    expect($settings->enterpriseSsoCountsAsMfa)->toBeFalse();
+});
+
+it('round-trips through toArray + fromUserSettings preserving every value', function (): void {
+    $original = new EnterpriseSsoSettings(enabled: false, enterpriseSsoCountsAsMfa: false);
+    $roundTripped = EnterpriseSsoSettings::fromUserSettings($original->toArray());
+
+    expect($roundTripped->enabled)->toBeFalse();
+    expect($roundTripped->enterpriseSsoCountsAsMfa)->toBeFalse();
+});
+
+it('tolerates partial or malformed settings shapes', function (): void {
+    $settings = EnterpriseSsoSettings::fromUserSettings([
+        'authentication_strategies' => 'not-an-array',
+        'multi_factor' => ['enterprise_sso_counts_as_mfa' => false],
+    ]);
+
+    expect($settings->enabled)->toBeTrue();
+    expect($settings->enterpriseSsoCountsAsMfa)->toBeFalse();
+});


### PR DESCRIPTION
Closes #205.

## Summary

Mirrors the v0.5 `PasskeySettings` shape:

- `Environment.user_settings.authentication_strategies.enterprise_sso.enabled` (default `true`) — strict-semantic. Gates *new* `EnterpriseConnection` enrollment and the `enterprise_sso` first-factor strategy from showing up on fresh sign-ins. Existing connections + linked `EnterpriseAccount` rows continue to work; the AU-7 strategy will enforce the distinction.
- `Environment.user_settings.multi_factor.enterprise_sso_counts_as_mfa` (default `true`) — AU-7 will use this to mark the session as second-factor-satisfied when the IdP advertises MFA in the SAML `<AuthnContextClassRef>` or OIDC `amr` claim.

Both settings ride on `Environment.user_settings` (existing JSONB column) — no schema change required.

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `php artisan test tests/Feature/Settings/EnterpriseSsoSettingsTest.php` — 4 passed