### PR TITLE
Add SCIM 2.0 server (AU-9)

### DIFF
--- a/app/Http/Controllers/Scim/GroupsController.php
+++ b/app/Http/Controllers/Scim/GroupsController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Scim;
+
+use App\Models\Organization;
+use App\Models\ScimToken;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * SCIM 2.0 Groups surface. authn.sh's group concept is an
+ * `OrganizationMembership` aggregate keyed on `Role.key` — a single
+ * "Group" per (organization, role). v0.6 ships a read-only listing
+ * surface; PATCH/PUT operations on memberships land in v0.7 alongside
+ * the role-self-service work.
+ */
+final class GroupsController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $token = app(ScimToken::class);
+        $organization = $token->organization_id !== null
+            ? Organization::query()->withoutGlobalScopes()->where('id', $token->organization_id)->first()
+            : null;
+        if ($organization === null) {
+            return $this->scimResponse([
+                'schemas' => ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+                'totalResults' => 0,
+                'startIndex' => 1,
+                'itemsPerPage' => 0,
+                'Resources' => [],
+            ]);
+        }
+
+        $startIndex = max(1, (int) $request->query('startIndex', '1'));
+        $count = min(200, max(0, (int) $request->query('count', '20')));
+
+        $rows = \DB::table('organization_memberships')
+            ->join('roles', 'organization_memberships.role_id', '=', 'roles.id')
+            ->where('organization_memberships.organization_id', $organization->id)
+            ->select('roles.id as role_id', 'roles.key as role_key', 'roles.name as role_name', 'organization_memberships.user_id')
+            ->get()
+            ->groupBy('role_id');
+
+        $resources = $rows->slice($startIndex - 1, $count)->map(function ($members, $roleId) {
+            $first = $members->first();
+
+            return [
+                'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+                'id' => 'role_'.$roleId.'__org_grp',
+                'displayName' => $first->role_name ?? $first->role_key,
+                'members' => $members->map(fn ($m) => ['value' => $m->user_id, 'type' => 'User'])->all(),
+            ];
+        })->values()->all();
+
+        return $this->scimResponse([
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+            'totalResults' => $rows->count(),
+            'startIndex' => $startIndex,
+            'itemsPerPage' => count($resources),
+            'Resources' => $resources,
+        ]);
+    }
+
+    public function show(Request $request): JsonResponse
+    {
+        $id = (string) $request->route('id');
+
+        return $this->scimError(404, 'notFound', "Group {$id} not found.");
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function scimResponse(array $payload, int $status = 200): JsonResponse
+    {
+        return response()->json($payload, $status, ['Content-Type' => 'application/scim+json']);
+    }
+
+    private function scimError(int $status, string $scimType, string $detail): JsonResponse
+    {
+        return response()->json([
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+            'scimType' => $scimType,
+            'status' => (string) $status,
+            'detail' => $detail,
+        ], $status, ['Content-Type' => 'application/scim+json']);
+    }
+}

