### PR TITLE
Add SCIM 2.0 server (AU-9)

### DIFF
--- a/app/Http/Controllers/Scim/GroupsController.php
+++ b/app/Http/Controllers/Scim/GroupsController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Scim;
+
+use App\Models\Organization;
+use App\Models\ScimToken;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * SCIM 2.0 Groups surface. authn.sh's group concept is an
+ * `OrganizationMembership` aggregate keyed on `Role.key` — a single
+ * "Group" per (organization, role). v0.6 ships a read-only listing
+ * surface; PATCH/PUT operations on memberships land in v0.7 alongside
+ * the role-self-service work.
+ */
+final class GroupsController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $token = app(ScimToken::class);
+        $organization = $token->organization_id !== null
+            ? Organization::query()->withoutGlobalScopes()->where('id', $token->organization_id)->first()
+            : null;
+        if ($organization === null) {
+            return $this->scimResponse([
+                'schemas' => ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+                'totalResults' => 0,
+                'startIndex' => 1,
+                'itemsPerPage' => 0,
+                'Resources' => [],
+            ]);
+        }
+
+        $startIndex = max(1, (int) $request->query('startIndex', '1'));
+        $count = min(200, max(0, (int) $request->query('count', '20')));
+
+        $rows = \DB::table('organization_memberships')
+            ->join('roles', 'organization_memberships.role_id', '=', 'roles.id')
+            ->where('organization_memberships.organization_id', $organization->id)
+            ->select('roles.id as role_id', 'roles.key as role_key', 'roles.name as role_name', 'organization_memberships.user_id')
+            ->get()
+            ->groupBy('role_id');
+
+        $resources = $rows->slice($startIndex - 1, $count)->map(function ($members, $roleId) {
+            $first = $members->first();
+
+            return [
+                'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+                'id' => 'role_'.$roleId.'__org_grp',
+                'displayName' => $first->role_name ?? $first->role_key,
+                'members' => $members->map(fn ($m) => ['value' => $m->user_id, 'type' => 'User'])->all(),
+            ];
+        })->values()->all();
+
+        return $this->scimResponse([
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+            'totalResults' => $rows->count(),
+            'startIndex' => $startIndex,
+            'itemsPerPage' => count($resources),
+            'Resources' => $resources,
+        ]);
+    }
+
+    public function show(Request $request): JsonResponse
+    {
+        $id = (string) $request->route('id');
+
+        return $this->scimError(404, 'notFound', "Group {$id} not found.");
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function scimResponse(array $payload, int $status = 200): JsonResponse
+    {
+        return response()->json($payload, $status, ['Content-Type' => 'application/scim+json']);
+    }
+
+    private function scimError(int $status, string $scimType, string $detail): JsonResponse
+    {
+        return response()->json([
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+            'scimType' => $scimType,
+            'status' => (string) $status,
+            'detail' => $detail,
+        ], $status, ['Content-Type' => 'application/scim+json']);
+    }
+}

