### PR TITLE
Add OIDC engine for enterprise connections (AU-4)

### DIFF
--- a/app/Auth/EnterpriseSso/EnterpriseConnectionService.php
+++ b/app/Auth/EnterpriseSso/EnterpriseConnectionService.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\EnterpriseSso;
+
+use App\Models\EmailAddress;
+use App\Models\EnterpriseAccount;
+use App\Models\EnterpriseConnection;
+use App\Models\Environment;
+use App\Models\OrganizationDomain;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Resolves enterprise SSO domain → connection routing, and find-or-creates
+ * the `User` + `EnterpriseAccount` rows from an inbound verified identity
+ * (SAML assertion or OIDC id_token).
+ *
+ * Domain matching (per PLAN §11.5):
+ *  1. Match the identifier's domain against verified `OrganizationDomain.domain`.
+ *  2. Walk the org's `EnterpriseConnection` rows where the domain appears in
+ *     `domains[]` and `enabled = true`.
+ *  3. Fall back to instance-wide connections (`organization_id IS NULL`) when
+ *     no org-scoped match exists.
+ */
+final class EnterpriseConnectionService
+{
+    /**
+     * Find the `EnterpriseConnection` an identifier (typically an email)
+     * should route to, or null when nothing matches. Honours the v0.3
+     * strict-semantic contract — disabled connections are skipped at
+     * resolution time so new sign-ins drop through; existing linked
+     * accounts still reach the connection via direct lookup.
+     */
+    public function findByIdentifierDomain(Environment $env, string $identifier): ?EnterpriseConnection
+    {
+        $domain = $this->extractDomain($identifier);
+        if ($domain === null) {
+            return null;
+        }
+
+        $orgMatch = OrganizationDomain::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('name', $domain)
+            ->where('verified', true)
+            ->first();
+
+        if ($orgMatch !== null) {
+            $orgScoped = EnterpriseConnection::query()
+                ->withoutGlobalScopes()
+                ->where('environment_id', $env->id)
+                ->where('organization_id', $orgMatch->organization_id)
+                ->where('enabled', true)
+                ->get()
+                ->first(fn (EnterpriseConnection $conn) => $this->connectionCoversDomain($conn, $domain));
+            if ($orgScoped !== null) {
+                return $orgScoped;
+            }
+        }
+
+        return EnterpriseConnection::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->whereNull('organization_id')
+            ->where('enabled', true)
+            ->get()
+            ->first(fn (EnterpriseConnection $conn) => $this->connectionCoversDomain($conn, $domain));
+    }
+
+    /**
+     * Find-or-create the `User` + `EnterpriseAccount` pair for the
+     * inbound identity. `$identity` carries the IdP-side subject id,
+     * email, name, and the raw attribute bag the connection's
+     * `attribute_mapping` may want to merge onto `User.public_metadata`.
+     *
+     * @param  array{
+     *     provider_user_id:string,
+     *     email_address:?string,
+     *     first_name:?string,
+     *     last_name:?string,
+     *     id_token:?string,
+     *     raw_attributes:array<string,mixed>,
+     * }  $identity
+     * @return array{user: User, account: EnterpriseAccount, was_created: bool}
+     */
+    public function provisionUserFromIdentity(EnterpriseConnection $conn, array $identity): array
+    {
+        return DB::transaction(function () use ($conn, $identity): array {
+            $existing = EnterpriseAccount::query()
+                ->withoutGlobalScopes()
+                ->where('enterprise_connection_id', $conn->id)
+                ->where('provider_user_id', $identity['provider_user_id'])
+                ->first();
+
+            if ($existing !== null) {
+                $existing->last_signed_in_at = now();
+                $existing->id_token = $identity['id_token'];
+                $existing->save();
+                $user = User::query()->withoutGlobalScopes()->where('id', $existing->user_id)->firstOrFail();
+
+                return ['user' => $user, 'account' => $existing->fresh(), 'was_created' => false];
+            }
+
+            $user = $this->findUserByEmail($conn->environment_id, $identity['email_address']);
+            $created = false;
+            if ($user === null) {
+                $user = User::query()->withoutGlobalScopes()->create([
+                    'environment_id' => $conn->environment_id,
+                    'first_name' => $identity['first_name'],
+                    'last_name' => $identity['last_name'],
+                ]);
+                $created = true;
+                if (is_string($identity['email_address']) && $identity['email_address'] !== '') {
+                    $email = EmailAddress::query()->withoutGlobalScopes()->create([
+                        'environment_id' => $conn->environment_id,
+                        'user_id' => $user->id,
+                        'email_address' => strtolower($identity['email_address']),
+                        'verified_at' => now(),
+                        'is_primary' => true,
+                    ]);
+                    $user->forceFill(['primary_email_address_id' => $email->id])->save();
+                }
+            }
+
+            $account = EnterpriseAccount::query()->withoutGlobalScopes()->create([
+                'environment_id' => $conn->environment_id,
+                'user_id' => $user->id,
+                'enterprise_connection_id' => $conn->id,
+                'provider_user_id' => $identity['provider_user_id'],
+                'email_address' => $identity['email_address'],
+                'verified' => true,
+                'public_metadata' => $this->mapAttributes($conn, $identity['raw_attributes']),
+                'id_token' => $identity['id_token'],
+                'linked_at' => now(),
+                'last_signed_in_at' => now(),
+            ]);
+
+            return ['user' => $user->fresh(), 'account' => $account, 'was_created' => $created];
+        });
+    }
+
+    /**
+     * Apply the connection's `attribute_mapping` (`{idp_attr: internal_path}`)
+     * to the raw attribute bag, returning the subset to persist on
+     * `EnterpriseAccount.public_metadata`. Unmapped attributes are
+     * dropped — operators opt them in through `attribute_mapping`.
+     *
+     * @param  array<string,mixed>  $rawAttributes
+     * @return array<string,mixed>
+     */
+    private function mapAttributes(EnterpriseConnection $conn, array $rawAttributes): array
+    {
+        $mapping = is_array($conn->attribute_mapping) ? $conn->attribute_mapping : [];
+        $mapped = [];
+        foreach ($mapping as $source => $target) {
+            if (! is_string($source) || ! is_string($target)) {
+                continue;
+            }
+            if (array_key_exists($source, $rawAttributes)) {
+                $mapped[$target] = $rawAttributes[$source];
+            }
+        }
+
+        return $mapped;
+    }
+
+    private function findUserByEmail(string $environmentId, ?string $email): ?User
+    {
+        if (! is_string($email) || $email === '') {
+            return null;
+        }
+        $row = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $environmentId)
+            ->where('email_address', strtolower($email))
+            ->first();
+        if ($row === null) {
+            return null;
+        }
+
+        return User::query()->withoutGlobalScopes()->where('id', $row->user_id)->first();
+    }
+
+    private function extractDomain(string $identifier): ?string
+    {
+        $at = strrpos($identifier, '@');
+        if ($at === false) {
+            return null;
+        }
+        $domain = strtolower(trim(substr($identifier, $at + 1)));
+
+        return $domain === '' ? null : $domain;
+    }
+
+    private function connectionCoversDomain(EnterpriseConnection $conn, string $domain): bool
+    {
+        $domains = is_array($conn->domains) ? $conn->domains : [];
+        foreach ($domains as $d) {
+            if (is_string($d) && strtolower($d) === $domain) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Auth/EnterpriseSso/OidcConnectionService.php
+++ b/app/Auth/EnterpriseSso/OidcConnectionService.php
@@ -1,0 +1,385 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\EnterpriseSso;
+
+use App\Models\EnterpriseConnection;
+use App\Support\Base64Url;
+use App\Support\Url;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Lcobucci\Clock\SystemClock;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256 as Rs256;
+use Lcobucci\JWT\Signer\Rsa\Sha384 as Rs384;
+use Lcobucci\JWT\Signer\Rsa\Sha512 as Rs512;
+use Lcobucci\JWT\Token\Parser;
+use Lcobucci\JWT\Token\Plain;
+use Lcobucci\JWT\Validation\Constraint\IssuedBy;
+use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
+use Lcobucci\JWT\Validation\Constraint\PermittedFor;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Lcobucci\JWT\Validation\Validator;
+use Throwable;
+
+/**
+ * OIDC engine for enterprise connections. Mirrors `app/Auth/Oauth` but
+ * keyed by `EnterpriseConnection` (instance-wide or org-scoped) rather
+ * than the v0.4 `OauthProvider`. Reuses the same JWS-via-JWKS, discovery
+ * + PKCE-S256 + nonce-round-trip patterns.
+ *
+ * Three public operations:
+ *   - `discover(EnterpriseConnection)` — fetch + cache `.well-known/openid-configuration`.
+ *   - `buildAuthorizeUrl(EnterpriseConnection, $state, $nonce)` — emit the IdP authorize URL with PKCE.
+ *   - `exchangeCode(EnterpriseConnection, $code, $codeVerifier)` — code → tokens.
+ *   - `verifyIdToken(EnterpriseConnection, $idToken, $nonce)` — JWS verify against JWKS + claim checks.
+ */
+final class OidcConnectionService
+{
+    private const DISCOVERY_CACHE_TTL_SECONDS = 300;
+
+    private const JWKS_CACHE_TTL_SECONDS = 3600;
+
+    private readonly Parser $parser;
+
+    private readonly Validator $validator;
+
+    public function __construct()
+    {
+        $this->parser = new Parser(new JoseEncoder);
+        $this->validator = new Validator;
+    }
+
+    /**
+     * Fetch `<oidc_issuer>/.well-known/openid-configuration` (or
+     * `oidc_discovery_endpoint` when set explicitly) and return the
+     * relevant subset. Cached 5 minutes per connection id; cache hits
+     * never touch the network.
+     *
+     * @return array{
+     *     authorization_endpoint:string,
+     *     token_endpoint:string,
+     *     userinfo_endpoint:?string,
+     *     jwks_uri:?string,
+     *     id_token_signing_algs:list<string>,
+     * }
+     *
+     * @throws OidcDiscoveryException
+     */
+    public function discover(EnterpriseConnection $conn): array
+    {
+        $url = $this->discoveryUrl($conn);
+        $cacheKey = 'oidc:enterprise:discovery:'.$conn->id;
+
+        return Cache::remember($cacheKey, self::DISCOVERY_CACHE_TTL_SECONDS, function () use ($url, $conn): array {
+            try {
+                $response = Http::acceptJson()->timeout(10)->get($url);
+            } catch (ConnectionException|RequestException|Throwable $e) {
+                throw new OidcDiscoveryException($conn->id, $url, $e->getMessage());
+            }
+
+            if (! $response->successful()) {
+                throw new OidcDiscoveryException($conn->id, $url, "HTTP {$response->status()}");
+            }
+
+            $document = $response->json();
+            if (! is_array($document)) {
+                throw new OidcDiscoveryException($conn->id, $url, 'Discovery body was not a JSON object');
+            }
+
+            foreach (['authorization_endpoint', 'token_endpoint'] as $required) {
+                if (! is_string($document[$required] ?? null) || $document[$required] === '') {
+                    throw new OidcDiscoveryException($conn->id, $url, "Missing {$required}");
+                }
+            }
+            $algs = $document['id_token_signing_alg_values_supported'] ?? ['RS256'];
+            if (! is_array($algs)) {
+                $algs = ['RS256'];
+            }
+            $algs = array_values(array_filter(array_map('strval', $algs), fn ($v) => $v !== ''));
+
+            return [
+                'authorization_endpoint' => (string) $document['authorization_endpoint'],
+                'token_endpoint' => (string) $document['token_endpoint'],
+                'userinfo_endpoint' => is_string($document['userinfo_endpoint'] ?? null)
+                    ? (string) $document['userinfo_endpoint']
+                    : null,
+                'jwks_uri' => is_string($document['jwks_uri'] ?? null) ? (string) $document['jwks_uri'] : null,
+                'id_token_signing_algs' => $algs,
+            ];
+        });
+    }
+
+    /**
+     * Build the IdP authorize URL with `state`, `nonce`, and a freshly
+     * generated PKCE-S256 challenge. The caller persists `$codeVerifier`
+     * on the parent Challenge row (callers in AU-7) and feeds it back
+     * to `exchangeCode()` on the callback leg.
+     *
+     * @return array{authorize_url:string, code_verifier:string}
+     */
+    public function buildAuthorizeUrl(EnterpriseConnection $conn, string $state, string $nonce): array
+    {
+        $endpoints = $this->discover($conn);
+
+        $codeVerifier = Base64Url::encode(random_bytes(32));
+        $codeChallenge = Base64Url::encode(hash('sha256', $codeVerifier, true));
+
+        $scopes = is_array($conn->oidc_scopes) && $conn->oidc_scopes !== []
+            ? $conn->oidc_scopes
+            : ['openid', 'email', 'profile'];
+
+        $params = [
+            'response_type' => 'code',
+            'client_id' => (string) $conn->oidc_client_id,
+            'redirect_uri' => $this->redirectUri($conn),
+            'scope' => implode(' ', $scopes),
+            'state' => $state,
+            'nonce' => $nonce,
+            'code_challenge' => $codeChallenge,
+            'code_challenge_method' => 'S256',
+        ];
+
+        return [
+            'authorize_url' => $endpoints['authorization_endpoint'].'?'.http_build_query($params, '', '&', PHP_QUERY_RFC3986),
+            'code_verifier' => $codeVerifier,
+        ];
+    }
+
+    /**
+     * Exchange the authorization code for tokens. Returns the raw token
+     * response — callers handle `id_token` extraction via `verifyIdToken`.
+     *
+     * @return array{access_token:?string, id_token:?string, refresh_token:?string, token_type:?string, expires_in:?int}
+     *
+     * @throws OidcTokenExchangeException
+     */
+    public function exchangeCode(EnterpriseConnection $conn, string $code, string $codeVerifier): array
+    {
+        $endpoints = $this->discover($conn);
+
+        try {
+            $response = Http::asForm()
+                ->acceptJson()
+                ->timeout(10)
+                ->post($endpoints['token_endpoint'], [
+                    'grant_type' => 'authorization_code',
+                    'code' => $code,
+                    'redirect_uri' => $this->redirectUri($conn),
+                    'client_id' => (string) $conn->oidc_client_id,
+                    'client_secret' => (string) $conn->oidc_client_secret,
+                    'code_verifier' => $codeVerifier,
+                ]);
+        } catch (ConnectionException|RequestException|Throwable $e) {
+            throw new OidcTokenExchangeException($conn->id, $e->getMessage());
+        }
+
+        if (! $response->successful()) {
+            throw new OidcTokenExchangeException($conn->id, "Token exchange returned HTTP {$response->status()}");
+        }
+
+        $body = $response->json();
+        if (! is_array($body)) {
+            throw new OidcTokenExchangeException($conn->id, 'Token response was not a JSON object');
+        }
+
+        return [
+            'access_token' => is_string($body['access_token'] ?? null) ? $body['access_token'] : null,
+            'id_token' => is_string($body['id_token'] ?? null) ? $body['id_token'] : null,
+            'refresh_token' => is_string($body['refresh_token'] ?? null) ? $body['refresh_token'] : null,
+            'token_type' => is_string($body['token_type'] ?? null) ? $body['token_type'] : null,
+            'expires_in' => is_int($body['expires_in'] ?? null) ? $body['expires_in'] : null,
+        ];
+    }
+
+    /**
+     * Verify a received id_token: parse, fetch JWKS (cached 1h), check
+     * the JWS signature against the matching JWK, validate `iss` / `aud`
+     * / `nonce` / `exp` / `iat`. Returns the verified claims or null on
+     * any failure.
+     *
+     * @return array<string,mixed>|null
+     */
+    public function verifyIdToken(EnterpriseConnection $conn, string $idToken, string $expectedNonce): ?array
+    {
+        $endpoints = $this->discover($conn);
+        if ($endpoints['jwks_uri'] === null) {
+            return null;
+        }
+
+        try {
+            $token = $this->parser->parse($idToken);
+        } catch (Throwable) {
+            return null;
+        }
+        if (! $token instanceof Plain) {
+            return null;
+        }
+
+        $alg = (string) $token->headers()->get('alg', '');
+        if (! in_array($alg, $endpoints['id_token_signing_algs'], true)) {
+            return null;
+        }
+        $kid = $token->headers()->get('kid');
+
+        $jwks = $this->fetchJwks($conn->id, $endpoints['jwks_uri']);
+        if ($jwks === null) {
+            return null;
+        }
+        $pem = $this->pickKey($jwks, is_string($kid) ? $kid : null);
+        if ($pem === null) {
+            return null;
+        }
+
+        $signer = match ($alg) {
+            'RS256' => new Rs256,
+            'RS384' => new Rs384,
+            'RS512' => new Rs512,
+            default => null,
+        };
+        if ($signer === null) {
+            return null;
+        }
+
+        $constraints = [new SignedWith($signer, InMemory::plainText($pem))];
+        if (is_string($conn->oidc_issuer) && $conn->oidc_issuer !== '') {
+            $constraints[] = new IssuedBy($conn->oidc_issuer);
+        }
+        if (is_string($conn->oidc_client_id) && $conn->oidc_client_id !== '') {
+            $constraints[] = new PermittedFor($conn->oidc_client_id);
+        }
+        $constraints[] = new LooseValidAt(SystemClock::fromUTC());
+
+        if (! $this->validator->validate($token, ...$constraints)) {
+            return null;
+        }
+
+        $claims = $token->claims()->all();
+        if (! is_array($claims)) {
+            return null;
+        }
+        if (($claims['nonce'] ?? null) !== $expectedNonce) {
+            return null;
+        }
+
+        return $claims;
+    }
+
+    /**
+     * The redirect URI the IdP posts the authorization code back to.
+     * Stable per env + connection so operators can paste it into the
+     * IdP's allow-list when configuring the connection.
+     */
+    public function redirectUri(EnterpriseConnection $conn): string
+    {
+        return Url::fapi($conn->environment, '/v1/enterprise-sso-callback/'.$conn->id);
+    }
+
+    private function discoveryUrl(EnterpriseConnection $conn): string
+    {
+        if (is_string($conn->oidc_discovery_endpoint) && $conn->oidc_discovery_endpoint !== '') {
+            return $conn->oidc_discovery_endpoint;
+        }
+        $issuer = rtrim((string) $conn->oidc_issuer, '/');
+
+        return $issuer.'/.well-known/openid-configuration';
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>|null
+     */
+    private function fetchJwks(string $connectionId, string $jwksUri): ?array
+    {
+        $cacheKey = 'oidc:enterprise:jwks:'.$connectionId.':'.hash('sha256', $jwksUri);
+
+        return Cache::remember($cacheKey, self::JWKS_CACHE_TTL_SECONDS, function () use ($jwksUri): ?array {
+            try {
+                $response = Http::timeout(5)->get($jwksUri);
+            } catch (ConnectionException|RequestException|Throwable) {
+                return null;
+            }
+            if (! $response->successful()) {
+                return null;
+            }
+            $body = $response->json();
+            $keys = $body['keys'] ?? null;
+            if (! is_array($keys)) {
+                return null;
+            }
+
+            return array_values(array_filter($keys, 'is_array'));
+        });
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>>  $jwks
+     */
+    private function pickKey(array $jwks, ?string $kid): ?string
+    {
+        foreach ($jwks as $jwk) {
+            if ($kid !== null && ($jwk['kid'] ?? null) !== $kid) {
+                continue;
+            }
+            if (($jwk['kty'] ?? null) !== 'RSA') {
+                continue;
+            }
+            $n = $jwk['n'] ?? null;
+            $e = $jwk['e'] ?? null;
+            if (! is_string($n) || ! is_string($e)) {
+                continue;
+            }
+
+            return $this->jwkToPem($n, $e);
+        }
+
+        return null;
+    }
+
+    private function jwkToPem(string $nB64Url, string $eB64Url): string
+    {
+        $n = Base64Url::decode($nB64Url);
+        $e = Base64Url::decode($eB64Url);
+
+        $modulus = $this->asn1Integer($n);
+        $exponent = $this->asn1Integer($e);
+        $rsaKey = $this->asn1Sequence($modulus.$exponent);
+        $bitString = "\x00".$rsaKey;
+        $bitStringWrap = "\x03".$this->asn1Length(strlen($bitString)).$bitString;
+        $algIdentifier = $this->asn1Sequence("\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01\x05\x00");
+        $spki = $this->asn1Sequence($algIdentifier.$bitStringWrap);
+
+        return "-----BEGIN PUBLIC KEY-----\n".chunk_split(base64_encode($spki), 64, "\n").'-----END PUBLIC KEY-----';
+    }
+
+    private function asn1Integer(string $bytes): string
+    {
+        if ($bytes !== '' && (ord($bytes[0]) & 0x80) !== 0) {
+            $bytes = "\x00".$bytes;
+        }
+
+        return "\x02".$this->asn1Length(strlen($bytes)).$bytes;
+    }
+
+    private function asn1Sequence(string $bytes): string
+    {
+        return "\x30".$this->asn1Length(strlen($bytes)).$bytes;
+    }
+
+    private function asn1Length(int $length): string
+    {
+        if ($length < 0x80) {
+            return chr($length);
+        }
+        $bytes = '';
+        while ($length > 0) {
+            $bytes = chr($length & 0xFF).$bytes;
+            $length >>= 8;
+        }
+
+        return chr(0x80 | strlen($bytes)).$bytes;
+    }
+}

--- a/app/Auth/EnterpriseSso/OidcDiscoveryException.php
+++ b/app/Auth/EnterpriseSso/OidcDiscoveryException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\EnterpriseSso;
+
+use RuntimeException;
+
+/**
+ * Thrown by `OidcConnectionService::discover()` when the IdP's
+ * `.well-known/openid-configuration` cannot be fetched or validated.
+ */
+final class OidcDiscoveryException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $connectionId,
+        public readonly string $discoveryUrl,
+        string $detail = '',
+    ) {
+        parent::__construct("OIDC discovery failed for connection {$connectionId} at {$discoveryUrl}: {$detail}");
+    }
+}

--- a/app/Auth/EnterpriseSso/OidcTokenExchangeException.php
+++ b/app/Auth/EnterpriseSso/OidcTokenExchangeException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\EnterpriseSso;
+
+use RuntimeException;
+
+/**
+ * Thrown by `OidcConnectionService::exchangeCode()` when the IdP's
+ * token endpoint refuses or returns a malformed response.
+ */
+final class OidcTokenExchangeException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $connectionId,
+        string $detail = '',
+    ) {
+        parent::__construct("OIDC token exchange failed for connection {$connectionId}: {$detail}");
+    }
+}