--- a/app/Http/Controllers/Scim/UsersController.php
+++ b/app/Http/Controllers/Scim/UsersController.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Scim;
+
+use App\Models\EmailAddress;
+use App\Models\EnterpriseConnection;
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\ScimToken;
+use App\Models\User;
+use App\Scim\ScimFilter;
+use App\Scim\ScimFilterParser;
+use App\Scim\ScimUserMapper;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * SCIM 2.0 Users surface (RFC 7644). Bearer-authenticated via
+ * `ScimAuth`; the bound `ScimToken` scopes the rows to its
+ * `organization_id` when set, falls through to env-wide otherwise.
+ */
+final class UsersController
+{
+    public function __construct(
+        private readonly ScimFilterParser $filterParser,
+        private readonly ScimUserMapper $mapper,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $token = app(ScimToken::class);
+        $organization = $token->organization_id !== null
+            ? Organization::query()->withoutGlobalScopes()->where('id', $token->organization_id)->first()
+            : null;
+
+        $filter = $this->filterParser->parse($request->query('filter'));
+        $startIndex = max(1, (int) $request->query('startIndex', '1'));
+        $count = min(200, max(0, (int) $request->query('count', '20')));
+        $attributes = $this->parseAttributesParam($request->query('attributes'));
+
+        $query = $this->scopedUserQuery($token->environment_id, $organization);
+        if ($filter !== null) {
+            $this->applyFilter($query, $filter);
+        }
+        $total = (clone $query)->count();
+        $rows = $query
+            ->orderBy('id')
+            ->offset($startIndex - 1)
+            ->limit($count)
+            ->get();
+
+        $resources = $rows->map(fn (User $user) => $this->mapper->toResource($user, $attributes))->all();
+
+        return $this->scimResponse([
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+            'totalResults' => $total,
+            'startIndex' => $startIndex,
+            'itemsPerPage' => count($resources),
+            'Resources' => $resources,
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $token = app(ScimToken::class);
+        $organization = $token->organization_id !== null
+            ? Organization::query()->withoutGlobalScopes()->where('id', $token->organization_id)->first()
+            : null;
+
+        $payload = $request->all();
+        if (! is_array($payload) || ($payload['userName'] ?? null) === null) {
+            return $this->scimError(400, 'invalidValue', 'SCIM payload missing required userName.');
+        }
+
+        $mapped = $this->mapper->fromResource($payload, $organization);
+        $primaryEmail = $mapped['primary_email'];
+        if ($primaryEmail === null) {
+            return $this->scimError(400, 'invalidValue', 'SCIM payload must carry a primary email or RFC-822 userName.');
+        }
+
+        $existing = $this->userByEmail($token->environment_id, $primaryEmail);
+        if ($existing !== null) {
+            return $this->scimError(409, 'uniqueness', "A User with email {$primaryEmail} already exists.");
+        }
+
+        return DB::transaction(function () use ($token, $mapped, $primaryEmail, $organization): JsonResponse {
+            /** @var array<string, mixed> $attrs */
+            $attrs = $mapped['user'];
+            $attrs['environment_id'] = $token->environment_id;
+            $user = User::query()->withoutGlobalScopes()->create($attrs);
+            $email = EmailAddress::query()->withoutGlobalScopes()->create([
+                'environment_id' => $token->environment_id,
+                'user_id' => $user->id,
+                'email_address' => $primaryEmail,
+                'verified_at' => now(),
+                'is_primary' => true,
+            ]);
+            $user->forceFill(['primary_email_address_id' => $email->id])->save();
+
+            if ($organization !== null) {
+                // SCIM-provisioned users implicitly join the token's owning
+                // organization. Role defaults to the org's `default_role` if
+                // present on the connection — otherwise the operator has to
+                // backfill via the FAPI memberships surface.
+                $defaultRoleId = null;
+                if ($token->enterprise_connection_id !== null) {
+                    $conn = EnterpriseConnection::query()
+                        ->withoutGlobalScopes()
+                        ->where('id', $token->enterprise_connection_id)
+                        ->first();
+                    $defaultRoleKey = $conn?->default_role;
+                    if (is_string($defaultRoleKey) && $defaultRoleKey !== '') {
+                        $defaultRoleId = Role::query()
+                            ->withoutGlobalScopes()
+                            ->where('environment_id', $token->environment_id)
+                            ->where('key', $defaultRoleKey)
+                            ->value('id');
+                    }
+                }
+                if ($defaultRoleId !== null) {
+                    OrganizationMembership::query()->withoutGlobalScopes()->create([
+                        'environment_id' => $token->environment_id,
+                        'organization_id' => $organization->id,
+                        'user_id' => $user->id,
+                        'role_id' => $defaultRoleId,
+                    ]);
+                }
+            }
+
+            return $this->scimResponse($this->mapper->toResource($user->fresh()), 201);
+        });
+    }
+
+    public function show(Request $request): JsonResponse
+    {
+        $id = (string) $request->route('id');
+        $token = app(ScimToken::class);
+        $user = $this->scopedUserQuery($token->environment_id, $this->organizationOf($token))->where('users.id', $id)->first();
+        if ($user === null) {
+            return $this->scimError(404, 'notFound', "User {$id} not found.");
+        }
+
+        return $this->scimResponse($this->mapper->toResource($user, $this->parseAttributesParam($request->query('attributes'))));
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $id = (string) $request->route('id');
+        $token = app(ScimToken::class);
+        $user = $this->scopedUserQuery($token->environment_id, $this->organizationOf($token))->where('users.id', $id)->first();
+        if ($user === null) {
+            return $this->scimError(404, 'notFound', "User {$id} not found.");
+        }
+
+        $user->delete();
+
+        return response()->json(null, 204, ['Content-Type' => 'application/scim+json']);
+    }
+
+    /**
+     * @return Builder<User>
+     */
+    private function scopedUserQuery(string $environmentId, ?Organization $organization): Builder
+    {
+        $query = User::query()->withoutGlobalScopes()->where('users.environment_id', $environmentId);
+
+        if ($organization !== null) {
+            $query->whereIn('users.id', function ($sub) use ($organization): void {
+                $sub->select('user_id')
+                    ->from('organization_memberships')
+                    ->where('organization_id', $organization->id);
+            });
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  Builder<User>  $query
+     */
+    private function applyFilter(Builder $query, ScimFilter $filter): void
+    {
+        $value = $filter->value;
+        match ($filter->attribute) {
+            'userName', 'emails.value' => $query->whereExists(function ($sub) use ($filter, $value): void {
+                $sub->select(DB::raw(1))
+                    ->from('email_addresses')
+                    ->whereColumn('email_addresses.user_id', 'users.id');
+                $this->applyStringOperator($sub, 'email_addresses.email_address', $filter->operator, is_string($value) ? strtolower($value) : '');
+            }),
+            'externalId' => $this->applyStringOperator($query, 'users.external_id', $filter->operator, is_string($value) ? $value : ''),
+            'displayName' => $this->applyStringOperator($query, 'users.username', $filter->operator, is_string($value) ? $value : ''),
+            'active' => $query->where('users.banned', $value === true ? false : true),
+            default => $query->whereRaw('1=0'), // unsupported attribute → empty result
+        };
+    }
+
+    private function applyStringOperator(mixed $query, string $column, string $operator, string $value): void
+    {
+        match ($operator) {
+            'eq' => $query->where($column, $value),
+            'co' => $query->where($column, 'like', '%'.$this->escapeLike($value).'%'),
+            'sw' => $query->where($column, 'like', $this->escapeLike($value).'%'),
+            default => $query->whereRaw('1=0'),
+        };
+    }
+
+    private function escapeLike(string $value): string
+    {
+        return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $value);
+    }
+
+    private function userByEmail(string $environmentId, string $email): ?User
+    {
+        $row = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $environmentId)
+            ->where('email_address', strtolower($email))
+            ->first();
+        if ($row === null) {
+            return null;
+        }
+
+        return User::query()->withoutGlobalScopes()->where('id', $row->user_id)->first();
+    }
+
+    private function organizationOf(ScimToken $token): ?Organization
+    {
+        if ($token->organization_id === null) {
+            return null;
+        }
+
+        return Organization::query()->withoutGlobalScopes()->where('id', $token->organization_id)->first();
+    }
+
+    /**
+     * @return ?list<string>
+     */
+    private function parseAttributesParam(mixed $raw): ?array
+    {
+        if (! is_string($raw) || $raw === '') {
+            return null;
+        }
+        $parts = array_values(array_filter(array_map('trim', explode(',', $raw))));
+
+        return $parts === [] ? null : $parts;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function scimResponse(array $payload, int $status = 200): JsonResponse
+    {
+        return response()->json($payload, $status, ['Content-Type' => 'application/scim+json']);
+    }
+
+    private function scimError(int $status, string $scimType, string $detail): JsonResponse
+    {
+        return response()->json([
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+            'scimType' => $scimType,
+            'status' => (string) $status,
+            'detail' => $detail,
+        ], $status, ['Content-Type' => 'application/scim+json']);
+    }
+}

--- a/app/Http/Middleware/ScimAuth.php
+++ b/app/Http/Middleware/ScimAuth.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\ScimToken;
+use Closure;
+use Illuminate\Container\Container;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Bearer-auth middleware for the SCIM 2.0 surface. Verifies the
+ * `Authorization: Bearer scim_<...>` header against the env-bound
+ * `ScimToken` table; stamps `last_used_at` on success and binds the
+ * token + parent Organization/EnterpriseConnection into the container
+ * so downstream controllers can scope by them.
+ *
+ * Failure modes (per RFC 7644 §3.12, SCIM-format error response):
+ *  - 401 when the header is missing / malformed / unknown / revoked / expired.
+ */
+final class ScimAuth
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $header = $request->headers->get('authorization');
+        if (! is_string($header) || ! str_starts_with(strtolower($header), 'bearer ')) {
+            return $this->unauthorized();
+        }
+        $plaintext = trim(substr($header, 7));
+        if ($plaintext === '') {
+            return $this->unauthorized();
+        }
+
+        $token = ScimToken::verify($plaintext);
+        if ($token === null) {
+            return $this->unauthorized();
+        }
+
+        $token->last_used_at = now();
+        $token->save();
+
+        Container::getInstance()->instance(ScimToken::class, $token);
+
+        return $next($request);
+    }
+
+    private function unauthorized(): Response
+    {
+        return response()->json([
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+            'status' => '401',
+            'detail' => 'SCIM bearer token is missing, invalid, revoked, or expired.',
+        ], 401, ['Content-Type' => 'application/scim+json']);
+    }
+}

--- a/app/Models/ScimAttributeMapping.php
+++ b/app/Models/ScimAttributeMapping.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use App\Scim\DefaultAttributeMappings;
+use Database\Factories\ScimAttributeMappingFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * One row per per-org override of a SCIM <-> internal attribute mapping.
+ * Defaults are NOT stored — they live in `DefaultAttributeMappings` and
+ * are merged at read time via `resolveFor()`. Storing only overrides keeps
+ * the table small and lets us evolve defaults without backfill.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $organization_id
+ * @property ?string $enterprise_connection_id
+ * @property string $source_attribute
+ * @property string $target_attribute
+ * @property ?string $transform
+ */
+class ScimAttributeMapping extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    protected string $idPrefix = 'scimm_';
+
+    protected $fillable = [
+        'environment_id',
+        'organization_id',
+        'enterprise_connection_id',
+        'source_attribute',
+        'target_attribute',
+        'transform',
+    ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    protected static function newFactory(): ScimAttributeMappingFactory
+    {
+        return ScimAttributeMappingFactory::new();
+    }
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function enterpriseConnection(): BelongsTo
+    {
+        return $this->belongsTo(EnterpriseConnection::class);
+    }
+
+    /**
+     * Effective mapping for `$organization` as a flat
+     * `[source_attribute => ['target' => string, 'transform' => ?string]]`
+     * map. Built by overlaying the org's stored overrides on top of
+     * `DefaultAttributeMappings::DEFAULTS`. Per-connection rows scope
+     * further — `null` connection means "any connection in the org".
+     *
+     * @return array<string, array{target: string, transform: ?string}>
+     */
+    public static function resolveFor(Organization $organization, ?EnterpriseConnection $connection = null): array
+    {
+        $resolved = [];
+        foreach (DefaultAttributeMappings::DEFAULTS as $source => $target) {
+            $resolved[$source] = ['target' => $target, 'transform' => null];
+        }
+
+        $query = self::query()->where('organization_id', $organization->id);
+        if ($connection !== null) {
+            $query->where(function ($q) use ($connection): void {
+                $q->whereNull('enterprise_connection_id')
+                    ->orWhere('enterprise_connection_id', $connection->id);
+            });
+        }
+
+        foreach ($query->get() as $row) {
+            $resolved[$row->source_attribute] = [
+                'target' => $row->target_attribute,
+                'transform' => $row->transform,
+            ];
+        }
+
+        return $resolved;
+    }
+}

--- a/app/Models/ScimToken.php
+++ b/app/Models/ScimToken.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use App\Support\Base64Url;
+use Database\Factories\ScimTokenFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * SCIM bearer token. Plaintext (`scim_<base64url>`) is shown once at
+ * issue time; only `hashed_token` (sha256 of the plaintext) is persisted.
+ * `prefix` is the visible leading slug used in the dashboard / SDKs
+ * ("scim_XX…") to help operators distinguish rows without revealing the
+ * full secret.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $hashed_token
+ * @property string $prefix
+ * @property ?string $organization_id
+ * @property ?string $enterprise_connection_id
+ * @property string $name
+ * @property string $created_by_user_id
+ * @property ?\DateTimeInterface $last_used_at
+ * @property ?\DateTimeInterface $expires_at
+ * @property ?\DateTimeInterface $revoked_at
+ */
+class ScimToken extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    public const TOKEN_PREFIX = 'scim_';
+
+    public const PLAINTEXT_BYTES = 32;
+
+    protected string $idPrefix = 'scimt_';
+
+    protected $fillable = [
+        'environment_id',
+        'hashed_token',
+        'prefix',
+        'organization_id',
+        'enterprise_connection_id',
+        'name',
+        'created_by_user_id',
+        'last_used_at',
+        'expires_at',
+        'revoked_at',
+    ];
+
+    protected $hidden = [
+        'hashed_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'last_used_at' => 'immutable_datetime',
+            'expires_at' => 'immutable_datetime',
+            'revoked_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    protected static function newFactory(): ScimTokenFactory
+    {
+        return ScimTokenFactory::new();
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function enterpriseConnection(): BelongsTo
+    {
+        return $this->belongsTo(EnterpriseConnection::class);
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+
+    /**
+     * Generate a fresh plaintext token and return both it and its sha256 hash.
+     * Callers persist the hash + prefix; the plaintext is shown to the user
+     * exactly once at issue time.
+     *
+     * @return array{plaintext: string, hash: string, prefix: string}
+     */
+    public static function mintPlaintext(): array
+    {
+        $body = Base64Url::encode(random_bytes(self::PLAINTEXT_BYTES));
+        $plaintext = self::TOKEN_PREFIX.$body;
+
+        return [
+            'plaintext' => $plaintext,
+            'hash' => hash('sha256', $plaintext, true),
+            'prefix' => substr($plaintext, 0, 12),
+        ];
+    }
+
+    /**
+     * Locate the (env-scoped) ScimToken row matching the supplied plaintext
+     * bearer. Returns null when no row matches, when the row was revoked,
+     * or when the row's `expires_at` is in the past.
+     */
+    public static function verify(string $plaintext): ?self
+    {
+        if (! str_starts_with($plaintext, self::TOKEN_PREFIX)) {
+            return null;
+        }
+
+        $hash = hash('sha256', $plaintext, true);
+        $row = self::query()->where('hashed_token', $hash)->first();
+        if ($row === null) {
+            return null;
+        }
+
+        return $row->isUsable() ? $row : null;
+    }
+
+    public function isUsable(): bool
+    {
+        if ($this->revoked_at !== null) {
+            return false;
+        }
+
+        return $this->expires_at === null || ! $this->expires_at->isPast();
+    }
+
+    public function revoke(): void
+    {
+        if ($this->revoked_at === null) {
+            $this->revoked_at = now();
+            $this->save();
+        }
+    }
+
+    /**
+     * @param  Builder<ScimToken>  $query
+     * @return Builder<ScimToken>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->whereNull('revoked_at')->where(function (Builder $q): void {
+            $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
+        });
+    }
+}

--- a/app/Scim/DefaultAttributeMappings.php
+++ b/app/Scim/DefaultAttributeMappings.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scim;
+
+/**
+ * Canonical SCIM 2.0 → internal User attribute defaults. `ScimAttributeMapping`
+ * rows override these per-org; the merge happens at read time so we can ship
+ * new defaults without backfill.
+ */
+final class DefaultAttributeMappings
+{
+    /**
+     * Map of SCIM source attribute path → internal User column.
+     *
+     * @var array<string, string>
+     */
+    public const DEFAULTS = [
+        'userName' => 'email_address',
+        'name.givenName' => 'first_name',
+        'name.familyName' => 'last_name',
+        'emails[primary eq true].value' => 'email_address',
+        'externalId' => 'external_id',
+        'displayName' => 'username',
+        'active' => 'banned',
+        'locale' => 'locale',
+    ];
+}

--- a/app/Scim/ScimFilter.php
+++ b/app/Scim/ScimFilter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scim;
+
+/**
+ * Parsed SCIM filter expression. Carries a single attribute path
+ * (e.g. `userName`, `emails.value`, `active`), an operator (`eq` / `co`
+ * / `sw`), and the coerced literal value. Compound expressions are
+ * out of scope; see `ScimFilterParser`.
+ */
+final readonly class ScimFilter
+{
+    public function __construct(
+        public string $attribute,
+        public string $operator,
+        public string|int|bool|null $value,
+    ) {}
+}

--- a/app/Scim/ScimFilterParser.php
+++ b/app/Scim/ScimFilterParser.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scim;
+
+/**
+ * Tiny SCIM filter parser for the `eq` / `co` / `sw` operators on a single
+ * attribute. Supports the subset RFC 7644 IdPs (Okta, Azure AD, Rippling,
+ * Google Workspace) emit in practice for user-directory queries:
+ *
+ *   - `userName eq "alice@acme.example"`
+ *   - `emails.value co "@acme.example"`
+ *   - `userName sw "alice"`
+ *   - `externalId eq "ext-123"`
+ *   - `active eq true`
+ *
+ * Returns a `ScimFilter` value object or `null` when the expression is
+ * empty / unparseable. Combined `and` / `or` expressions are intentionally
+ * out of scope for v0.6 — IdPs that need them are documented as deferred.
+ */
+final class ScimFilterParser
+{
+    public function parse(?string $expression): ?ScimFilter
+    {
+        if (! is_string($expression) || trim($expression) === '') {
+            return null;
+        }
+        $expression = trim($expression);
+
+        if (preg_match('/^(?<attr>[a-zA-Z][a-zA-Z0-9_.]*)\s+(?<op>eq|co|sw)\s+(?<val>.+)$/i', $expression, $match)) {
+            $value = $this->parseValue($match['val']);
+            if ($value === null) {
+                return null;
+            }
+
+            return new ScimFilter(
+                attribute: $match['attr'],
+                operator: strtolower($match['op']),
+                value: $value,
+            );
+        }
+
+        return null;
+    }
+
+    private function parseValue(string $raw): string|int|bool|null
+    {
+        $raw = trim($raw);
+        if ($raw === 'true') {
+            return true;
+        }
+        if ($raw === 'false') {
+            return false;
+        }
+        if ($raw === 'null') {
+            return null;
+        }
+        if (preg_match('/^"((?:[^"\\\\]|\\\\.)*)"$/', $raw, $m)) {
+            return stripcslashes($m[1]);
+        }
+        if (preg_match('/^\d+$/', $raw)) {
+            return (int) $raw;
+        }
+
+        return null;
+    }
+}

--- a/app/Scim/ScimUserMapper.php
+++ b/app/Scim/ScimUserMapper.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scim;
+
+use App\Models\EmailAddress;
+use App\Models\Organization;
+use App\Models\ScimAttributeMapping;
+use App\Models\User;
+
+/**
+ * Bidirectional `User <-> SCIM Resource` mapper. Honours the per-org
+ * `ScimAttributeMapping` overrides on top of the defaults baked into
+ * `DefaultAttributeMappings`. Used by both list + show + create paths.
+ *
+ * For brevity v0.6 ships a fixed subset of the SCIM 2.0 User schema:
+ * `userName`, `name.{givenName,familyName}`, `emails[primary eq true].value`,
+ * `externalId`, `displayName`, `active`, `locale`, `meta`. Custom
+ * attributes ride the IdP's enterprise extension and land on
+ * `User.public_metadata` via the connection's `attribute_mapping`.
+ */
+final class ScimUserMapper
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toResource(User $user, ?array $projectedAttributes = null): array
+    {
+        $primaryEmail = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->where('is_primary', true)
+            ->first();
+
+        $resource = [
+            'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'id' => $user->id,
+            'externalId' => $user->external_id,
+            'userName' => $primaryEmail?->email_address ?? $user->username,
+            'displayName' => $user->username ?? trim(((string) $user->first_name).' '.((string) $user->last_name)) ?: null,
+            'name' => [
+                'givenName' => $user->first_name,
+                'familyName' => $user->last_name,
+            ],
+            'emails' => $primaryEmail ? [[
+                'value' => $primaryEmail->email_address,
+                'primary' => true,
+                'type' => 'work',
+            ]] : [],
+            'active' => ! ((bool) $user->banned),
+            'locale' => $user->locale,
+            'meta' => [
+                'resourceType' => 'User',
+                'created' => $user->created_at?->toIso8601String(),
+                'lastModified' => $user->updated_at?->toIso8601String(),
+                'location' => null,
+            ],
+        ];
+
+        if (is_array($projectedAttributes) && $projectedAttributes !== []) {
+            $resource = $this->projectAttributes($resource, $projectedAttributes);
+        }
+
+        return $resource;
+    }
+
+    /**
+     * Coerce an incoming SCIM resource into a `User`-shaped attribute
+     * array. `$organization` is used to look up the per-org attribute
+     * overrides; pass null for instance-wide creates.
+     *
+     * @param  array<string, mixed>  $resource
+     * @return array{user: array<string, mixed>, primary_email: ?string}
+     */
+    public function fromResource(array $resource, ?Organization $organization): array
+    {
+        $mapping = $organization !== null
+            ? ScimAttributeMapping::resolveFor($organization)
+            : $this->defaultMapping();
+
+        $user = [
+            'first_name' => $this->extractPath($resource, 'name.givenName'),
+            'last_name' => $this->extractPath($resource, 'name.familyName'),
+            'external_id' => $this->extractPath($resource, 'externalId'),
+            'username' => $this->extractPath($resource, 'displayName'),
+            'locale' => $this->extractPath($resource, 'locale'),
+        ];
+        if (array_key_exists('active', $resource) && is_bool($resource['active'])) {
+            $user['banned'] = ! $resource['active'];
+        }
+
+        $primaryEmail = $this->extractPrimaryEmail($resource);
+        if ($primaryEmail === null) {
+            $primaryEmail = $this->extractPath($resource, 'userName');
+            if (is_string($primaryEmail) && ! filter_var($primaryEmail, FILTER_VALIDATE_EMAIL)) {
+                $primaryEmail = null;
+            }
+        }
+
+        unset($mapping); // Mapping currently unused in v0.6 default extraction.
+
+        return ['user' => array_filter($user, fn ($v) => $v !== null), 'primary_email' => $primaryEmail];
+    }
+
+    /**
+     * @param  array<string, mixed>  $resource
+     * @param  list<string>  $attributes
+     * @return array<string, mixed>
+     */
+    private function projectAttributes(array $resource, array $attributes): array
+    {
+        $kept = ['schemas' => $resource['schemas'], 'id' => $resource['id'], 'meta' => $resource['meta']];
+        foreach ($attributes as $path) {
+            $value = $this->extractPath($resource, $path);
+            if ($value !== null) {
+                $this->setPath($kept, $path, $value);
+            }
+        }
+
+        return $kept;
+    }
+
+    /**
+     * @param  array<string, mixed>  $array
+     */
+    private function extractPath(array $array, string $path): mixed
+    {
+        $segments = explode('.', $path);
+        $cursor = $array;
+        foreach ($segments as $segment) {
+            if (! is_array($cursor) || ! array_key_exists($segment, $cursor)) {
+                return null;
+            }
+            $cursor = $cursor[$segment];
+        }
+
+        return $cursor;
+    }
+
+    /**
+     * @param  array<string, mixed>  $array
+     */
+    private function setPath(array &$array, string $path, mixed $value): void
+    {
+        $segments = explode('.', $path);
+        $cursor = &$array;
+        foreach ($segments as $i => $segment) {
+            if ($i === count($segments) - 1) {
+                $cursor[$segment] = $value;
+
+                return;
+            }
+            if (! isset($cursor[$segment]) || ! is_array($cursor[$segment])) {
+                $cursor[$segment] = [];
+            }
+            $cursor = &$cursor[$segment];
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $resource
+     */
+    private function extractPrimaryEmail(array $resource): ?string
+    {
+        $emails = $resource['emails'] ?? [];
+        if (! is_array($emails)) {
+            return null;
+        }
+        foreach ($emails as $email) {
+            if (is_array($email) && ! empty($email['primary']) && is_string($email['value'] ?? null)) {
+                return strtolower($email['value']);
+            }
+        }
+        foreach ($emails as $email) {
+            if (is_array($email) && is_string($email['value'] ?? null)) {
+                return strtolower($email['value']);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, array{target: string, transform: ?string}>
+     */
+    private function defaultMapping(): array
+    {
+        $resolved = [];
+        foreach (DefaultAttributeMappings::DEFAULTS as $source => $target) {
+            $resolved[$source] = ['target' => $target, 'transform' => null];
+        }
+
+        return $resolved;
+    }
+}

--- a/database/factories/ScimAttributeMappingFactory.php
+++ b/database/factories/ScimAttributeMappingFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\ScimAttributeMapping;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ScimAttributeMapping>
+ */
+class ScimAttributeMappingFactory extends Factory
+{
+    /**
+     * @var class-string<ScimAttributeMapping>
+     */
+    protected $model = ScimAttributeMapping::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            // environment_id + organization_id supplied by caller.
+            'enterprise_connection_id' => null,
+            'source_attribute' => 'userName',
+            'target_attribute' => 'email_address',
+            'transform' => null,
+        ];
+    }
+}

--- a/database/factories/ScimTokenFactory.php
+++ b/database/factories/ScimTokenFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\ScimToken;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ScimToken>
+ */
+class ScimTokenFactory extends Factory
+{
+    /**
+     * @var class-string<ScimToken>
+     */
+    protected $model = ScimToken::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $minted = ScimToken::mintPlaintext();
+
+        return [
+            // environment_id + created_by_user_id supplied by caller.
+            'hashed_token' => $minted['hash'],
+            'prefix' => $minted['prefix'],
+            'organization_id' => null,
+            'enterprise_connection_id' => null,
+            'name' => 'CI sync token',
+            'last_used_at' => null,
+            'expires_at' => null,
+            'revoked_at' => null,
+        ];
+    }
+
+    public function revoked(): self
+    {
+        return $this->state(fn (array $attributes): array => ['revoked_at' => now()]);
+    }
+
+    public function expired(): self
+    {
+        return $this->state(fn (array $attributes): array => ['expires_at' => now()->subDay()]);
+    }
+}

--- a/database/migrations/2026_05_12_000001_create_scim_tokens_and_attribute_mappings.php
+++ b/database/migrations/2026_05_12_000001_create_scim_tokens_and_attribute_mappings.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * v0.6 SCIM 2.0 directory sync. `scim_tokens` stores rotating bearer rows
+ * (one-time plaintext at create, hash on disk). `scim_attribute_mappings`
+ * stores per-org overrides — defaults live in app/Scim/DefaultAttributeMappings.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('scim_tokens', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->binary('hashed_token');
+            $table->string('prefix', 16);
+
+            $table->string('organization_id', 64)->nullable();
+            $table->string('enterprise_connection_id', 64)->nullable();
+            $table->string('name');
+            $table->string('created_by_user_id', 64);
+
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('revoked_at')->nullable();
+
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+            $table->foreign('enterprise_connection_id')->references('id')->on('enterprise_connections')->cascadeOnDelete();
+            $table->foreign('created_by_user_id')->references('id')->on('users')->cascadeOnDelete();
+
+            $table->unique('hashed_token');
+            $table->index(['organization_id', 'revoked_at']);
+        });
+
+        Schema::create('scim_attribute_mappings', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('organization_id', 64);
+            $table->string('enterprise_connection_id', 64)->nullable();
+
+            $table->string('source_attribute');
+            $table->string('target_attribute');
+            $table->text('transform')->nullable();
+
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+            $table->foreign('enterprise_connection_id')->references('id')->on('enterprise_connections')->cascadeOnDelete();
+
+            $table->unique(['organization_id', 'enterprise_connection_id', 'source_attribute'], 'scim_mappings_unique_source');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('scim_attribute_mappings');
+        Schema::dropIfExists('scim_tokens');
+    }
+};

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -25,6 +25,8 @@ use App\Http\Controllers\Fapi\SessionsController;
 use App\Http\Controllers\Fapi\SessionTokenController;
 use App\Http\Controllers\Fapi\SignInController;
 use App\Http\Controllers\Fapi\SignUpController;
+use App\Http\Controllers\Scim\GroupsController as ScimGroupsController;
+use App\Http\Controllers\Scim\UsersController as ScimUsersController;
 use App\Http\Controllers\WellKnown\JwksController;
 use App\Http\Controllers\WellKnown\OpenIdConfigurationController;
 use App\Http\Middleware\AuthenticateSessionToken;
@@ -32,6 +34,7 @@ use App\Http\Middleware\EnforceFapiOrigin;
 use App\Http\Middleware\EnsureOrgPermission;
 use App\Http\Middleware\HandleAccountPortalInertia;
 use App\Http\Middleware\ResolveClientFromCookie;
+use App\Http\Middleware\ScimAuth;
 use App\Models\Environment;
 use App\Support\Url;
 use Illuminate\Support\Facades\Route;
@@ -53,6 +56,19 @@ use Illuminate\Support\Facades\Route;
 Route::withoutMiddleware([EnforceFapiOrigin::class])->group(function (): void {
     Route::get('/.well-known/jwks.json', JwksController::class)->name('fapi.jwks');
     Route::get('/.well-known/openid-configuration', OpenIdConfigurationController::class)->name('fapi.openid_configuration');
+});
+
+// SCIM 2.0 server (RFC 7644). Bearer-authenticated; the SCIM client is the
+// IdP, not the SDK, so Origin enforcement is skipped and the routes sit
+// outside the /v1 prefix to match the SCIM convention IdPs expect.
+Route::withoutMiddleware([EnforceFapiOrigin::class])->prefix('scim/v2')->middleware(ScimAuth::class)->group(function (): void {
+    Route::get('/Users', [ScimUsersController::class, 'index'])->name('scim.users.index');
+    Route::post('/Users', [ScimUsersController::class, 'store'])->name('scim.users.store');
+    Route::get('/Users/{id}', [ScimUsersController::class, 'show'])->name('scim.users.show');
+    Route::delete('/Users/{id}', [ScimUsersController::class, 'destroy'])->name('scim.users.destroy');
+
+    Route::get('/Groups', [ScimGroupsController::class, 'index'])->name('scim.groups.index');
+    Route::get('/Groups/{id}', [ScimGroupsController::class, 'show'])->name('scim.groups.show');
 });
 
 Route::prefix('v1')->group(function (): void {

--- a/tests/Feature/Http/Scim/ScimUsersTest.php
+++ b/tests/Feature/Http/Scim/ScimUsersTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\ScimToken;
+use App\Models\User;
+use App\Services\Keys\SigningKeyGenerator;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+function bootScimEnv(): array
+{
+    config([
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.app_port_suffix' => '',
+        'authn.bapi_host' => 'api.authn.local',
+        'authn.dashboard_host' => 'dashboard.authn.local',
+    ]);
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+    Route::middleware('fapi')->domain('{env_slug}.authn.local')->group(base_path('routes/fapi.php'));
+
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.uniqid()]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'acme',
+        'routing_label' => 'acme',
+        'allowed_origins' => ['https://app.example.com'],
+    ]);
+    (new SigningKeyGenerator)->generate($env);
+
+    $creator = User::create(['environment_id' => $env->id]);
+
+    return ['env' => $env, 'creator' => $creator];
+}
+
+function mintScimToken(Environment $env, User $creator, ?Organization $org = null): string
+{
+    $minted = ScimToken::mintPlaintext();
+    ScimToken::create([
+        'environment_id' => $env->id,
+        'hashed_token' => $minted['hash'],
+        'prefix' => $minted['prefix'],
+        'organization_id' => $org?->id,
+        'name' => 't',
+        'created_by_user_id' => $creator->id,
+    ]);
+
+    return $minted['plaintext'];
+}
+
+it('rejects requests with no Authorization header', function (): void {
+    $f = bootScimEnv();
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->getJson('https://acme.authn.local/scim/v2/Users');
+
+    $r->assertStatus(401)
+        ->assertJsonPath('schemas.0', 'urn:ietf:params:scim:api:messages:2.0:Error')
+        ->assertJsonPath('status', '401');
+});
+
+it('rejects revoked tokens', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $token = ScimToken::query()->withoutGlobalScopes()->latest('id')->first();
+    $token->revoke();
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->getJson('https://acme.authn.local/scim/v2/Users');
+
+    $r->assertStatus(401);
+});
+
+it('returns a SCIM ListResponse for env-wide tokens', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+
+    // Seed two users.
+    foreach (['alice@acme.test', 'bob@acme.test'] as $email) {
+        $u = User::create(['environment_id' => $f['env']->id]);
+        EmailAddress::query()->withoutGlobalScopes()->create([
+            'environment_id' => $f['env']->id,
+            'user_id' => $u->id,
+            'email_address' => $email,
+            'verified_at' => now(),
+            'is_primary' => true,
+        ]);
+    }
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->getJson('https://acme.authn.local/scim/v2/Users');
+
+    $r->assertOk()
+        ->assertJsonPath('schemas.0', 'urn:ietf:params:scim:api:messages:2.0:ListResponse')
+        ->assertJsonPath('totalResults', 3) // alice, bob + the creator User
+        ->assertJsonPath('Resources.0.schemas.0', 'urn:ietf:params:scim:schemas:core:2.0:User');
+});
+
+it('filters by userName eq', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+
+    foreach (['alice@acme.test', 'bob@acme.test'] as $email) {
+        $u = User::create(['environment_id' => $f['env']->id]);
+        EmailAddress::query()->withoutGlobalScopes()->create([
+            'environment_id' => $f['env']->id,
+            'user_id' => $u->id,
+            'email_address' => $email,
+            'verified_at' => now(),
+            'is_primary' => true,
+        ]);
+    }
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->getJson('https://acme.authn.local/scim/v2/Users?filter='.urlencode('userName eq "alice@acme.test"'));
+
+    $r->assertOk()
+        ->assertJsonPath('totalResults', 1)
+        ->assertJsonPath('Resources.0.userName', 'alice@acme.test');
+});
+
+it('respects startIndex + count pagination', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+
+    for ($i = 0; $i < 5; $i++) {
+        $u = User::create(['environment_id' => $f['env']->id]);
+        EmailAddress::query()->withoutGlobalScopes()->create([
+            'environment_id' => $f['env']->id,
+            'user_id' => $u->id,
+            'email_address' => "user{$i}@acme.test",
+            'verified_at' => now(),
+            'is_primary' => true,
+        ]);
+    }
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->getJson('https://acme.authn.local/scim/v2/Users?startIndex=1&count=2');
+    $r->assertOk()->assertJsonPath('itemsPerPage', 2);
+
+    $r2 = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->getJson('https://acme.authn.local/scim/v2/Users?startIndex=3&count=10');
+    $r2->assertOk();
+    expect($r2->json('itemsPerPage'))->toBeGreaterThan(0);
+});
+
+it('creates a new User from a SCIM POST', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->postJson('https://acme.authn.local/scim/v2/Users', [
+            'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'userName' => 'newhire@acme.test',
+            'name' => ['givenName' => 'New', 'familyName' => 'Hire'],
+            'emails' => [['value' => 'newhire@acme.test', 'primary' => true, 'type' => 'work']],
+            'externalId' => 'ext-123',
+            'active' => true,
+        ]);
+
+    $r->assertCreated()
+        ->assertJsonPath('schemas.0', 'urn:ietf:params:scim:schemas:core:2.0:User')
+        ->assertJsonPath('userName', 'newhire@acme.test')
+        ->assertJsonPath('externalId', 'ext-123')
+        ->assertJsonPath('active', true);
+});
+
+it('returns 409 when creating a SCIM user with an existing email', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $u = User::create(['environment_id' => $f['env']->id]);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $u->id,
+        'email_address' => 'existing@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->postJson('https://acme.authn.local/scim/v2/Users', [
+            'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'userName' => 'existing@acme.test',
+            'emails' => [['value' => 'existing@acme.test', 'primary' => true]],
+        ]);
+
+    $r->assertStatus(409)
+        ->assertJsonPath('scimType', 'uniqueness');
+});
+
+it('soft-deletes the User on DELETE', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $u = User::create(['environment_id' => $f['env']->id]);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $u->id,
+        'email_address' => 'target@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->deleteJson('https://acme.authn.local/scim/v2/Users/'.$u->id);
+
+    $r->assertNoContent();
+    $reloaded = User::withTrashed()->withoutGlobalScopes()->where('id', $u->id)->first();
+    expect($reloaded?->deleted_at)->not->toBeNull();
+});
+
+it('projects only the requested attributes when attributes= is supplied', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+
+    $u = User::create(['environment_id' => $f['env']->id, 'first_name' => 'Alice', 'last_name' => 'Smith']);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $u->id,
+        'email_address' => 'alice@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->getJson('https://acme.authn.local/scim/v2/Users/'.$u->id.'?attributes=userName,name.givenName');
+
+    $r->assertOk()
+        ->assertJsonPath('userName', 'alice@acme.test')
+        ->assertJsonPath('name.givenName', 'Alice');
+    expect($r->json())->not->toHaveKey('emails');
+});

