### PR TITLE
Add BAPI /v1/enterprise-connections instance-wide CRUD (AU-5)

### DIFF
--- a/app/Http/Controllers/Bapi/EnterpriseConnectionController.php
+++ b/app/Http/Controllers/Bapi/EnterpriseConnectionController.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Auth\EnterpriseSso\OidcConnectionService;
+use App\Auth\EnterpriseSso\OidcDiscoveryException;
+use App\Http\Resources\EnterpriseConnectionResource;
+use App\Models\EnterpriseAccount;
+use App\Models\EnterpriseConnection;
+use App\Models\Environment;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Throwable;
+
+/**
+ * BAPI `/v1/enterprise-connections` — instance-wide CRUD (OA-4). Per-org
+ * creation goes through the FAPI surface in AU-6. Mirrors the v0.4
+ * `OauthProviderController` shape.
+ *
+ *   GET    /v1/enterprise-connections                              (with ?organization_id filter)
+ *   POST   /v1/enterprise-connections
+ *   GET    /v1/enterprise-connections/{id}
+ *   PATCH  /v1/enterprise-connections/{id}
+ *   DELETE /v1/enterprise-connections/{id}   — 409 when EnterpriseAccount rows still link
+ *   POST   /v1/enterprise-connections/{id}/test
+ */
+final class EnterpriseConnectionController
+{
+    public function __construct(private readonly OidcConnectionService $oidc) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $query = EnterpriseConnection::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->orderBy('id');
+
+        if ($request->has('organization_id')) {
+            $orgId = $request->input('organization_id');
+            if ($orgId === null || $orgId === '') {
+                $query->whereNull('organization_id');
+            } else {
+                $query->where('organization_id', $orgId);
+            }
+        }
+
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (EnterpriseConnection $c) => EnterpriseConnectionResource::from($c))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        // Instance-wide creates only on this surface — per-org goes through
+        // the FAPI per-org endpoint in AU-6.
+        if ($request->has('organization_id') && $request->input('organization_id') !== null) {
+            return $this->error(422, 'organization_id_not_allowed', 'Use the per-org FAPI endpoint to scope a connection to an organization.');
+        }
+
+        $validator = Validator::make($request->all(), $this->validationRules($request, isCreate: true));
+        if ($validator->fails()) {
+            return $this->validationError($validator->errors()->toArray());
+        }
+        $data = $validator->validated();
+        $data['environment_id'] = $env->id;
+
+        $conn = EnterpriseConnection::query()->withoutGlobalScopes()->create($data);
+
+        return response()->json(EnterpriseConnectionResource::from($conn->fresh()), 201)
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function show(Request $request): JsonResponse
+    {
+        $conn = $this->loadOrFail($request);
+        if ($conn instanceof JsonResponse) {
+            return $conn;
+        }
+
+        return response()->json(EnterpriseConnectionResource::from($conn))->header('Cache-Control', 'no-store');
+    }
+
+    public function update(Request $request): JsonResponse
+    {
+        $conn = $this->loadOrFail($request);
+        if ($conn instanceof JsonResponse) {
+            return $conn;
+        }
+
+        if ($request->has('protocol') && $request->input('protocol') !== $conn->protocol) {
+            return $this->error(422, 'protocol_immutable', 'protocol cannot change after a connection is created.');
+        }
+        if ($request->has('organization_id') && $request->input('organization_id') !== $conn->organization_id) {
+            return $this->error(422, 'organization_id_immutable', 'organization_id cannot change after a connection is created.');
+        }
+
+        $validator = Validator::make($request->all(), $this->validationRules($request, isCreate: false, protocol: $conn->protocol));
+        if ($validator->fails()) {
+            return $this->validationError($validator->errors()->toArray());
+        }
+        $conn->fill(array_intersect_key($validator->validated(), array_flip([
+            'name', 'enabled', 'domains', 'default_role', 'attribute_mapping',
+            'saml_idp_entity_id', 'saml_sso_url', 'saml_idp_certificate',
+            'saml_signing_algorithm', 'saml_audience_uri', 'saml_signing_key',
+            'oidc_issuer', 'oidc_discovery_endpoint', 'oidc_client_id', 'oidc_client_secret', 'oidc_scopes',
+        ])));
+        $conn->save();
+
+        return response()->json(EnterpriseConnectionResource::from($conn->fresh()))->header('Cache-Control', 'no-store');
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $conn = $this->loadOrFail($request);
+        if ($conn instanceof JsonResponse) {
+            return $conn;
+        }
+
+        $linked = EnterpriseAccount::query()->withoutGlobalScopes()
+            ->where('enterprise_connection_id', $conn->id)
+            ->exists();
+        if ($linked) {
+            return $this->error(409, 'enterprise_connection_in_use', 'Cannot delete — there are still EnterpriseAccount rows linked to this connection.');
+        }
+
+        $conn->delete();
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * `test` dry-run — for OIDC fetches the discovery document; for SAML
+     * validates the configured `saml_idp_entity_id` and (when set) the
+     * IdP-side metadata URL is reachable. Returns a structured result
+     * envelope; never alters connection state.
+     */
+    public function test(Request $request): JsonResponse
+    {
+        $conn = $this->loadOrFail($request);
+        if ($conn instanceof JsonResponse) {
+            return $conn;
+        }
+
+        if ($conn->isOidc()) {
+            try {
+                $endpoints = $this->oidc->discover($conn);
+
+                return response()->json([
+                    'authorize_url' => $endpoints['authorization_endpoint'],
+                    'discovery_status' => 200,
+                    'errors' => [],
+                ]);
+            } catch (OidcDiscoveryException $e) {
+                return response()->json([
+                    'authorize_url' => '',
+                    'discovery_status' => null,
+                    'errors' => [[
+                        'code' => 'oidc_discovery_failed',
+                        'message' => 'OIDC discovery failed.',
+                        'long_message' => $e->getMessage(),
+                    ]],
+                ]);
+            } catch (Throwable $e) {
+                return response()->json([
+                    'authorize_url' => '',
+                    'discovery_status' => null,
+                    'errors' => [[
+                        'code' => 'oidc_discovery_failed',
+                        'message' => 'OIDC discovery failed.',
+                        'long_message' => $e->getMessage(),
+                    ]],
+                ]);
+            }
+        }
+
+        $errors = [];
+        foreach (['saml_idp_entity_id', 'saml_sso_url', 'saml_idp_certificate'] as $field) {
+            $value = $conn->{$field};
+            if (! is_string($value) || $value === '') {
+                $errors[] = [
+                    'code' => 'saml_missing_field',
+                    'message' => "Field {$field} is required.",
+                    'long_message' => "The SAML connection cannot be exercised until `{$field}` is set on the row. Update the connection and retry the test.",
+                    'meta' => ['param' => $field],
+                ];
+            }
+        }
+
+        return response()->json([
+            'authorize_url' => $errors === [] ? (string) $conn->saml_sso_url : '',
+            'discovery_status' => $errors === [] ? 200 : null,
+            'errors' => $errors,
+        ]);
+    }
+
+    /**
+     * @return array<string, list<string>|string>
+     */
+    private function validationRules(Request $request, bool $isCreate, ?string $protocol = null): array
+    {
+        $protocol = $protocol ?? (string) $request->input('protocol');
+        $rules = [
+            'protocol' => $isCreate ? 'required|in:saml,oidc' : 'in:saml,oidc',
+            'name' => $isCreate ? 'required|string|max:255' : 'string|max:255',
+            'enabled' => 'boolean',
+            'domains' => 'array',
+            'domains.*' => 'string',
+            'default_role' => 'nullable|string|max:255',
+            'attribute_mapping' => 'array',
+        ];
+        if ($protocol === EnterpriseConnection::PROTOCOL_SAML) {
+            $rules += [
+                'saml_idp_entity_id' => ($isCreate ? 'required|' : '').'string|max:512',
+                'saml_sso_url' => ($isCreate ? 'required|' : '').'url|max:512',
+                'saml_idp_certificate' => ($isCreate ? 'required|' : '').'string',
+                'saml_signing_algorithm' => 'nullable|string|max:128',
+                'saml_audience_uri' => 'nullable|string|max:512',
+                'saml_signing_key' => 'nullable|string',
+            ];
+        }
+        if ($protocol === EnterpriseConnection::PROTOCOL_OIDC) {
+            $rules += [
+                'oidc_issuer' => ($isCreate ? 'required|' : '').'url|max:512',
+                'oidc_discovery_endpoint' => 'nullable|url|max:512',
+                'oidc_client_id' => ($isCreate ? 'required|' : '').'string|max:255',
+                'oidc_client_secret' => ($isCreate ? 'required|' : '').'string',
+                'oidc_scopes' => 'array',
+                'oidc_scopes.*' => 'string',
+            ];
+        }
+
+        return $rules;
+    }
+
+    private function loadOrFail(Request $request): EnterpriseConnection|JsonResponse
+    {
+        $env = app(Environment::class);
+        $id = (string) $request->route('enterprise_connection_id');
+        $conn = EnterpriseConnection::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $id)
+            ->first();
+        if ($conn === null) {
+            return $this->error(404, 'enterprise_connection_not_found', "EnterpriseConnection {$id} not found.");
+        }
+
+        return $conn;
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [['code' => $code, 'message' => $message]],
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    /**
+     * @param  array<string, list<string>>  $errors
+     */
+    private function validationError(array $errors): JsonResponse
+    {
+        $flat = [];
+        foreach ($errors as $field => $messages) {
+            foreach ($messages as $message) {
+                $flat[] = ['code' => 'form_param_invalid', 'message' => $message, 'param' => $field];
+            }
+        }
+
+        return response()->json(['errors' => $flat], 422)->header('Cache-Control', 'no-store');
+    }
+}