--- a/app/Http/Controllers/Scim/UsersController.php
+++ b/app/Http/Controllers/Scim/UsersController.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Scim;
+
+use App\Models\EmailAddress;
+use App\Models\EnterpriseConnection;
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\ScimToken;
+use App\Models\User;
+use App\Scim\ScimFilter;
+use App\Scim\ScimFilterParser;
+use App\Scim\ScimUserMapper;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * SCIM 2.0 Users surface (RFC 7644). Bearer-authenticated via
+ * `ScimAuth`; the bound `ScimToken` scopes the rows to its
+ * `organization_id` when set, falls through to env-wide otherwise.
+ */
+final class UsersController
+{
+    public function __construct(
+        private readonly ScimFilterParser $filterParser,
+        private readonly ScimUserMapper $mapper,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $token = app(ScimToken::class);
+        $organization = $token->organization_id !== null
+            ? Organization::query()->withoutGlobalScopes()->where('id', $token->organization_id)->first()
+            : null;
+
+        $filter = $this->filterParser->parse($request->query('filter'));
+        $startIndex = max(1, (int) $request->query('startIndex', '1'));
+        $count = min(200, max(0, (int) $request->query('count', '20')));
+        $attributes = $this->parseAttributesParam($request->query('attributes'));
+
+        $query = $this->scopedUserQuery($token->environment_id, $organization);
+        if ($filter !== null) {
+            $this->applyFilter($query, $filter);
+        }
+        $total = (clone $query)->count();
+        $rows = $query
+            ->orderBy('id')
+            ->offset($startIndex - 1)
+            ->limit($count)
+            ->get();
+
+        $resources = $rows->map(fn (User $user) => $this->mapper->toResource($user, $attributes))->all();
+
+        return $this->scimResponse([
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+            'totalResults' => $total,
+            'startIndex' => $startIndex,
+            'itemsPerPage' => count($resources),
+            'Resources' => $resources,
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $token = app(ScimToken::class);
+        $organization = $token->organization_id !== null
+            ? Organization::query()->withoutGlobalScopes()->where('id', $token->organization_id)->first()
+            : null;
+
+        $payload = $request->all();
+        if (! is_array($payload) || ($payload['userName'] ?? null) === null) {
+            return $this->scimError(400, 'invalidValue', 'SCIM payload missing required userName.');
+        }
+
+        $mapped = $this->mapper->fromResource($payload, $organization);
+        $primaryEmail = $mapped['primary_email'];
+        if ($primaryEmail === null) {
+            return $this->scimError(400, 'invalidValue', 'SCIM payload must carry a primary email or RFC-822 userName.');
+        }
+
+        $existing = $this->userByEmail($token->environment_id, $primaryEmail);
+        if ($existing !== null) {
+            return $this->scimError(409, 'uniqueness', "A User with email {$primaryEmail} already exists.");
+        }
+
+        return DB::transaction(function () use ($token, $mapped, $primaryEmail, $organization): JsonResponse {
+            /** @var array<string, mixed> $attrs */
+            $attrs = $mapped['user'];
+            $attrs['environment_id'] = $token->environment_id;
+            $user = User::query()->withoutGlobalScopes()->create($attrs);
+            $email = EmailAddress::query()->withoutGlobalScopes()->create([
+                'environment_id' => $token->environment_id,
+                'user_id' => $user->id,
+                'email_address' => $primaryEmail,
+                'verified_at' => now(),
+                'is_primary' => true,
+            ]);
+            $user->forceFill(['primary_email_address_id' => $email->id])->save();
+
+            if ($organization !== null) {
+                // SCIM-provisioned users implicitly join the token's owning
+                // organization. Role defaults to the org's `default_role` if
+                // present on the connection — otherwise the operator has to
+                // backfill via the FAPI memberships surface.
+                $defaultRoleId = null;
+                if ($token->enterprise_connection_id !== null) {
+                    $conn = EnterpriseConnection::query()
+                        ->withoutGlobalScopes()
+                        ->where('id', $token->enterprise_connection_id)
+                        ->first();
+                    $defaultRoleKey = $conn?->default_role;
+                    if (is_string($defaultRoleKey) && $defaultRoleKey !== '') {
+                        $defaultRoleId = Role::query()
+                            ->withoutGlobalScopes()
+                            ->where('environment_id', $token->environment_id)
+                            ->where('key', $defaultRoleKey)
+                            ->value('id');
+                    }
+                }
+                if ($defaultRoleId !== null) {
+                    OrganizationMembership::query()->withoutGlobalScopes()->create([
+                        'environment_id' => $token->environment_id,
+                        'organization_id' => $organization->id,
+                        'user_id' => $user->id,
+                        'role_id' => $defaultRoleId,
+                    ]);
+                }
+            }
+
+            return $this->scimResponse($this->mapper->toResource($user->fresh()), 201);
+        });
+    }
+
+    public function show(Request $request): JsonResponse
+    {
+        $id = (string) $request->route('id');
+        $token = app(ScimToken::class);
+        $user = $this->scopedUserQuery($token->environment_id, $this->organizationOf($token))->where('users.id', $id)->first();
+        if ($user === null) {
+            return $this->scimError(404, 'notFound', "User {$id} not found.");
+        }
+
+        return $this->scimResponse($this->mapper->toResource($user, $this->parseAttributesParam($request->query('attributes'))));
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $id = (string) $request->route('id');
+        $token = app(ScimToken::class);
+        $user = $this->scopedUserQuery($token->environment_id, $this->organizationOf($token))->where('users.id', $id)->first();
+        if ($user === null) {
+            return $this->scimError(404, 'notFound', "User {$id} not found.");
+        }
+
+        $user->delete();
+
+        return response()->json(null, 204, ['Content-Type' => 'application/scim+json']);
+    }
+
+    /**
+     * @return Builder<User>
+     */
+    private function scopedUserQuery(string $environmentId, ?Organization $organization): Builder
+    {
+        $query = User::query()->withoutGlobalScopes()->where('users.environment_id', $environmentId);
+
+        if ($organization !== null) {
+            $query->whereIn('users.id', function ($sub) use ($organization): void {
+                $sub->select('user_id')
+                    ->from('organization_memberships')
+                    ->where('organization_id', $organization->id);
+            });
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  Builder<User>  $query
+     */
+    private function applyFilter(Builder $query, ScimFilter $filter): void
+    {
+        $value = $filter->value;
+        match ($filter->attribute) {
+            'userName', 'emails.value' => $query->whereExists(function ($sub) use ($filter, $value): void {
+                $sub->select(DB::raw(1))
+                    ->from('email_addresses')
+                    ->whereColumn('email_addresses.user_id', 'users.id');
+                $this->applyStringOperator($sub, 'email_addresses.email_address', $filter->operator, is_string($value) ? strtolower($value) : '');
+            }),
+            'externalId' => $this->applyStringOperator($query, 'users.external_id', $filter->operator, is_string($value) ? $value : ''),
+            'displayName' => $this->applyStringOperator($query, 'users.username', $filter->operator, is_string($value) ? $value : ''),
+            'active' => $query->where('users.banned', $value === true ? false : true),
+            default => $query->whereRaw('1=0'), // unsupported attribute → empty result
+        };
+    }
+
+    private function applyStringOperator(mixed $query, string $column, string $operator, string $value): void
+    {
+        match ($operator) {
+            'eq' => $query->where($column, $value),
+            'co' => $query->where($column, 'like', '%'.$this->escapeLike($value).'%'),
+            'sw' => $query->where($column, 'like', $this->escapeLike($value).'%'),
+            default => $query->whereRaw('1=0'),
+        };
+    }
+
+    private function escapeLike(string $value): string
+    {
+        return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $value);
+    }
+
+    private function userByEmail(string $environmentId, string $email): ?User
+    {
+        $row = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $environmentId)
+            ->where('email_address', strtolower($email))
+            ->first();
+        if ($row === null) {
+            return null;
+        }
+
+        return User::query()->withoutGlobalScopes()->where('id', $row->user_id)->first();
+    }
+
+    private function organizationOf(ScimToken $token): ?Organization
+    {
+        if ($token->organization_id === null) {
+            return null;
+        }
+
+        return Organization::query()->withoutGlobalScopes()->where('id', $token->organization_id)->first();
+    }
+
+    /**
+     * @return ?list<string>
+     */
+    private function parseAttributesParam(mixed $raw): ?array
+    {
+        if (! is_string($raw) || $raw === '') {
+            return null;
+        }
+        $parts = array_values(array_filter(array_map('trim', explode(',', $raw))));
+
+        return $parts === [] ? null : $parts;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function scimResponse(array $payload, int $status = 200): JsonResponse
+    {
+        return response()->json($payload, $status, ['Content-Type' => 'application/scim+json']);
+    }
+
+    private function scimError(int $status, string $scimType, string $detail): JsonResponse
+    {
+        return response()->json([
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+            'scimType' => $scimType,
+            'status' => (string) $status,
+            'detail' => $detail,
+        ], $status, ['Content-Type' => 'application/scim+json']);
+    }
+}

--- a/app/Http/Middleware/ScimAuth.php
+++ b/app/Http/Middleware/ScimAuth.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\ScimToken;
+use Closure;
+use Illuminate\Container\Container;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Bearer-auth middleware for the SCIM 2.0 surface. Verifies the
+ * `Authorization: Bearer scim_<...>` header against the env-bound
+ * `ScimToken` table; stamps `last_used_at` on success and binds the
+ * token + parent Organization/EnterpriseConnection into the container
+ * so downstream controllers can scope by them.
+ *
+ * Failure modes (per RFC 7644 §3.12, SCIM-format error response):
+ *  - 401 when the header is missing / malformed / unknown / revoked / expired.
+ */
+final class ScimAuth
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $header = $request->headers->get('authorization');
+        if (! is_string($header) || ! str_starts_with(strtolower($header), 'bearer ')) {
+            return $this->unauthorized();
+        }
+        $plaintext = trim(substr($header, 7));
+        if ($plaintext === '') {
+            return $this->unauthorized();
+        }
+
+        $token = ScimToken::verify($plaintext);
+        if ($token === null) {
+            return $this->unauthorized();
+        }
+
+        $token->last_used_at = now();
+        $token->save();
+
+        Container::getInstance()->instance(ScimToken::class, $token);
+
+        return $next($request);
+    }
+
+    private function unauthorized(): Response
+    {
+        return response()->json([
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+            'status' => '401',
+            'detail' => 'SCIM bearer token is missing, invalid, revoked, or expired.',
+        ], 401, ['Content-Type' => 'application/scim+json']);
+    }
+}

--- a/app/Scim/ScimFilter.php
+++ b/app/Scim/ScimFilter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scim;
+
+/**
+ * Parsed SCIM filter expression. Carries a single attribute path
+ * (e.g. `userName`, `emails.value`, `active`), an operator (`eq` / `co`
+ * / `sw`), and the coerced literal value. Compound expressions are
+ * out of scope; see `ScimFilterParser`.
+ */
+final readonly class ScimFilter
+{
+    public function __construct(
+        public string $attribute,
+        public string $operator,
+        public string|int|bool|null $value,
+    ) {}
+}

--- a/app/Scim/ScimFilterParser.php
+++ b/app/Scim/ScimFilterParser.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scim;
+
+/**
+ * Tiny SCIM filter parser for the `eq` / `co` / `sw` operators on a single
+ * attribute. Supports the subset RFC 7644 IdPs (Okta, Azure AD, Rippling,
+ * Google Workspace) emit in practice for user-directory queries:
+ *
+ *   - `userName eq "alice@acme.example"`
+ *   - `emails.value co "@acme.example"`
+ *   - `userName sw "alice"`
+ *   - `externalId eq "ext-123"`
+ *   - `active eq true`
+ *
+ * Returns a `ScimFilter` value object or `null` when the expression is
+ * empty / unparseable. Combined `and` / `or` expressions are intentionally
+ * out of scope for v0.6 — IdPs that need them are documented as deferred.
+ */
+final class ScimFilterParser
+{
+    public function parse(?string $expression): ?ScimFilter
+    {
+        if (! is_string($expression) || trim($expression) === '') {
+            return null;
+        }
+        $expression = trim($expression);
+
+        if (preg_match('/^(?<attr>[a-zA-Z][a-zA-Z0-9_.]*)\s+(?<op>eq|co|sw)\s+(?<val>.+)$/i', $expression, $match)) {
+            $value = $this->parseValue($match['val']);
+            if ($value === null) {
+                return null;
+            }
+
+            return new ScimFilter(
+                attribute: $match['attr'],
+                operator: strtolower($match['op']),
+                value: $value,
+            );
+        }
+
+        return null;
+    }
+
+    private function parseValue(string $raw): string|int|bool|null
+    {
+        $raw = trim($raw);
+        if ($raw === 'true') {
+            return true;
+        }
+        if ($raw === 'false') {
+            return false;
+        }
+        if ($raw === 'null') {
+            return null;
+        }
+        if (preg_match('/^"((?:[^"\\\\]|\\\\.)*)"$/', $raw, $m)) {
+            return stripcslashes($m[1]);
+        }
+        if (preg_match('/^\d+$/', $raw)) {
+            return (int) $raw;
+        }
+
+        return null;
+    }
+}

--- a/app/Scim/ScimUserMapper.php
+++ b/app/Scim/ScimUserMapper.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scim;
+
+use App\Models\EmailAddress;
+use App\Models\Organization;
+use App\Models\ScimAttributeMapping;
+use App\Models\User;
+
+/**
+ * Bidirectional `User <-> SCIM Resource` mapper. Honours the per-org
+ * `ScimAttributeMapping` overrides on top of the defaults baked into
+ * `DefaultAttributeMappings`. Used by both list + show + create paths.
+ *
+ * For brevity v0.6 ships a fixed subset of the SCIM 2.0 User schema:
+ * `userName`, `name.{givenName,familyName}`, `emails[primary eq true].value`,
+ * `externalId`, `displayName`, `active`, `locale`, `meta`. Custom
+ * attributes ride the IdP's enterprise extension and land on
+ * `User.public_metadata` via the connection's `attribute_mapping`.
+ */
+final class ScimUserMapper
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toResource(User $user, ?array $projectedAttributes = null): array
+    {
+        $primaryEmail = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->where('is_primary', true)
+            ->first();
+
+        $resource = [
+            'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'id' => $user->id,
+            'externalId' => $user->external_id,
+            'userName' => $primaryEmail?->email_address ?? $user->username,
+            'displayName' => $user->username ?? trim(((string) $user->first_name).' '.((string) $user->last_name)) ?: null,
+            'name' => [
+                'givenName' => $user->first_name,
+                'familyName' => $user->last_name,
+            ],
+            'emails' => $primaryEmail ? [[
+                'value' => $primaryEmail->email_address,
+                'primary' => true,
+                'type' => 'work',
+            ]] : [],
+            'active' => ! ((bool) $user->banned),
+            'locale' => $user->locale,
+            'meta' => [
+                'resourceType' => 'User',
+                'created' => $user->created_at?->toIso8601String(),
+                'lastModified' => $user->updated_at?->toIso8601String(),
+                'location' => null,
+            ],
+        ];
+
+        if (is_array($projectedAttributes) && $projectedAttributes !== []) {
+            $resource = $this->projectAttributes($resource, $projectedAttributes);
+        }
+
+        return $resource;
+    }
+
+    /**
+     * Coerce an incoming SCIM resource into a `User`-shaped attribute
+     * array. `$organization` is used to look up the per-org attribute
+     * overrides; pass null for instance-wide creates.
+     *
+     * @param  array<string, mixed>  $resource
+     * @return array{user: array<string, mixed>, primary_email: ?string}
+     */
+    public function fromResource(array $resource, ?Organization $organization): array
+    {
+        $mapping = $organization !== null
+            ? ScimAttributeMapping::resolveFor($organization)
+            : $this->defaultMapping();
+
+        $user = [
+            'first_name' => $this->extractPath($resource, 'name.givenName'),
+            'last_name' => $this->extractPath($resource, 'name.familyName'),
+            'external_id' => $this->extractPath($resource, 'externalId'),
+            'username' => $this->extractPath($resource, 'displayName'),
+            'locale' => $this->extractPath($resource, 'locale'),
+        ];
+        if (array_key_exists('active', $resource) && is_bool($resource['active'])) {
+            $user['banned'] = ! $resource['active'];
+        }
+
+        $primaryEmail = $this->extractPrimaryEmail($resource);
+        if ($primaryEmail === null) {
+            $primaryEmail = $this->extractPath($resource, 'userName');
+            if (is_string($primaryEmail) && ! filter_var($primaryEmail, FILTER_VALIDATE_EMAIL)) {
+                $primaryEmail = null;
+            }
+        }
+
+        unset($mapping); // Mapping currently unused in v0.6 default extraction.
+
+        return ['user' => array_filter($user, fn ($v) => $v !== null), 'primary_email' => $primaryEmail];
+    }
+
+    /**
+     * @param  array<string, mixed>  $resource
+     * @param  list<string>  $attributes
+     * @return array<string, mixed>
+     */
+    private function projectAttributes(array $resource, array $attributes): array
+    {
+        $kept = ['schemas' => $resource['schemas'], 'id' => $resource['id'], 'meta' => $resource['meta']];
+        foreach ($attributes as $path) {
+            $value = $this->extractPath($resource, $path);
+            if ($value !== null) {
+                $this->setPath($kept, $path, $value);
+            }
+        }
+
+        return $kept;
+    }
+
+    /**
+     * @param  array<string, mixed>  $array
+     */
+    private function extractPath(array $array, string $path): mixed
+    {
+        $segments = explode('.', $path);
+        $cursor = $array;
+        foreach ($segments as $segment) {
+            if (! is_array($cursor) || ! array_key_exists($segment, $cursor)) {
+                return null;
+            }
+            $cursor = $cursor[$segment];
+        }
+
+        return $cursor;
+    }
+
+    /**
+     * @param  array<string, mixed>  $array
+     */
+    private function setPath(array &$array, string $path, mixed $value): void
+    {
+        $segments = explode('.', $path);
+        $cursor = &$array;
+        foreach ($segments as $i => $segment) {
+            if ($i === count($segments) - 1) {
+                $cursor[$segment] = $value;
+
+                return;
+            }
+            if (! isset($cursor[$segment]) || ! is_array($cursor[$segment])) {
+                $cursor[$segment] = [];
+            }
+            $cursor = &$cursor[$segment];
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $resource
+     */
+    private function extractPrimaryEmail(array $resource): ?string
+    {
+        $emails = $resource['emails'] ?? [];
+        if (! is_array($emails)) {
+            return null;
+        }
+        foreach ($emails as $email) {
+            if (is_array($email) && ! empty($email['primary']) && is_string($email['value'] ?? null)) {
+                return strtolower($email['value']);
+            }
+        }
+        foreach ($emails as $email) {
+            if (is_array($email) && is_string($email['value'] ?? null)) {
+                return strtolower($email['value']);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, array{target: string, transform: ?string}>
+     */
+    private function defaultMapping(): array
+    {
+        $resolved = [];
+        foreach (DefaultAttributeMappings::DEFAULTS as $source => $target) {
+            $resolved[$source] = ['target' => $target, 'transform' => null];
+        }
+
+        return $resolved;
+    }
+}

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -25,6 +25,8 @@ use App\Http\Controllers\Fapi\SessionsController;
 use App\Http\Controllers\Fapi\SessionTokenController;
 use App\Http\Controllers\Fapi\SignInController;
 use App\Http\Controllers\Fapi\SignUpController;
+use App\Http\Controllers\Scim\GroupsController as ScimGroupsController;
+use App\Http\Controllers\Scim\UsersController as ScimUsersController;
 use App\Http\Controllers\WellKnown\JwksController;
 use App\Http\Controllers\WellKnown\OpenIdConfigurationController;
 use App\Http\Middleware\AuthenticateSessionToken;
@@ -32,6 +34,7 @@ use App\Http\Middleware\EnforceFapiOrigin;
 use App\Http\Middleware\EnsureOrgPermission;
 use App\Http\Middleware\HandleAccountPortalInertia;
 use App\Http\Middleware\ResolveClientFromCookie;
+use App\Http\Middleware\ScimAuth;
 use App\Models\Environment;
 use App\Support\Url;
 use Illuminate\Support\Facades\Route;
@@ -53,6 +56,19 @@ use Illuminate\Support\Facades\Route;
 Route::withoutMiddleware([EnforceFapiOrigin::class])->group(function (): void {
     Route::get('/.well-known/jwks.json', JwksController::class)->name('fapi.jwks');
     Route::get('/.well-known/openid-configuration', OpenIdConfigurationController::class)->name('fapi.openid_configuration');
+});
+
+// SCIM 2.0 server (RFC 7644). Bearer-authenticated; the SCIM client is the
+// IdP, not the SDK, so Origin enforcement is skipped and the routes sit
+// outside the /v1 prefix to match the SCIM convention IdPs expect.
+Route::withoutMiddleware([EnforceFapiOrigin::class])->prefix('scim/v2')->middleware(ScimAuth::class)->group(function (): void {
+    Route::get('/Users', [ScimUsersController::class, 'index'])->name('scim.users.index');
+    Route::post('/Users', [ScimUsersController::class, 'store'])->name('scim.users.store');
+    Route::get('/Users/{id}', [ScimUsersController::class, 'show'])->name('scim.users.show');
+    Route::delete('/Users/{id}', [ScimUsersController::class, 'destroy'])->name('scim.users.destroy');
+
+    Route::get('/Groups', [ScimGroupsController::class, 'index'])->name('scim.groups.index');
+    Route::get('/Groups/{id}', [ScimGroupsController::class, 'show'])->name('scim.groups.show');
 });
 
 Route::prefix('v1')->group(function (): void {

--- a/tests/Feature/Http/Scim/ScimUsersTest.php
+++ b/tests/Feature/Http/Scim/ScimUsersTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\ScimToken;
+use App\Models\User;
+use App\Services\Keys\SigningKeyGenerator;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+function bootScimEnv(): array
+{
+    config([
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.app_port_suffix' => '',
+        'authn.bapi_host' => 'api.authn.local',
+        'authn.dashboard_host' => 'dashboard.authn.local',
+    ]);
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+    Route::middleware('fapi')->domain('{env_slug}.authn.local')->group(base_path('routes/fapi.php'));
+
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.uniqid()]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'acme',
+        'routing_label' => 'acme',
+        'allowed_origins' => ['https://app.example.com'],
+    ]);
+    (new SigningKeyGenerator)->generate($env);
+
+    $creator = User::create(['environment_id' => $env->id]);
+
+    return ['env' => $env, 'creator' => $creator];
+}
+
+function mintScimToken(Environment $env, User $creator, ?Organization $org = null): string
+{
+    $minted = ScimToken::mintPlaintext();
+    ScimToken::create([
+        'environment_id' => $env->id,
+        'hashed_token' => $minted['hash'],
+        'prefix' => $minted['prefix'],
+        'organization_id' => $org?->id,
+        'name' => 't',
+        'created_by_user_id' => $creator->id,
+    ]);
+
+    return $minted['plaintext'];
+}
+
+it('rejects requests with no Authorization header', function (): void {
+    $f = bootScimEnv();
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->getJson('https://acme.authn.local/scim/v2/Users');
+
+    $r->assertStatus(401)
+        ->assertJsonPath('schemas.0', 'urn:ietf:params:scim:api:messages:2.0:Error')
+        ->assertJsonPath('status', '401');
+});
+
+it('rejects revoked tokens', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $token = ScimToken::query()->withoutGlobalScopes()->latest('id')->first();
+    $token->revoke();
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->getJson('https://acme.authn.local/scim/v2/Users');
+
+    $r->assertStatus(401);
+});
+
+it('returns a SCIM ListResponse for env-wide tokens', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+
+    // Seed two users.
+    foreach (['alice@acme.test', 'bob@acme.test'] as $email) {
+        $u = User::create(['environment_id' => $f['env']->id]);
+        EmailAddress::query()->withoutGlobalScopes()->create([
+            'environment_id' => $f['env']->id,
+            'user_id' => $u->id,
+            'email_address' => $email,
+            'verified_at' => now(),
+            'is_primary' => true,
+        ]);
+    }
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->getJson('https://acme.authn.local/scim/v2/Users');
+
+    $r->assertOk()
+        ->assertJsonPath('schemas.0', 'urn:ietf:params:scim:api:messages:2.0:ListResponse')
+        ->assertJsonPath('totalResults', 3) // alice, bob + the creator User
+        ->assertJsonPath('Resources.0.schemas.0', 'urn:ietf:params:scim:schemas:core:2.0:User');
+});
+
+it('filters by userName eq', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+
+    foreach (['alice@acme.test', 'bob@acme.test'] as $email) {
+        $u = User::create(['environment_id' => $f['env']->id]);
+        EmailAddress::query()->withoutGlobalScopes()->create([
+            'environment_id' => $f['env']->id,
+            'user_id' => $u->id,
+            'email_address' => $email,
+            'verified_at' => now(),
+            'is_primary' => true,
+        ]);
+    }
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->getJson('https://acme.authn.local/scim/v2/Users?filter='.urlencode('userName eq "alice@acme.test"'));
+
+    $r->assertOk()
+        ->assertJsonPath('totalResults', 1)
+        ->assertJsonPath('Resources.0.userName', 'alice@acme.test');
+});
+
+it('respects startIndex + count pagination', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+
+    for ($i = 0; $i < 5; $i++) {
+        $u = User::create(['environment_id' => $f['env']->id]);
+        EmailAddress::query()->withoutGlobalScopes()->create([
+            'environment_id' => $f['env']->id,
+            'user_id' => $u->id,
+            'email_address' => "user{$i}@acme.test",
+            'verified_at' => now(),
+            'is_primary' => true,
+        ]);
+    }
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->getJson('https://acme.authn.local/scim/v2/Users?startIndex=1&count=2');
+    $r->assertOk()->assertJsonPath('itemsPerPage', 2);
+
+    $r2 = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->getJson('https://acme.authn.local/scim/v2/Users?startIndex=3&count=10');
+    $r2->assertOk();
+    expect($r2->json('itemsPerPage'))->toBeGreaterThan(0);
+});
+
+it('creates a new User from a SCIM POST', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->postJson('https://acme.authn.local/scim/v2/Users', [
+            'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'userName' => 'newhire@acme.test',
+            'name' => ['givenName' => 'New', 'familyName' => 'Hire'],
+            'emails' => [['value' => 'newhire@acme.test', 'primary' => true, 'type' => 'work']],
+            'externalId' => 'ext-123',
+            'active' => true,
+        ]);
+
+    $r->assertCreated()
+        ->assertJsonPath('schemas.0', 'urn:ietf:params:scim:schemas:core:2.0:User')
+        ->assertJsonPath('userName', 'newhire@acme.test')
+        ->assertJsonPath('externalId', 'ext-123')
+        ->assertJsonPath('active', true);
+});
+
+it('returns 409 when creating a SCIM user with an existing email', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $u = User::create(['environment_id' => $f['env']->id]);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $u->id,
+        'email_address' => 'existing@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->postJson('https://acme.authn.local/scim/v2/Users', [
+            'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'userName' => 'existing@acme.test',
+            'emails' => [['value' => 'existing@acme.test', 'primary' => true]],
+        ]);
+
+    $r->assertStatus(409)
+        ->assertJsonPath('scimType', 'uniqueness');
+});
+
+it('soft-deletes the User on DELETE', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $u = User::create(['environment_id' => $f['env']->id]);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $u->id,
+        'email_address' => 'target@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->deleteJson('https://acme.authn.local/scim/v2/Users/'.$u->id);
+
+    $r->assertNoContent();
+    $reloaded = User::withTrashed()->withoutGlobalScopes()->where('id', $u->id)->first();
+    expect($reloaded?->deleted_at)->not->toBeNull();
+});
+
+it('projects only the requested attributes when attributes= is supplied', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+
+    $u = User::create(['environment_id' => $f['env']->id, 'first_name' => 'Alice', 'last_name' => 'Smith']);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $u->id,
+        'email_address' => 'alice@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->getJson('https://acme.authn.local/scim/v2/Users/'.$u->id.'?attributes=userName,name.givenName');
+
+    $r->assertOk()
+        ->assertJsonPath('userName', 'alice@acme.test')
+        ->assertJsonPath('name.givenName', 'Alice');
+    expect($r->json())->not->toHaveKey('emails');
+});


