### PR TITLE
Emit entcon + entacc JWT claims on session tokens (AU-16)

### DIFF
--- a/app/Services/Sessions/SessionTokenIssuer.php
+++ b/app/Services/Sessions/SessionTokenIssuer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Sessions;
 
+use App\Models\EnterpriseAccount;
 use App\Models\Environment;
 use App\Models\OrganizationMembership;
 use App\Models\Passkey;
@@ -90,6 +91,12 @@ final class SessionTokenIssuer
         $builder = $builder->withClaim('pnv', $this->phoneNumberVerified($session));
         $builder = $builder->withClaim('pkv', $this->passkeyVerified($session));
         $builder = $builder->withClaim('pkc', $this->passkeyCount($session));
+
+        $enterprise = $this->enterpriseClaims($session);
+        if ($enterprise !== null) {
+            $builder = $builder->withClaim('entcon', $enterprise['entcon']);
+            $builder = $builder->withClaim('entacc', $enterprise['entacc']);
+        }
 
         $dsf = $this->defaultSecondFactor($session);
         if ($dsf !== null) {
@@ -232,6 +239,52 @@ final class SessionTokenIssuer
             ->where('strategy', Verification::STRATEGY_PASSKEY)
             ->where('status', Verification::STATUS_VERIFIED)
             ->exists();
+    }
+
+    /**
+     * Compact enterprise-SSO state for downstream SDK consumers (sdk-php
+     * SP-3, sdk-node JS-8). Only emits when the SignInAttempt that
+     * produced this session was verified via the `enterprise_sso` /
+     * `saml` strategy AND the matching `EnterpriseAccount` row is still
+     * live. Returns null otherwise so the claims are absent from the JWT.
+     *
+     * @return array{entcon: string, entacc: string}|null
+     */
+    private function enterpriseClaims(Session $session): ?array
+    {
+        $attempt = SignInAttempt::query()
+            ->withoutGlobalScopes()
+            ->where('created_session_id', $session->id)
+            ->first();
+        if ($attempt === null) {
+            return null;
+        }
+
+        $verification = Verification::query()
+            ->withoutGlobalScopes()
+            ->where('verifiable_type', $attempt->getMorphClass())
+            ->where('verifiable_id', $attempt->id)
+            ->whereIn('strategy', [Verification::STRATEGY_ENTERPRISE_SSO, Verification::STRATEGY_SAML])
+            ->where('status', Verification::STATUS_VERIFIED)
+            ->latest('id')
+            ->first();
+        if ($verification === null) {
+            return null;
+        }
+
+        $account = EnterpriseAccount::query()
+            ->withoutGlobalScopes()
+            ->where('user_id', $session->user_id)
+            ->latest('last_signed_in_at')
+            ->first();
+        if ($account === null) {
+            return null;
+        }
+
+        return [
+            'entcon' => $account->enterprise_connection_id,
+            'entacc' => $account->id,
+        ];
     }
 
     /**

--- a/tests/Feature/Services/Sessions/SessionTokenIssuerEnterpriseClaimsTest.php
+++ b/tests/Feature/Services/Sessions/SessionTokenIssuerEnterpriseClaimsTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\EnterpriseAccount;
+use App\Models\EnterpriseConnection;
+use App\Models\SignInAttempt;
+use App\Models\Verification;
+use App\Services\Sessions\SessionTokenIssuer;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function decodeEnterpriseClaims(string $jwt): array
+{
+    $config = Configuration::forSymmetricSigner(
+        new Sha256,
+        InMemory::plainText(str_repeat('x', 64)),
+    );
+
+    return $config->parser()->parse($jwt)->claims()->all();
+}
+
+it('omits entcon + entacc when the session was not produced by an enterprise SSO sign-in', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeEnterpriseClaims($minted['jwt']);
+
+    expect($claims)->not->toHaveKey('entcon');
+    expect($claims)->not->toHaveKey('entacc');
+});
+
+it('emits entcon + entacc when the parent SignIn was verified via enterprise_sso', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+    $account = EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'enterprise_connection_id' => $conn->id,
+    ]);
+
+    $attempt = SignInAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $auth['session']->client_id,
+        'status' => SignInAttempt::STATUS_COMPLETE,
+        'created_session_id' => $auth['session']->id,
+    ]);
+    Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => Verification::STRATEGY_ENTERPRISE_SSO,
+        'status' => Verification::STATUS_VERIFIED,
+        'expire_at' => now()->addHour(),
+        'verified_at' => now(),
+        'attempts' => 1,
+    ]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeEnterpriseClaims($minted['jwt']);
+
+    expect($claims)->toHaveKey('entcon');
+    expect($claims)->toHaveKey('entacc');
+    expect($claims['entcon'])->toBe($conn->id);
+    expect($claims['entacc'])->toBe($account->id);
+});
+
+it('emits entcon + entacc for the saml strategy too (parity with enterprise_sso)', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+    $account = EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'enterprise_connection_id' => $conn->id,
+    ]);
+
+    $attempt = SignInAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $auth['session']->client_id,
+        'status' => SignInAttempt::STATUS_COMPLETE,
+        'created_session_id' => $auth['session']->id,
+    ]);
+    Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => Verification::STRATEGY_SAML,
+        'status' => Verification::STATUS_VERIFIED,
+        'expire_at' => now()->addHour(),
+        'verified_at' => now(),
+        'attempts' => 1,
+    ]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeEnterpriseClaims($minted['jwt']);
+
+    expect($claims['entcon'])->toBe($conn->id);
+    expect($claims['entacc'])->toBe($account->id);
+});
+
+it('omits the claims when the Verification is still unverified', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+    EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $auth['user']->id,
+        'enterprise_connection_id' => $conn->id,
+    ]);
+    $attempt = SignInAttempt::create([
+        'environment_id' => $f['env']->id,
+        'client_id' => $auth['session']->client_id,
+        'status' => SignInAttempt::STATUS_NEEDS_FIRST_FACTOR,
+        'created_session_id' => $auth['session']->id,
+    ]);
+    Verification::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'verifiable_type' => $attempt->getMorphClass(),
+        'verifiable_id' => $attempt->id,
+        'strategy' => Verification::STRATEGY_ENTERPRISE_SSO,
+        'status' => Verification::STATUS_UNVERIFIED,
+        'expire_at' => now()->addHour(),
+        'attempts' => 0,
+    ]);
+
+    $minted = app(SessionTokenIssuer::class)->mint($auth['session']->fresh());
+    $claims = decodeEnterpriseClaims($minted['jwt']);
+
+    expect($claims)->not->toHaveKey('entcon');
+});


### PR DESCRIPTION
Closes #207.

## Summary

Mirrors v0.5's `pkv` / `pkc` pattern for downstream SDK consumers. Two new compact claims appear on the session JWT *only* when the originating SignInAttempt was verified via the `enterprise_sso` or `saml` strategy AND the matching `EnterpriseAccount` row is still live:

- `entcon` (string) — `EnterpriseConnection.id`
- `entacc` (string) — `EnterpriseAccount.id`

Both claims are absent when the session was minted from any other strategy (password / oauth_* / passkey / etc.).

`SessionTokenIssuer::enterpriseClaims()` resolves the `(attempt, verification, account)` triple on every mint — so role / connection changes apply on the next session refresh without an explicit re-issue.

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `php artisan test tests/Feature/Services/Sessions/` — 33 passed (4 new + 29 prior)

## Dependencies

- #224 (AU-7) — the strategy + verification flow this claim consumes.

## Downstream

sdk-php SP-3 and sdk-node JS-8 will parse these claims to surface `VerifiedClaims.enterpriseConnectionId()` / `enterpriseAccountId()` and `wasVerifiedByEnterpriseSso()`.