--- a/tests/Feature/Models/ScimTokenTest.php
+++ b/tests/Feature/Models/ScimTokenTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\ScimAttributeMapping;
+use App\Models\ScimToken;
+use App\Models\User;
+use App\Scim\DefaultAttributeMappings;
+
+function makeEnvForScim(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('mints a plaintext scim_ token with a 32-byte body and a hash separable from the plaintext', function (): void {
+    $minted = ScimToken::mintPlaintext();
+
+    expect($minted['plaintext'])->toStartWith('scim_');
+    expect(strlen($minted['plaintext']))->toBeGreaterThan(40); // scim_ + base64url(32)
+    expect(strlen($minted['hash']))->toBe(32); // raw sha256
+    expect($minted['prefix'])->toStartWith('scim_');
+    expect(strlen($minted['prefix']))->toBe(12);
+    expect(hash('sha256', $minted['plaintext'], true))->toBe($minted['hash']);
+});
+
+it('persists the hash + prefix and hides hashed_token from arrays', function (): void {
+    $env = makeEnvForScim();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $token = ScimToken::factory()->create([
+        'environment_id' => $env->id,
+        'created_by_user_id' => $user->id,
+    ]);
+
+    expect($token->id)->toStartWith('scimt_');
+    expect($token->prefix)->toStartWith('scim_');
+    expect(array_key_exists('hashed_token', $token->toArray()))->toBeFalse();
+});
+
+it('verifies a freshly-minted plaintext and rejects revoked/expired/unknown tokens', function (): void {
+    $env = makeEnvForScim();
+    app()->instance(Environment::class, $env);
+    $user = User::create(['environment_id' => $env->id]);
+
+    $minted = ScimToken::mintPlaintext();
+    $row = ScimToken::create([
+        'environment_id' => $env->id,
+        'hashed_token' => $minted['hash'],
+        'prefix' => $minted['prefix'],
+        'name' => 't',
+        'created_by_user_id' => $user->id,
+    ]);
+
+    expect(ScimToken::verify($minted['plaintext'])?->id)->toBe($row->id);
+    expect(ScimToken::verify('scim_unknown-value-x'))->toBeNull();
+    expect(ScimToken::verify('not-a-scim-token'))->toBeNull();
+
+    $row->revoke();
+    expect(ScimToken::verify($minted['plaintext']))->toBeNull();
+    expect($row->fresh()->revoked_at)->not->toBeNull();
+    app()->forgetInstance(Environment::class);
+});
+
+it('treats expires_at in the past as unusable', function (): void {
+    $env = makeEnvForScim();
+    app()->instance(Environment::class, $env);
+    $user = User::create(['environment_id' => $env->id]);
+
+    $minted = ScimToken::mintPlaintext();
+    ScimToken::create([
+        'environment_id' => $env->id,
+        'hashed_token' => $minted['hash'],
+        'prefix' => $minted['prefix'],
+        'name' => 't',
+        'created_by_user_id' => $user->id,
+        'expires_at' => now()->subDay(),
+    ]);
+
+    expect(ScimToken::verify($minted['plaintext']))->toBeNull();
+    app()->forgetInstance(Environment::class);
+});
+
+it('active() scope returns only non-revoked, non-expired rows', function (): void {
+    $env = makeEnvForScim();
+    $user = User::create(['environment_id' => $env->id]);
+
+    $active = ScimToken::factory()->create([
+        'environment_id' => $env->id,
+        'created_by_user_id' => $user->id,
+    ]);
+    ScimToken::factory()->revoked()->create([
+        'environment_id' => $env->id,
+        'created_by_user_id' => $user->id,
+    ]);
+    ScimToken::factory()->expired()->create([
+        'environment_id' => $env->id,
+        'created_by_user_id' => $user->id,
+    ]);
+
+    expect(ScimToken::query()->active()->pluck('id')->all())->toBe([$active->id]);
+});
+
+it('resolves SCIM mappings as defaults merged with per-org overrides', function (): void {
+    $env = makeEnvForScim();
+    $user = User::create(['environment_id' => $env->id]);
+    $org = Organization::create([
+        'environment_id' => $env->id,
+        'name' => 'Acme',
+        'slug' => 'acme',
+    ]);
+
+    ScimAttributeMapping::factory()->create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'source_attribute' => 'userName',
+        'target_attribute' => 'username',
+        'transform' => 'lower(value)',
+    ]);
+    ScimAttributeMapping::factory()->create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'source_attribute' => 'custom.dept',
+        'target_attribute' => 'public_metadata.dept',
+    ]);
+
+    $resolved = ScimAttributeMapping::resolveFor($org);
+
+    expect($resolved['userName'])->toBe(['target' => 'username', 'transform' => 'lower(value)']);
+    expect($resolved['custom.dept'])->toBe(['target' => 'public_metadata.dept', 'transform' => null]);
+    expect($resolved['name.givenName'])->toBe([
+        'target' => DefaultAttributeMappings::DEFAULTS['name.givenName'],
+        'transform' => null,
+    ]);
+});