--- a/app/Http/Resources/EnterpriseConnectionResource.php
+++ b/app/Http/Resources/EnterpriseConnectionResource.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Auth\EnterpriseSso\OidcConnectionService;
+use App\Auth\Saml\SamlConnectionService;
+use App\Models\EnterpriseConnection;
+
+/**
+ * BAPI/FAPI shape for `EnterpriseConnection`. Mirrors OA-1. Encrypted
+ * fields (`saml_signing_key`, `oidc_client_secret`) are never returned;
+ * computed read-only fields (`saml_acs_url`, `saml_sp_entity_id`,
+ * `oidc_redirect_uri`) are derived from the env's FAPI host.
+ */
+final class EnterpriseConnectionResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function from(EnterpriseConnection $conn): array
+    {
+        $base = [
+            'object' => 'enterprise_connection',
+            'id' => $conn->id,
+            'protocol' => $conn->protocol,
+            'name' => $conn->name,
+            'enabled' => (bool) $conn->enabled,
+            'organization_id' => $conn->organization_id,
+            'domains' => is_array($conn->domains) ? array_values($conn->domains) : [],
+            'default_role' => $conn->default_role ?? '',
+            'attribute_mapping' => is_array($conn->attribute_mapping) ? $conn->attribute_mapping : [],
+            'created_at' => $conn->created_at?->getTimestampMs(),
+            'updated_at' => $conn->updated_at?->getTimestampMs(),
+        ];
+
+        if ($conn->isSaml()) {
+            $saml = app(SamlConnectionService::class);
+
+            return array_merge($base, [
+                'saml_idp_entity_id' => $conn->saml_idp_entity_id,
+                'saml_sso_url' => $conn->saml_sso_url,
+                'saml_idp_certificate' => $conn->saml_idp_certificate,
+                'saml_signing_algorithm' => $conn->saml_signing_algorithm,
+                'saml_audience_uri' => $conn->saml_audience_uri,
+                'saml_acs_url' => $saml->acsUrl($conn),
+                'saml_sp_entity_id' => $saml->spEntityId($conn),
+            ]);
+        }
+
+        if ($conn->isOidc()) {
+            $oidc = app(OidcConnectionService::class);
+
+            return array_merge($base, [
+                'oidc_issuer' => $conn->oidc_issuer,
+                'oidc_discovery_endpoint' => $conn->oidc_discovery_endpoint,
+                'oidc_client_id' => $conn->oidc_client_id,
+                'oidc_scopes' => is_array($conn->oidc_scopes) ? array_values($conn->oidc_scopes) : [],
+                'oidc_redirect_uri' => $oidc->redirectUri($conn),
+            ]);
+        }
+
+        return $base;
+    }
+}