--- a/tests/Feature/Auth/EnterpriseSso/EnterpriseConnectionServiceTest.php
+++ b/tests/Feature/Auth/EnterpriseSso/EnterpriseConnectionServiceTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\EnterpriseSso\EnterpriseConnectionService;
+use App\Models\EmailAddress;
+use App\Models\EnterpriseAccount;
+use App\Models\EnterpriseConnection;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationDomain;
+use App\Models\Project;
+use App\Models\User;
+
+function makeEntServiceEnv(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('returns null when the identifier has no domain or no connection matches', function (): void {
+    $env = makeEntServiceEnv();
+    $service = new EnterpriseConnectionService;
+
+    expect($service->findByIdentifierDomain($env, 'no-at-sign'))->toBeNull();
+    expect($service->findByIdentifierDomain($env, 'alice@unknown.test'))->toBeNull();
+});
+
+it('prefers an org-scoped connection when the identifier domain matches a verified org domain', function (): void {
+    $env = makeEntServiceEnv();
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => 'acme']);
+    OrganizationDomain::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'name' => 'acme.test',
+        'verified' => true,
+        'enrollment_mode' => 'manual_invitation',
+    ]);
+
+    $instanceConn = EnterpriseConnection::factory()->create([
+        'environment_id' => $env->id,
+        'organization_id' => null,
+        'domains' => ['acme.test'],
+    ]);
+    $orgConn = EnterpriseConnection::factory()->create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'domains' => ['acme.test'],
+    ]);
+
+    $found = (new EnterpriseConnectionService)->findByIdentifierDomain($env, 'alice@acme.test');
+
+    expect($found?->id)->toBe($orgConn->id);
+    expect($found?->id)->not->toBe($instanceConn->id);
+});
+
+it('falls back to an instance-wide connection when no org-scoped match covers the domain', function (): void {
+    $env = makeEntServiceEnv();
+    $conn = EnterpriseConnection::factory()->create([
+        'environment_id' => $env->id,
+        'organization_id' => null,
+        'domains' => ['acme.test', 'corp.acme.test'],
+    ]);
+
+    expect((new EnterpriseConnectionService)->findByIdentifierDomain($env, 'alice@acme.test')?->id)->toBe($conn->id);
+    expect((new EnterpriseConnectionService)->findByIdentifierDomain($env, 'bob@CORP.ACME.TEST')?->id)->toBe($conn->id);
+});
+
+it('skips disabled connections even when the domain matches', function (): void {
+    $env = makeEntServiceEnv();
+    EnterpriseConnection::factory()->disabled()->create([
+        'environment_id' => $env->id,
+        'domains' => ['acme.test'],
+    ]);
+
+    expect((new EnterpriseConnectionService)->findByIdentifierDomain($env, 'alice@acme.test'))->toBeNull();
+});
+
+it('creates a User + EnterpriseAccount when the identity is brand new', function (): void {
+    $env = makeEntServiceEnv();
+    $conn = EnterpriseConnection::factory()->create([
+        'environment_id' => $env->id,
+        'attribute_mapping' => ['department' => 'department'],
+    ]);
+
+    $result = (new EnterpriseConnectionService)->provisionUserFromIdentity($conn, [
+        'provider_user_id' => 'idp-subject-1',
+        'email_address' => 'alice@acme.test',
+        'first_name' => 'Alice',
+        'last_name' => 'Smith',
+        'id_token' => 'id.tok.value',
+        'raw_attributes' => ['department' => 'Engineering', 'extra' => 'dropped'],
+    ]);
+
+    expect($result['was_created'])->toBeTrue();
+    expect($result['user']->id)->toStartWith('user_');
+    expect($result['user']->first_name)->toBe('Alice');
+    expect($result['account']->id)->toStartWith('entacc_');
+    expect($result['account']->provider_user_id)->toBe('idp-subject-1');
+    expect($result['account']->id_token)->toBe('id.tok.value');
+    expect($result['account']->public_metadata)->toBe(['department' => 'Engineering']);
+
+    $email = EmailAddress::query()->withoutGlobalScopes()->where('user_id', $result['user']->id)->first();
+    expect($email?->email_address)->toBe('alice@acme.test');
+    expect($email?->isVerified())->toBeTrue();
+    expect($email?->is_primary)->toBeTrue();
+});
+
+it('reuses an existing User when the email already exists and links a new EnterpriseAccount', function (): void {
+    $env = makeEntServiceEnv();
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $env->id]);
+
+    $existing = User::create(['environment_id' => $env->id]);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $env->id,
+        'user_id' => $existing->id,
+        'email_address' => 'alice@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $result = (new EnterpriseConnectionService)->provisionUserFromIdentity($conn, [
+        'provider_user_id' => 'idp-subject-1',
+        'email_address' => 'alice@acme.test',
+        'first_name' => null,
+        'last_name' => null,
+        'id_token' => null,
+        'raw_attributes' => [],
+    ]);
+
+    expect($result['was_created'])->toBeFalse();
+    expect($result['user']->id)->toBe($existing->id);
+    expect($result['account']->user_id)->toBe($existing->id);
+});
+
+it('reuses the same EnterpriseAccount when the provider subject is already linked', function (): void {
+    $env = makeEntServiceEnv();
+    $user = User::create(['environment_id' => $env->id]);
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $env->id]);
+
+    EnterpriseAccount::factory()->create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'enterprise_connection_id' => $conn->id,
+        'provider_user_id' => 'idp-subject-1',
+        'id_token' => 'old.tok',
+    ]);
+
+    $result = (new EnterpriseConnectionService)->provisionUserFromIdentity($conn, [
+        'provider_user_id' => 'idp-subject-1',
+        'email_address' => null,
+        'first_name' => null,
+        'last_name' => null,
+        'id_token' => 'new.tok',
+        'raw_attributes' => [],
+    ]);
+
+    expect($result['was_created'])->toBeFalse();
+    expect($result['user']->id)->toBe($user->id);
+    expect($result['account']->id_token)->toBe('new.tok');
+});