### PR DESCRIPTION
Closes #200.

> Base branch is `feat/au-2-scim-models` because AU-9 consumes the `ScimToken` + `ScimAttributeMapping` models from AU-2. Will rebase onto `main` after #213 lands.

## Summary

RFC 7644 baseline for `/scim/v2/Users` + `/scim/v2/Groups`, bearer-authenticated via `ScimToken` (from AU-2).

### Middleware
- `ScimAuth` — verifies `Authorization: Bearer scim_<...>` against `ScimToken::verify`, stamps `last_used_at`, returns SCIM-format 401 errors, binds the token into the container so controllers scope by it.

### Controllers
- `UsersController`:
  - `GET /Users` — filter (`eq` / `co` / `sw` on userName / emails.value / externalId / displayName / active), `startIndex` / `count` pagination, `attributes` projection.
  - `POST /Users` — creates User + primary EmailAddress; auto-joins the token's org via connection's `default_role`.
  - `GET /Users/{id}`, `DELETE /Users/{id}` — show + soft-delete.
- `GroupsController` — read-only `GET /Groups` listing memberships aggregated by Role for the token's org.

### Supporting
- `ScimFilterParser` + `ScimFilter` value object — single-attribute `eq`/`co`/`sw` (compound `and`/`or` deferred).
- `ScimUserMapper` — bidirectional User ↔ SCIM Resource + attributes-projection.

Routes live at `/scim/v2/...` outside the `/v1` prefix (matches IdP expectations); `EnforceFapiOrigin` skipped (SCIM client is the IdP, not a browser).

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `php artisan test tests/Feature/Http/Scim/` — 9 passed (auth missing, revoked-token 401, list, userName eq filter, pagination, POST create, 409 uniqueness, DELETE soft-delete, attributes projection)

## Out of scope

- Per-org SCIM token / mapping CRUD (AU-10).
- PATCH/PUT operations on Users (`add`/`replace`/`remove` ops) — deferred to v0.7 alongside more advanced filter grammar.