--- a/database/factories/EnterpriseConnectionFactory.php
+++ b/database/factories/EnterpriseConnectionFactory.php
@@ -34,7 +34,7 @@ class EnterpriseConnectionFactory extends Factory
             'saml_idp_entity_id' => 'https://idp.example.com/saml/metadata',
             'saml_sso_url' => 'https://idp.example.com/saml/sso',
             'saml_idp_certificate' => "-----BEGIN CERTIFICATE-----\nMIIBfake\n-----END CERTIFICATE-----",
-            'saml_signing_algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+            'saml_signing_algorithm' => 'RSA_SHA256',
             'saml_audience_uri' => null,
             'saml_signing_key' => null,
             'oidc_issuer' => null,

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\Bapi\AllowlistIdentifiersController;
 use App\Http\Controllers\Bapi\BlocklistIdentifiersController;
+use App\Http\Controllers\Bapi\EnterpriseConnectionController;
 use App\Http\Controllers\Bapi\ExternalAccountController;
 use App\Http\Controllers\Bapi\InstanceAppearanceController;
 use App\Http\Controllers\Bapi\InstanceController;
@@ -116,6 +117,14 @@ Route::get('/oauth-providers/{oauth_provider_id}', [OauthProviderController::cla
 Route::patch('/oauth-providers/{oauth_provider_id}', [OauthProviderController::class, 'update'])->middleware(RateLimit::class.':oauth_providers.update,60,60')->name('bapi.oauth_providers.update');
 Route::delete('/oauth-providers/{oauth_provider_id}', [OauthProviderController::class, 'destroy'])->middleware(RateLimit::class.':oauth_providers.destroy,30,60')->name('bapi.oauth_providers.destroy');
 Route::post('/oauth-providers/{oauth_provider_id}/test', [OauthProviderController::class, 'test'])->middleware(RateLimit::class.':oauth_providers.test,30,60')->name('bapi.oauth_providers.test');
+
+// Enterprise connections (SAML + OIDC)
+Route::get('/enterprise-connections', [EnterpriseConnectionController::class, 'index'])->middleware(RateLimit::class.':enterprise_connections.list,300,60')->name('bapi.enterprise_connections.index');
+Route::post('/enterprise-connections', [EnterpriseConnectionController::class, 'store'])->middleware(RateLimit::class.':enterprise_connections.create,30,60')->name('bapi.enterprise_connections.store');
+Route::get('/enterprise-connections/{enterprise_connection_id}', [EnterpriseConnectionController::class, 'show'])->middleware(RateLimit::class.':enterprise_connections.read,300,60')->name('bapi.enterprise_connections.show');
+Route::patch('/enterprise-connections/{enterprise_connection_id}', [EnterpriseConnectionController::class, 'update'])->middleware(RateLimit::class.':enterprise_connections.update,60,60')->name('bapi.enterprise_connections.update');
+Route::delete('/enterprise-connections/{enterprise_connection_id}', [EnterpriseConnectionController::class, 'destroy'])->middleware(RateLimit::class.':enterprise_connections.destroy,30,60')->name('bapi.enterprise_connections.destroy');
+Route::post('/enterprise-connections/{enterprise_connection_id}/test', [EnterpriseConnectionController::class, 'test'])->middleware(RateLimit::class.':enterprise_connections.test,30,60')->name('bapi.enterprise_connections.test');
 
 // Passkeys (admin) — sdk-php SP-1 wraps this.
 Route::get('/passkeys', [PasskeyController::class, 'index'])->middleware(RateLimit::class.':passkeys.list,300,60')->name('bapi.passkeys.index');

--- a/tests/Feature/Http/Bapi/EnterpriseConnectionsTest.php
+++ b/tests/Feature/Http/Bapi/EnterpriseConnectionsTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\EnterpriseAccount;
+use App\Models\EnterpriseConnection;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+
+it('lists enterprise connections filtered by organization_id', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $token = $f['token'];
+
+    $instance = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id, 'organization_id' => null]);
+    $orgConn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id, 'organization_id' => null]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($token))
+        ->getJson(BapiTestSupport::url('/enterprise-connections'));
+
+    $r->assertOk()->assertJsonPath('total_count', 2);
+});
+
+it('creates a SAML enterprise connection (instance-wide)', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $token = $f['token'];
+
+    $r = $this->withHeaders(BapiTestSupport::headers($token))
+        ->postJson(BapiTestSupport::url('/enterprise-connections'), [
+            'protocol' => 'saml',
+            'name' => 'Acme SSO',
+            'domains' => ['acme.test'],
+            'default_role' => 'org:member',
+            'saml_idp_entity_id' => 'https://idp.example.com/saml/metadata',
+            'saml_sso_url' => 'https://idp.example.com/saml/sso',
+            'saml_idp_certificate' => "-----BEGIN CERTIFICATE-----\nMIIBfake\n-----END CERTIFICATE-----",
+            'saml_signing_algorithm' => 'RSA_SHA256',
+        ]);
+
+    $r->assertCreated()
+        ->assertJsonPath('object', 'enterprise_connection')
+        ->assertJsonPath('protocol', 'saml')
+        ->assertJsonPath('name', 'Acme SSO')
+        ->assertJsonPath('domains.0', 'acme.test')
+        ->assertJsonPath('organization_id', null);
+
+    expect($r->json('saml_acs_url'))->toContain('/v1/saml/');
+    expect($r->json('saml_sp_entity_id'))->toContain('/saml/');
+});
+
+it('creates an OIDC enterprise connection (instance-wide)', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $token = $f['token'];
+
+    $r = $this->withHeaders(BapiTestSupport::headers($token))
+        ->postJson(BapiTestSupport::url('/enterprise-connections'), [
+            'protocol' => 'oidc',
+            'name' => 'Acme OIDC',
+            'oidc_issuer' => 'https://idp.example.com',
+            'oidc_client_id' => 'client-xyz',
+            'oidc_client_secret' => 'secret-abc',
+            'oidc_scopes' => ['openid', 'email', 'profile'],
+        ]);
+
+    $r->assertCreated()
+        ->assertJsonPath('protocol', 'oidc')
+        ->assertJsonPath('oidc_client_id', 'client-xyz')
+        ->assertJsonPath('oidc_scopes.0', 'openid');
+    expect($r->json('oidc_redirect_uri'))->toContain('/v1/enterprise-sso-callback/');
+});
+
+it('rejects organization_id on BAPI create (per-org goes through FAPI)', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $token = $f['token'];
+
+    $r = $this->withHeaders(BapiTestSupport::headers($token))
+        ->postJson(BapiTestSupport::url('/enterprise-connections'), [
+            'protocol' => 'saml',
+            'name' => 'NotAllowed',
+            'organization_id' => 'org_someid',
+            'saml_idp_entity_id' => 'x',
+            'saml_sso_url' => 'https://x',
+            'saml_idp_certificate' => 'cert',
+        ]);
+
+    $r->assertStatus(422)
+        ->assertJsonPath('errors.0.code', 'organization_id_not_allowed');
+});
+
+it('patches a connection and rejects protocol changes', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $token = $f['token'];
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id, 'name' => 'Old']);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($token))
+        ->patchJson(BapiTestSupport::url('/enterprise-connections/'.$conn->id), [
+            'name' => 'New',
+            'enabled' => false,
+        ]);
+
+    $r->assertOk()->assertJsonPath('name', 'New')->assertJsonPath('enabled', false);
+
+    $r2 = $this->withHeaders(BapiTestSupport::headers($token))
+        ->patchJson(BapiTestSupport::url('/enterprise-connections/'.$conn->id), [
+            'protocol' => 'oidc',
+        ]);
+    $r2->assertStatus(422)->assertJsonPath('errors.0.code', 'protocol_immutable');
+});
+
+it('refuses to delete a connection with linked EnterpriseAccount rows', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $token = $f['token'];
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+    $user = User::create(['environment_id' => $f['env']->id]);
+    EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'enterprise_connection_id' => $conn->id,
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($token))
+        ->deleteJson(BapiTestSupport::url('/enterprise-connections/'.$conn->id));
+
+    $r->assertStatus(409)->assertJsonPath('errors.0.code', 'enterprise_connection_in_use');
+});
+
+it('soft-deletes a connection with no linked accounts', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $token = $f['token'];
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($token))
+        ->deleteJson(BapiTestSupport::url('/enterprise-connections/'.$conn->id));
+
+    $r->assertNoContent();
+    expect(EnterpriseConnection::withTrashed()->withoutGlobalScopes()->where('id', $conn->id)->first()?->removed_at)->not->toBeNull();
+});
+
+it('reports OIDC discovery success in the test action', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $token = $f['token'];
+    $conn = EnterpriseConnection::factory()->oidc()->create([
+        'environment_id' => $f['env']->id,
+        'oidc_issuer' => 'https://idp.example.com',
+        'oidc_discovery_endpoint' => 'https://idp.example.com/.well-known/openid-configuration',
+    ]);
+
+    Http::fake([
+        'idp.example.com/.well-known/openid-configuration' => Http::response([
+            'authorization_endpoint' => 'https://idp.example.com/oauth/authorize',
+            'token_endpoint' => 'https://idp.example.com/oauth/token',
+            'userinfo_endpoint' => 'https://idp.example.com/oauth/userinfo',
+            'jwks_uri' => 'https://idp.example.com/oauth/jwks',
+            'id_token_signing_alg_values_supported' => ['RS256'],
+        ]),
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($token))
+        ->postJson(BapiTestSupport::url('/enterprise-connections/'.$conn->id.'/test'));
+
+    $r->assertOk()
+        ->assertJsonPath('discovery_status', 200)
+        ->assertJsonPath('authorize_url', 'https://idp.example.com/oauth/authorize')
+        ->assertJsonPath('errors', []);
+});
+
+it('reports SAML test errors when the connection lacks an IdP certificate', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $token = $f['token'];
+    $conn = EnterpriseConnection::factory()->create([
+        'environment_id' => $f['env']->id,
+        'saml_idp_certificate' => null,
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($token))
+        ->postJson(BapiTestSupport::url('/enterprise-connections/'.$conn->id.'/test'));
+
+    $r->assertOk()
+        ->assertJsonPath('discovery_status', null)
+        ->assertJsonPath('errors.0.code', 'saml_missing_field')
+        ->assertJsonPath('errors.0.meta.param', 'saml_idp_certificate');
+});


