### PR TITLE
Add FAPI per-org enterprise-connections CRUD (AU-6)

### DIFF
--- a/app/Auth/Strategies/EnterpriseSsoStrategy.php
+++ b/app/Auth/Strategies/EnterpriseSsoStrategy.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Strategies;
+
+use App\Auth\EnterpriseSso\EnterpriseConnectionService;
+use App\Auth\EnterpriseSso\OidcConnectionService;
+use App\Auth\ErrorCodes;
+use App\Auth\Oauth\StateToken;
+use App\Auth\Saml\SamlConnectionService;
+use App\Models\Client;
+use App\Models\EnterpriseConnection;
+use App\Models\SignInAttempt;
+use App\Models\Verification;
+use App\Services\Verification\VerificationManager;
+use App\Settings\EnterpriseSsoSettings;
+
+/**
+ * `enterprise_sso` + `saml` first-factor strategy. Mirrors
+ * `OauthRedirectStrategy` (the "answer" lives on the IdP redirect
+ * callback handled by `EnterpriseSsoCallbackController` /
+ * `samlAcs`). `prepare()` resolves the right `EnterpriseConnection`,
+ * builds the authorize URL (OIDC) or AuthnRequest (SAML), stashes
+ * `state` + `nonce` + `code_verifier` for the callback to consume,
+ * and writes the URL onto `Verification.external_verification_redirect_url`.
+ */
+final class EnterpriseSsoStrategy implements Strategy
+{
+    public function __construct(
+        private readonly EnterpriseConnectionService $resolver,
+        private readonly OidcConnectionService $oidc,
+        private readonly SamlConnectionService $saml,
+        private readonly VerificationManager $verifications,
+    ) {}
+
+    public function name(): string
+    {
+        return 'enterprise_sso';
+    }
+
+    public function requiresPrepare(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    public function prepare(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        $strategyKey = (string) ($params['strategy'] ?? Verification::STRATEGY_ENTERPRISE_SSO);
+        $client = $params['client'] ?? null;
+        $clientId = $client instanceof Client ? $client->id : '';
+
+        $conn = $this->resolveConnection($attempt, $params);
+        if (! $conn instanceof EnterpriseConnection) {
+            return $conn;
+        }
+
+        // Strict-semantic toggle (AU-14): existing linked accounts continue
+        // to work, but new SignIns drop through when the env flips off.
+        $settings = EnterpriseSsoSettings::fromUserSettings(is_array($attempt->environment?->user_settings) ? $attempt->environment->user_settings : []);
+        if (! $settings->enabled) {
+            return StrategyResult::fail($attempt, ErrorCodes::STRATEGY_NOT_SUPPORTED, 'Enterprise SSO is disabled on this environment.', 422);
+        }
+
+        $verification = $this->verifications->start($attempt, $strategyKey, StateToken::TTL_SECONDS);
+        $nonce = bin2hex(random_bytes(16));
+
+        if ($conn->isOidc()) {
+            $authorize = $this->oidc->buildAuthorizeUrl($conn, state: $verification->id, nonce: $nonce);
+            $state = StateToken::mint(
+                environmentId: $attempt->environment_id,
+                providerKey: 'enterprise:'.$conn->id,
+                verificationId: $verification->id,
+                clientId: $clientId,
+                attemptId: $attempt->id,
+                attemptKind: 'sign_in',
+                redirectUrl: is_string($params['redirect_url'] ?? null) ? (string) $params['redirect_url'] : null,
+                redirectUrlComplete: is_string($params['redirect_url_complete'] ?? null) ? (string) $params['redirect_url_complete'] : null,
+                nonce: $nonce,
+                extra: ['conn' => $conn->id, 'cv' => $authorize['code_verifier']],
+            );
+            // Rebuild the URL with the encrypted state token in place of
+            // the verification id we used for `buildAuthorizeUrl`'s state
+            // placeholder above.
+            $authorizeUrl = $this->swapStateInUrl($authorize['authorize_url'], $verification->id, $state);
+
+            $verification->forceFill([
+                'external_verification_redirect_url' => $authorizeUrl,
+                'nonce' => $nonce,
+            ])->save();
+
+            return StrategyResult::ok($attempt, verification: $verification);
+        }
+
+        // SAML — mint AuthnRequest with our verification id as RelayState.
+        $state = StateToken::mint(
+            environmentId: $attempt->environment_id,
+            providerKey: 'enterprise:'.$conn->id,
+            verificationId: $verification->id,
+            clientId: $clientId,
+            attemptId: $attempt->id,
+            attemptKind: 'sign_in',
+            redirectUrl: is_string($params['redirect_url'] ?? null) ? (string) $params['redirect_url'] : null,
+            redirectUrlComplete: is_string($params['redirect_url_complete'] ?? null) ? (string) $params['redirect_url_complete'] : null,
+            nonce: $nonce,
+            extra: ['conn' => $conn->id],
+        );
+        $samlRequestB64 = $this->saml->buildAuthnRequest($conn, relayState: $state);
+        $separator = str_contains((string) $conn->saml_sso_url, '?') ? '&' : '?';
+        $authorizeUrl = (string) $conn->saml_sso_url.$separator.http_build_query([
+            'SAMLRequest' => $samlRequestB64,
+            'RelayState' => $state,
+        ]);
+
+        $verification->forceFill([
+            'external_verification_redirect_url' => $authorizeUrl,
+            'nonce' => $nonce,
+        ])->save();
+
+        return StrategyResult::ok($attempt, verification: $verification);
+    }
+
+    public function attempt(SignInAttempt $attempt, array $params): StrategyResult
+    {
+        return StrategyResult::fail(
+            $attempt,
+            ErrorCodes::PREPARE_NOT_REQUIRED,
+            'enterprise_sso completes via the /v1/enterprise-sso-callback OIDC redirect or /v1/saml/{connection_id}/acs SAML POST, not the answer endpoint.',
+            422,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    private function resolveConnection(SignInAttempt $attempt, array $params): EnterpriseConnection|StrategyResult
+    {
+        $env = $attempt->environment;
+        if ($env === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_PARAM_NIL, 'attempt has no environment.', 422);
+        }
+
+        $explicitId = $params['enterprise_connection_id'] ?? null;
+        if (is_string($explicitId) && $explicitId !== '') {
+            $conn = EnterpriseConnection::query()->withoutGlobalScopes()
+                ->where('environment_id', $env->id)
+                ->where('id', $explicitId)
+                ->where('enabled', true)
+                ->first();
+            if ($conn === null) {
+                return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'No enabled enterprise connection matches that id.', 422);
+            }
+
+            return $conn;
+        }
+
+        $identifier = (string) $attempt->identifier;
+        $conn = $this->resolver->findByIdentifierDomain($env, $identifier);
+        if ($conn === null) {
+            return StrategyResult::fail($attempt, ErrorCodes::FORM_IDENTIFIER_NOT_FOUND, 'No enterprise connection routes the identifier domain.', 422);
+        }
+
+        return $conn;
+    }
+
+    /**
+     * Replace the placeholder `state=<id>` (we used the verification id to
+     * pre-mint the URL) with the actual encrypted state token. Cheaper
+     * than re-running the whole OIDC URL build.
+     */
+    private function swapStateInUrl(string $url, string $oldState, string $newState): string
+    {
+        return str_replace(
+            'state='.rawurlencode($oldState),
+            'state='.rawurlencode($newState),
+            $url,
+        );
+    }
+}

--- a/app/Auth/StrategyResolver.php
+++ b/app/Auth/StrategyResolver.php
@@ -7,6 +7,7 @@ namespace App\Auth;
 use App\Auth\Strategies\BackupCodeStrategy;
 use App\Auth\Strategies\EmailCodeStrategy;
 use App\Auth\Strategies\EmailLinkStrategy;
+use App\Auth\Strategies\EnterpriseSsoStrategy;
 use App\Auth\Strategies\OauthRedirectStrategy;
 use App\Auth\Strategies\PasskeyStrategy;
 use App\Auth\Strategies\PasswordStrategy;
@@ -35,6 +36,7 @@ final class StrategyResolver
         private readonly PhoneCodeStrategy $phoneCode,
         private readonly OauthRedirectStrategy $oauth,
         private readonly PasskeyStrategy $passkey,
+        private readonly EnterpriseSsoStrategy $enterpriseSso,
     ) {}
 
     public function resolve(string $name): Strategy