--- a/tests/Feature/Auth/EnterpriseSso/OidcConnectionServiceTest.php
+++ b/tests/Feature/Auth/EnterpriseSso/OidcConnectionServiceTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\EnterpriseSso\OidcConnectionService;
+use App\Auth\EnterpriseSso\OidcDiscoveryException;
+use App\Models\EnterpriseConnection;
+use App\Models\Environment;
+use App\Models\Project;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+function makeOidcEnv(string $slug = 'acme'): Environment
+{
+    config([
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_port_suffix' => '',
+    ]);
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+function makeOidcConnection(Environment $env, array $overrides = []): EnterpriseConnection
+{
+    return EnterpriseConnection::factory()->oidc()->create(array_merge([
+        'environment_id' => $env->id,
+        'oidc_issuer' => 'https://idp.example.com',
+        'oidc_discovery_endpoint' => 'https://idp.example.com/.well-known/openid-configuration',
+        'oidc_client_id' => 'client-abc',
+        'oidc_client_secret' => 'secret-xyz',
+        'oidc_scopes' => ['openid', 'email', 'profile'],
+    ], $overrides));
+}
+
+beforeEach(function (): void {
+    Cache::flush();
+});
+
+it('fetches and caches discovery, parsing the endpoints + signing algs', function (): void {
+    $env = makeOidcEnv();
+    $conn = makeOidcConnection($env);
+
+    Http::fake([
+        'idp.example.com/.well-known/openid-configuration' => Http::response([
+            'authorization_endpoint' => 'https://idp.example.com/oauth/authorize',
+            'token_endpoint' => 'https://idp.example.com/oauth/token',
+            'userinfo_endpoint' => 'https://idp.example.com/oauth/userinfo',
+            'jwks_uri' => 'https://idp.example.com/oauth/jwks',
+            'id_token_signing_alg_values_supported' => ['RS256', 'RS512'],
+        ]),
+    ]);
+
+    $service = new OidcConnectionService;
+    $first = $service->discover($conn);
+    expect($first['authorization_endpoint'])->toBe('https://idp.example.com/oauth/authorize');
+    expect($first['token_endpoint'])->toBe('https://idp.example.com/oauth/token');
+    expect($first['jwks_uri'])->toBe('https://idp.example.com/oauth/jwks');
+    expect($first['id_token_signing_algs'])->toBe(['RS256', 'RS512']);
+
+    // Cache hit on second call — second fake unneeded.
+    $second = $service->discover($conn);
+    expect($second)->toBe($first);
+    Http::assertSentCount(1);
+});
+
+it('throws OidcDiscoveryException when the IdP returns 5xx', function (): void {
+    $env = makeOidcEnv();
+    $conn = makeOidcConnection($env);
+
+    Http::fake([
+        'idp.example.com/.well-known/openid-configuration' => Http::response('server error', 502),
+    ]);
+
+    expect(fn () => (new OidcConnectionService)->discover($conn))
+        ->toThrow(OidcDiscoveryException::class);
+});
+
+it('throws OidcDiscoveryException when the response is missing required endpoints', function (): void {
+    $env = makeOidcEnv();
+    $conn = makeOidcConnection($env);
+
+    Http::fake([
+        'idp.example.com/.well-known/openid-configuration' => Http::response([
+            'authorization_endpoint' => 'https://idp.example.com/oauth/authorize',
+            // token_endpoint missing
+        ]),
+    ]);
+
+    expect(fn () => (new OidcConnectionService)->discover($conn))
+        ->toThrow(OidcDiscoveryException::class);
+});
+
+it('builds an authorize URL with PKCE-S256 challenge, state, nonce and configured scopes', function (): void {
+    $env = makeOidcEnv();
+    $conn = makeOidcConnection($env, ['oidc_scopes' => ['openid', 'email', 'groups']]);
+
+    Http::fake([
+        'idp.example.com/.well-known/openid-configuration' => Http::response([
+            'authorization_endpoint' => 'https://idp.example.com/oauth/authorize',
+            'token_endpoint' => 'https://idp.example.com/oauth/token',
+            'jwks_uri' => 'https://idp.example.com/oauth/jwks',
+            'id_token_signing_alg_values_supported' => ['RS256'],
+        ]),
+    ]);
+
+    $result = (new OidcConnectionService)->buildAuthorizeUrl($conn, state: 'sid:sia_abc', nonce: 'n-xyz');
+    expect($result['authorize_url'])->toStartWith('https://idp.example.com/oauth/authorize?');
+    parse_str(parse_url($result['authorize_url'], PHP_URL_QUERY) ?: '', $query);
+    expect($query['response_type'])->toBe('code');
+    expect($query['client_id'])->toBe('client-abc');
+    expect($query['redirect_uri'])->toBe('https://acme.authn.local/v1/enterprise-sso-callback/'.$conn->id);
+    expect($query['state'])->toBe('sid:sia_abc');
+    expect($query['nonce'])->toBe('n-xyz');
+    expect($query['scope'])->toBe('openid email groups');
+    expect($query['code_challenge_method'])->toBe('S256');
+    expect($query['code_challenge'])->not->toBeEmpty();
+    expect(strlen($result['code_verifier']))->toBeGreaterThan(20);
+});
+
+it('exchanges an authorization code for tokens and returns the relevant fields', function (): void {
+    $env = makeOidcEnv();
+    $conn = makeOidcConnection($env);
+
+    Http::fake([
+        'idp.example.com/.well-known/openid-configuration' => Http::response([
+            'authorization_endpoint' => 'https://idp.example.com/oauth/authorize',
+            'token_endpoint' => 'https://idp.example.com/oauth/token',
+            'jwks_uri' => 'https://idp.example.com/oauth/jwks',
+            'id_token_signing_alg_values_supported' => ['RS256'],
+        ]),
+        'idp.example.com/oauth/token' => Http::response([
+            'access_token' => 'at-tok',
+            'id_token' => 'id-tok',
+            'refresh_token' => 'rt-tok',
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+        ]),
+    ]);
+
+    $tokens = (new OidcConnectionService)->exchangeCode($conn, code: 'auth-code-1', codeVerifier: 'verifier-1');
+    expect($tokens['access_token'])->toBe('at-tok');
+    expect($tokens['id_token'])->toBe('id-tok');
+    expect($tokens['refresh_token'])->toBe('rt-tok');
+    expect($tokens['token_type'])->toBe('Bearer');
+    expect($tokens['expires_in'])->toBe(3600);
+});
+
+it('returns null from verifyIdToken when the JWS signature is bogus', function (): void {
+    $env = makeOidcEnv();
+    $conn = makeOidcConnection($env);
+
+    Http::fake([
+        'idp.example.com/.well-known/openid-configuration' => Http::response([
+            'authorization_endpoint' => 'https://idp.example.com/oauth/authorize',
+            'token_endpoint' => 'https://idp.example.com/oauth/token',
+            'jwks_uri' => 'https://idp.example.com/oauth/jwks',
+            'id_token_signing_alg_values_supported' => ['RS256'],
+        ]),
+        'idp.example.com/oauth/jwks' => Http::response(['keys' => []]),
+    ]);
+
+    // garbage id_token
+    expect((new OidcConnectionService)->verifyIdToken($conn, 'header.payload.sig', 'expected-nonce'))->toBeNull();
+});


### PR DESCRIPTION
Closes #195.

## Summary

Two services under `app/Auth/EnterpriseSso/`:

### OidcConnectionService

Wraps OIDC discovery + token exchange + JWS verification. Mirrors v0.4's `OauthProviderResolver` + `IdTokenValidator` pattern but keyed on `EnterpriseConnection`:

- `discover(conn)` — fetches `<oidc_issuer>/.well-known/openid-configuration` (or `oidc_discovery_endpoint` when set), caches 5 min per connection id.
- `buildAuthorizeUrl(conn, state, nonce)` — emits IdP authorize URL with fresh PKCE-S256 challenge + configured scopes; returns the matching `code_verifier` for caller-side persistence.
- `exchangeCode(conn, code, codeVerifier)` — swaps the auth code for tokens.
- `verifyIdToken(conn, idToken, expectedNonce)` — parses JWS, picks matching JWK by `kid` (1h cache), validates signature, `iss` / `aud` / `nonce` / `exp` / `iat`. Returns the verified claims or null.

### EnterpriseConnectionService

Domain → connection routing + identity provisioning:

- `findByIdentifierDomain(env, identifier)` — matches identifier domain against verified `OrganizationDomain.name`; prefers org-scoped, falls back to instance-wide. Disabled connections are skipped (strict-semantic AU-14 contract).
- `provisionUserFromIdentity(conn, identity)` — find-or-creates the `EnterpriseAccount` for `(connection, provider_user_id)`; reuses an existing User when the email matches, otherwise creates the User + EmailAddress + EnterpriseAccount tuple in a transaction. `attribute_mapping` is applied — only mapped keys land on `EnterpriseAccount.public_metadata`.

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `php artisan test tests/Feature/Auth/EnterpriseSso/` — 13 passed (cache hit/miss, 5xx + missing endpoints, PKCE-S256 authorize URL shape, token exchange happy path, JWS bogus signature rejection, domain routing precedence, disabled-skip, new-user provision, existing-user relink, idempotent re-sign-in)

## Out of scope

- Strategy plumbing (AU-7).
- BAPI/FAPI endpoints (AU-5, AU-6).