### PR DESCRIPTION
Closes #196.

> This branch carries the AU-3 (#217) and AU-4 (#218) commits via merge in addition to the AU-5 work; once those land on \`main\` GitHub will collapse the diff to just the AU-5 commit. Reviewable as-is; the AU-5 controller / resource / tests are the new content.

## Summary

Mirrors OA-4. Instance-wide creates only; per-org goes through FAPI (AU-6).

### Controller (\`EnterpriseConnectionController\`)
- \`GET /v1/enterprise-connections\` — list with \`organization_id\` filter (blank for instance-wide, value for org-scoped).
- \`POST\` — creates SAML or OIDC connection; \`organization_id\` rejected here.
- \`GET|PATCH|DELETE /{id}\` — show / update / soft-delete. \`protocol\` + \`organization_id\` immutable. DELETE returns \`409 enterprise_connection_in_use\` when \`EnterpriseAccount\` rows still link.
- \`POST /{id}/test\` — dry-run probe. OIDC fetches the discovery doc; SAML reports missing fields. Returns OA-4's \`EnterpriseConnectionTestResult\` envelope (\`authorize_url\`, \`discovery_status\`, \`errors[]\`).

Inline validation per protocol — SAML creates require \`saml_idp_entity_id\` + \`saml_sso_url\` + \`saml_idp_certificate\`; OIDC creates require \`oidc_issuer\` + \`oidc_client_id\` + \`oidc_client_secret\`.

### Resource (\`EnterpriseConnectionResource\`)
Mirrors \`EnterpriseConnection.yaml\` from openapi. Strips encrypted fields from reads. Adds computed \`saml_acs_url\` + \`saml_sp_entity_id\` (from \`SamlConnectionService\`) and \`oidc_redirect_uri\` (from \`OidcConnectionService\`).

Factory: \`saml_signing_algorithm\` defaulted to \`RSA_SHA256\` (matches the spec enum).

## Test plan

- [x] \`vendor/bin/pint --test\`
- [x] \`php artisan test tests/Feature/Http/Bapi/EnterpriseConnectionsTest.php\` — 9 passed
- [x] Existing model / SAML / OIDC / SCIM tests all still pass (27 total)

## Dependencies

- #217 (AU-3) — \`SamlConnectionService\` for computed URLs
- #218 (AU-4) — \`OidcConnectionService\` for discovery probe

## Out of scope

- Per-org FAPI CRUD (AU-6).
- Strategy / callback wiring (AU-7).