@@ -53,6 +55,7 @@ final class StrategyResolver
             Verification::STRATEGY_BACKUP_CODE => $this->backupCode,
             Verification::STRATEGY_PHONE_CODE => $this->phoneCode,
             Verification::STRATEGY_PASSKEY => $this->passkey,
+            Verification::STRATEGY_ENTERPRISE_SSO, Verification::STRATEGY_SAML => $this->enterpriseSso,
             default => throw new InvalidArgumentException("Strategy {$name} is not supported."),
         };
     }

--- a/app/Http/Controllers/Fapi/EnterpriseSsoCallbackController.php
+++ b/app/Http/Controllers/Fapi/EnterpriseSsoCallbackController.php
@@ -1,0 +1,361 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Auth\EnterpriseSso\EnterpriseConnectionService;
+use App\Auth\EnterpriseSso\OidcConnectionService;
+use App\Auth\Oauth\StateToken;
+use App\Auth\Saml\SamlConnectionService;
+use App\Auth\Saml\SamlException;
+use App\Models\Challenge;
+use App\Models\EnterpriseConnection;
+use App\Models\Environment;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\Session;
+use App\Models\SignInAttempt;
+use App\Models\User;
+use App\Models\Verification;
+use App\Services\Sessions\SessionLifecycle;
+use App\Settings\EnterpriseSsoSettings;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Throwable;
+
+/**
+ * Callback handlers for Enterprise SSO:
+ *
+ *   GET  /v1/enterprise-sso-callback    — OIDC redirect-back. `state`
+ *                                          is the encrypted `StateToken`,
+ *                                          `code` is the IdP-issued auth
+ *                                          code. We exchange + verify the
+ *                                          id_token, provision the User
+ *                                          + EnterpriseAccount, close the
+ *                                          parent SignIn.
+ *   POST /v1/saml/{connection_id}/acs   — SAML AssertionConsumerService.
+ *                                          `SAMLResponse` is form-posted;
+ *                                          `RelayState` carries the same
+ *                                          encrypted `StateToken`.
+ *
+ * Both paths converge on `finalize()` which does the
+ * provisionUser → close-SignIn → OrganizationMembership-autojoin work.
+ */
+final class EnterpriseSsoCallbackController
+{
+    public function __construct(
+        private readonly OidcConnectionService $oidc,
+        private readonly SamlConnectionService $saml,
+        private readonly EnterpriseConnectionService $connections,
+        private readonly SessionLifecycle $sessions,
+    ) {}
+
+    public function oidcCallback(Request $request): RedirectResponse
+    {
+        $stateToken = (string) $request->query('state', '');
+        $code = (string) $request->query('code', '');
+        $state = StateToken::unwrap($stateToken);
+        if ($state === null) {
+            return $this->failTopLevel(null, 'state_invalid', 'state token is missing or expired.');
+        }
+
+        $env = app()->bound(Environment::class) ? app(Environment::class) : null;
+        if ($env === null || $env->id !== ($state['env'] ?? null)) {
+            return $this->failTopLevel($state['ru'] ?? null, 'state_env_mismatch', 'state.environment_id does not match.');
+        }
+
+        $verification = $this->loadVerification($state['v'] ?? '', $env->id);
+        if ($verification === null) {
+            return $this->failTopLevel($state['ru'] ?? null, 'verification_not_found', 'verification row missing.');
+        }
+
+        $connId = (string) ($state['conn'] ?? '');
+        $conn = EnterpriseConnection::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $connId)
+            ->first();
+        if ($conn === null || ! $conn->isOidc()) {
+            return $this->failWithVerification($state['ru'] ?? null, $verification, 'enterprise_connection_not_found', 'Connection missing or wrong protocol.');
+        }
+
+        $codeVerifier = (string) ($state['cv'] ?? '');
+        if ($code === '' || $codeVerifier === '') {
+            return $this->failWithVerification($state['ru'] ?? null, $verification, 'oidc_callback_incomplete', 'IdP did not return an authorization code.');
+        }
+
+        try {
+            $tokens = $this->oidc->exchangeCode($conn, $code, $codeVerifier);
+        } catch (Throwable $e) {
+            Log::warning('enterprise_sso.oidc.token_exchange_failed', ['conn' => $conn->id, 'error' => $e->getMessage()]);
+
+            return $this->failWithVerification($state['ru'] ?? null, $verification, 'oidc_token_exchange_failed', $e->getMessage());
+        }
+
+        $idToken = (string) ($tokens['id_token'] ?? '');
+        if ($idToken === '') {
+            return $this->failWithVerification($state['ru'] ?? null, $verification, 'oidc_id_token_missing', 'IdP did not return an id_token.');
+        }
+        $claims = $this->oidc->verifyIdToken($conn, $idToken, expectedNonce: (string) ($state['n'] ?? ''));
+        if ($claims === null) {
+            return $this->failWithVerification($state['ru'] ?? null, $verification, 'oidc_id_token_invalid', 'id_token verification failed.');
+        }
+
+        $identity = [
+            'provider_user_id' => (string) ($claims['sub'] ?? ''),
+            'email_address' => isset($claims['email']) ? strtolower((string) $claims['email']) : null,
+            'first_name' => isset($claims['given_name']) ? (string) $claims['given_name'] : null,
+            'last_name' => isset($claims['family_name']) ? (string) $claims['family_name'] : null,
+            'id_token' => $idToken,
+            'raw_attributes' => $claims,
+        ];
+
+        return $this->finalize($env, $conn, $verification, $state, $identity, $claims['amr'] ?? null);
+    }
+
+    public function samlAcs(Request $request): RedirectResponse
+    {
+        $env = app()->bound(Environment::class) ? app(Environment::class) : null;
+        if ($env === null) {
+            return $this->failTopLevel(null, 'environment_not_resolved', 'Environment missing on SAML ACS.');
+        }
+
+        $connId = (string) $request->route('connection_id');
+        $conn = EnterpriseConnection::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $connId)
+            ->first();
+        if ($conn === null || ! $conn->isSaml()) {
+            return $this->failTopLevel(null, 'enterprise_connection_not_found', 'Connection missing or wrong protocol.');
+        }
+
+        $samlResponseB64 = (string) $request->input('SAMLResponse', '');
+        $relayState = (string) $request->input('RelayState', '');
+        $state = StateToken::unwrap($relayState);
+        if ($state === null) {
+            return $this->failTopLevel(null, 'state_invalid', 'RelayState is missing or expired.');
+        }
+        if (($state['conn'] ?? null) !== $conn->id) {
+            return $this->failTopLevel($state['ru'] ?? null, 'state_connection_mismatch', 'RelayState.connection does not match the ACS URL.');
+        }
+
+        $verification = $this->loadVerification($state['v'] ?? '', $env->id);
+        if ($verification === null) {
+            return $this->failTopLevel($state['ru'] ?? null, 'verification_not_found', 'verification row missing.');
+        }
+
+        try {
+            $assertion = $this->saml->parseSamlResponse($samlResponseB64, $conn);
+        } catch (SamlException $e) {
+            Log::warning('enterprise_sso.saml.parse_failed', ['conn' => $conn->id, 'reason' => $e->reason]);
+
+            return $this->failWithVerification($state['ru'] ?? null, $verification, $e->reason, $e->getMessage());
+        } catch (Throwable $e) {
+            return $this->failWithVerification($state['ru'] ?? null, $verification, 'saml_parse_failed', $e->getMessage());
+        }
+
+        $identity = [
+            'provider_user_id' => $assertion->nameId,
+            'email_address' => $this->extractEmailFromSamlAttributes($assertion->attributes),
+            'first_name' => $assertion->firstAttribute('givenName')
+                ?? $assertion->firstAttribute('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname'),
+            'last_name' => $assertion->firstAttribute('surname')
+                ?? $assertion->firstAttribute('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname'),
+            'id_token' => null,
+            'raw_attributes' => $assertion->attributes,
+        ];
+
+        return $this->finalize($env, $conn, $verification, $state, $identity, $assertion->authnContextClassRef);
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     * @param  array{provider_user_id:string, email_address:?string, first_name:?string, last_name:?string, id_token:?string, raw_attributes:array<string, mixed>}  $identity
+     */
+    private function finalize(
+        Environment $env,
+        EnterpriseConnection $conn,
+        Verification $verification,
+        array $state,
+        array $identity,
+        mixed $authnContextSignal,
+    ): RedirectResponse {
+        if ($identity['provider_user_id'] === '') {
+            return $this->failWithVerification($state['ru'] ?? null, $verification, 'subject_missing', 'No subject (NameID / sub) on the IdP assertion.');
+        }
+
+        $attempt = $this->loadAttempt($state, $env->id);
+        if ($attempt === null) {
+            return $this->failWithVerification($state['ru'] ?? null, $verification, 'sign_in_not_found', 'Parent SignInAttempt missing.');
+        }
+
+        try {
+            $provisioned = $this->connections->provisionUserFromIdentity($conn, $identity);
+        } catch (Throwable $e) {
+            return $this->failWithVerification($state['ru'] ?? null, $verification, 'provision_failed', $e->getMessage());
+        }
+
+        $session = DB::transaction(function () use ($env, $attempt, $verification, $conn, $provisioned, $authnContextSignal): Session {
+            $verification->forceFill([
+                'status' => Verification::STATUS_VERIFIED,
+                'verified_at' => now(),
+            ])->save();
+
+            $challenge = Challenge::query()->withoutGlobalScopes()
+                ->where('parent_type', Challenge::PARENT_SIGN_IN)
+                ->where('parent_id', $attempt->id)
+                ->latest('id')
+                ->first();
+            if ($challenge !== null) {
+                $challenge->forceFill(['status' => Challenge::STATUS_VERIFIED])->save();
+            }
+
+            $this->autojoinOrgIfApplicable($conn, $provisioned['user']);
+
+            $attempt->status = SignInAttempt::STATUS_COMPLETE;
+            $session = $this->sessions->mint($env, $provisioned['user'], $attempt);
+            $attempt->created_session_id = $session->id;
+            $attempt->save();
+
+            $this->stampMfaSatisfiedIfApplicable($env, $session, $authnContextSignal);
+
+            return $session;
+        });
+
+        $redirectUrlComplete = is_string($state['ruc'] ?? null) ? (string) $state['ruc'] : null;
+        $redirectUrl = is_string($state['ru'] ?? null) ? (string) $state['ru'] : null;
+        $target = $redirectUrlComplete ?? $redirectUrl ?? '/';
+        unset($session); // touched so PHPStan is happy
+
+        return redirect()->away($target);
+    }
+
+    private function autojoinOrgIfApplicable(EnterpriseConnection $conn, User $user): void
+    {
+        if ($conn->organization_id === null || $conn->default_role === null || $conn->default_role === '') {
+            return;
+        }
+        $existing = OrganizationMembership::query()->withoutGlobalScopes()
+            ->where('organization_id', $conn->organization_id)
+            ->where('user_id', $user->id)
+            ->exists();
+        if ($existing) {
+            return;
+        }
+        $role = Role::query()->withoutGlobalScopes()
+            ->where('environment_id', $conn->environment_id)
+            ->where('key', $conn->default_role)
+            ->first();
+        if ($role === null) {
+            return;
+        }
+        OrganizationMembership::query()->withoutGlobalScopes()->create([
+            'environment_id' => $conn->environment_id,
+            'organization_id' => $conn->organization_id,
+            'user_id' => $user->id,
+            'role_id' => $role->id,
+        ]);
+    }
+
+    /**
+     * AU-14: when the env opts in and the IdP advertises MFA, stamp the
+     * session as second-factor-satisfied.
+     */
+    private function stampMfaSatisfiedIfApplicable(Environment $env, Session $session, mixed $authnContextSignal): void
+    {
+        $settings = EnterpriseSsoSettings::fromUserSettings(is_array($env->user_settings) ? $env->user_settings : []);
+        if (! $settings->enterpriseSsoCountsAsMfa) {
+            return;
+        }
+        $signalsMfa = false;
+        if (is_array($authnContextSignal)) {
+            foreach ($authnContextSignal as $entry) {
+                if (is_string($entry) && strtolower($entry) === 'mfa') {
+                    $signalsMfa = true;
+                    break;
+                }
+            }
+        } elseif (is_string($authnContextSignal)) {
+            // SAML AuthnContextClassRef — accept any URN containing "mfa" or
+            // the spec's MultiFactor PasswordProtectedTransport variants.
+            $lower = strtolower($authnContextSignal);
+            $signalsMfa = str_contains($lower, 'mfa')
+                || str_contains($lower, 'multifactor')
+                || str_contains($lower, 'multi-factor');
+        }
+        if (! $signalsMfa) {
+            return;
+        }
+        if (Schema::hasColumn('sessions', 'second_factor_satisfied_at')) {
+            $session->forceFill(['second_factor_satisfied_at' => now()])->save();
+        }
+    }
+
+    /**
+     * @param  array<string, list<string>>  $attributes
+     */
+    private function extractEmailFromSamlAttributes(array $attributes): ?string
+    {
+        foreach (['email', 'mail', 'emailAddress', 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'] as $key) {
+            if (isset($attributes[$key][0]) && filter_var($attributes[$key][0], FILTER_VALIDATE_EMAIL)) {
+                return strtolower((string) $attributes[$key][0]);
+            }
+        }
+
+        return null;
+    }
+
+    private function loadVerification(mixed $id, string $environmentId): ?Verification
+    {
+        if (! is_string($id) || $id === '') {
+            return null;
+        }
+
+        return Verification::query()->withoutGlobalScopes()
+            ->where('id', $id)
+            ->where('environment_id', $environmentId)
+            ->first();
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    private function loadAttempt(array $state, string $environmentId): ?SignInAttempt
+    {
+        $id = $state['a'] ?? null;
+        if (! is_string($id) || $id === '') {
+            return null;
+        }
+
+        return SignInAttempt::query()->withoutGlobalScopes()
+            ->where('id', $id)
+            ->where('environment_id', $environmentId)
+            ->first();
+    }
+
+    private function failTopLevel(?string $redirectUrl, string $code, string $message): RedirectResponse
+    {
+        return $this->renderError($redirectUrl, $code, $message);
+    }
+
+    private function failWithVerification(?string $redirectUrl, Verification $verification, string $code, string $message): RedirectResponse
+    {
+        $verification->forceFill([
+            'status' => Verification::STATUS_FAILED,
+            'error_code' => $code,
+            'error_message' => $message,
+        ])->save();
+
+        return $this->renderError($redirectUrl, $code, $message);
+    }
+
+    private function renderError(?string $redirectUrl, string $code, string $message): RedirectResponse
+    {
+        $target = ($redirectUrl ?? '/').(str_contains($redirectUrl ?? '', '?') ? '&' : '?').'__authn_error='.urlencode($code);
+
+        return redirect()->away($target);
+    }
+}

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Http\Controllers\AccountPortal\AccountPortalController;
 use App\Http\Controllers\Fapi\ChallengeController;
 use App\Http\Controllers\Fapi\ClientController;
+use App\Http\Controllers\Fapi\EnterpriseSsoCallbackController;
 use App\Http\Controllers\Fapi\EnvironmentController;
 use App\Http\Controllers\Fapi\LocalizationController;
 use App\Http\Controllers\Fapi\MagicLinkController;
@@ -81,6 +82,14 @@ Route::prefix('v1')->group(function (): void {
         // fresh navigation context); state token in the query string is
         // the integrity check.
         Route::get('/oauth-callback/{provider_key}', OauthCallbackController::class)->name('fapi.oauth_callback');
+
+        // Enterprise SSO callbacks (AU-7). OIDC = GET redirect; SAML = POST ACS.
+        Route::get('/enterprise-sso-callback', [EnterpriseSsoCallbackController::class, 'oidcCallback'])
+            ->name('fapi.enterprise_sso.oidc_callback');
+        Route::get('/enterprise-sso-callback/{connection_id}', [EnterpriseSsoCallbackController::class, 'oidcCallback'])
+            ->name('fapi.enterprise_sso.oidc_callback_with_connection');
+        Route::post('/saml/{connection_id}/acs', [EnterpriseSsoCallbackController::class, 'samlAcs'])
+            ->name('fapi.enterprise_sso.saml_acs');
     });
 
     // Sign-in: POST creates the attempt (and, if needed, the Client). The

--- a/tests/Feature/Auth/EnterpriseSso/EnterpriseSsoStrategyTest.php
+++ b/tests/Feature/Auth/EnterpriseSso/EnterpriseSsoStrategyTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Strategies\EnterpriseSsoStrategy;
+use App\Auth\StrategyResolver;
+use App\Models\Verification;
+
+it('registers the enterprise_sso + saml strategies on the resolver', function (): void {
+    $resolver = app(StrategyResolver::class);
+    expect($resolver->resolve(Verification::STRATEGY_ENTERPRISE_SSO))->toBeInstanceOf(EnterpriseSsoStrategy::class);
+    expect($resolver->resolve(Verification::STRATEGY_SAML))->toBeInstanceOf(EnterpriseSsoStrategy::class);
+});
+
+it('declares both strategies as requiring a prepare step', function (): void {
+    $strategy = app(EnterpriseSsoStrategy::class);
+    expect($strategy->requiresPrepare())->toBeTrue();
+    expect($strategy->name())->toBe('enterprise_sso');
+});

--- a/tests/Feature/Http/Fapi/EnterpriseSsoCallbackTest.php
+++ b/tests/Feature/Http/Fapi/EnterpriseSsoCallbackTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\EnterpriseConnection;
+use App\Models\Environment;
+use App\Models\Project;
+use App\Services\Keys\SigningKeyGenerator;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+function bootEnvForEnterpriseSsoCallback(): array
+{
+    config([
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.app_port_suffix' => '',
+        'authn.bapi_host' => 'api.authn.local',
+        'authn.dashboard_host' => 'dashboard.authn.local',
+    ]);
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+    Route::middleware('fapi')->domain('{env_slug}.authn.local')->group(base_path('routes/fapi.php'));
+
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.uniqid()]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'acme',
+        'routing_label' => 'acme',
+        'allowed_origins' => ['https://app.example.com'],
+    ]);
+    (new SigningKeyGenerator)->generate($env);
+
+    return ['env' => $env];
+}
+
+it('returns a redirect with __authn_error=state_invalid when the OIDC state is bogus', function (): void {
+    bootEnvForEnterpriseSsoCallback();
+
+    $r = $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local'])
+        ->get('https://acme.authn.local/v1/enterprise-sso-callback?state=tampered&code=anything');
+
+    $r->assertRedirect();
+    expect($r->headers->get('Location'))->toContain('__authn_error=state_invalid');
+});
+
+it('returns a redirect with __authn_error=state_invalid when the SAML RelayState is missing', function (): void {
+    $f = bootEnvForEnterpriseSsoCallback();
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+
+    $r = $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local'])
+        ->post("https://acme.authn.local/v1/saml/{$conn->id}/acs", [
+            'SAMLResponse' => 'not-a-real-response',
+        ]);
+
+    $r->assertRedirect();
+    expect($r->headers->get('Location'))->toContain('__authn_error=state_invalid');
+});
+
+it('returns enterprise_connection_not_found when the SAML ACS connection id is unknown', function (): void {
+    bootEnvForEnterpriseSsoCallback();
+
+    $r = $this->withCredentials()
+        ->withHeaders(['Host' => 'acme.authn.local'])
+        ->post('https://acme.authn.local/v1/saml/entcon_unknown/acs', [
+            'SAMLResponse' => 'x',
+            'RelayState' => 'y',
+        ]);
+
+    $r->assertRedirect();
+    expect($r->headers->get('Location'))->toContain('__authn_error=enterprise_connection_not_found');
+});


### PR DESCRIPTION
Closes #197. Re-opening; rebased onto main after #220 (AU-5) merged. (Original #221 was auto-closed when its base branch was deleted.) See [#221 body](https://github.com/authn-sh/authn/pull/221) for the full description.