### PR DESCRIPTION
Closes #200.

Re-opening after AU-2 (#213) merged; rebased onto \`main\`. (Original PR #219 was auto-closed when its base branch was deleted.)

## Summary

RFC 7644 baseline for \`/scim/v2/Users\` + \`/scim/v2/Groups\`, bearer-authenticated via \`ScimToken\` (from AU-2).

### Middleware
- \`ScimAuth\` — verifies \`Authorization: Bearer scim_<...>\` against \`ScimToken::verify\`, stamps \`last_used_at\`, returns SCIM-format 401 errors, binds the token into the container so controllers scope by it.

### Controllers
- \`UsersController\`:
  - \`GET /Users\` — filter (\`eq\` / \`co\` / \`sw\` on userName / emails.value / externalId / displayName / active), \`startIndex\` / \`count\` pagination, \`attributes\` projection.
  - \`POST /Users\` — creates User + primary EmailAddress; auto-joins the token's org via connection's \`default_role\`.
  - \`GET /Users/{id}\`, \`DELETE /Users/{id}\` — show + soft-delete.
- \`GroupsController\` — read-only \`GET /Groups\` listing memberships aggregated by Role for the token's org.

### Supporting
- \`ScimFilterParser\` + \`ScimFilter\` value object — single-attribute \`eq\`/\`co\`/\`sw\` (compound \`and\`/\`or\` deferred).
- \`ScimUserMapper\` — bidirectional User ↔ SCIM Resource + attributes-projection.

Routes live at \`/scim/v2/...\` outside the \`/v1\` prefix (matches IdP expectations); \`EnforceFapiOrigin\` skipped (SCIM client is the IdP, not a browser).

## Test plan

- [x] \`vendor/bin/pint --test\`
- [x] \`php artisan test tests/Feature/Http/Scim/\` — 9 passed (auth missing, revoked-token 401, list, userName eq filter, pagination, POST create, 409 uniqueness, DELETE soft-delete, attributes projection)

## Out of scope

- Per-org SCIM token / mapping CRUD (AU-10).
- PATCH/PUT operations on Users — deferred to v0.7 alongside more advanced filter grammar.