### PR TITLE
Add domain-routed sign-in + enrollment-mode honouring (AU-8)

### DIFF
--- a/app/Http/Controllers/Fapi/EnterpriseSsoCallbackController.php
+++ b/app/Http/Controllers/Fapi/EnterpriseSsoCallbackController.php
@@ -12,6 +12,7 @@ use App\Auth\Saml\SamlException;
 use App\Models\Challenge;
 use App\Models\EnterpriseConnection;
 use App\Models\Environment;
+use App\Models\OrganizationDomain;
 use App\Models\OrganizationMembership;
 use App\Models\Role;
 use App\Models\Session;
@@ -198,7 +199,7 @@ final class EnterpriseSsoCallbackController
             return $this->failWithVerification($state['ru'] ?? null, $verification, 'provision_failed', $e->getMessage());
         }
 
-        $session = DB::transaction(function () use ($env, $attempt, $verification, $conn, $provisioned, $authnContextSignal): Session {
+        $session = DB::transaction(function () use ($env, $attempt, $verification, $conn, $provisioned, $authnContextSignal, $identity): Session {
             $verification->forceFill([
                 'status' => Verification::STATUS_VERIFIED,
                 'verified_at' => now(),
@@ -213,7 +214,10 @@ final class EnterpriseSsoCallbackController
                 $challenge->forceFill(['status' => Challenge::STATUS_VERIFIED])->save();
             }
 
-            $this->autojoinOrgIfApplicable($conn, $provisioned['user']);
+            $identifierForAutojoin = is_string($attempt->identifier) && $attempt->identifier !== ''
+                ? $attempt->identifier
+                : $identity['email_address'];
+            $this->autojoinOrgIfApplicable($conn, $provisioned['user'], $identifierForAutojoin);
 
             $attempt->status = SignInAttempt::STATUS_COMPLETE;
             $session = $this->sessions->mint($env, $provisioned['user'], $attempt);
@@ -233,31 +237,72 @@ final class EnterpriseSsoCallbackController
         return redirect()->away($target);
     }
 
-    private function autojoinOrgIfApplicable(EnterpriseConnection $conn, User $user): void
+    private function autojoinOrgIfApplicable(EnterpriseConnection $conn, User $user, ?string $identifier = null): void
     {
-        if ($conn->organization_id === null || $conn->default_role === null || $conn->default_role === '') {
-            return;
+        // Path A — org-scoped connection with a default_role: always auto-join.
+        if ($conn->organization_id !== null && is_string($conn->default_role) && $conn->default_role !== '') {
+            $this->createMembershipIfMissing($conn->environment_id, $conn->organization_id, $conn->default_role, $user);
         }
+
+        // Path B (AU-8) — instance-wide connection but the identifier's
+        // domain matches a verified `OrganizationDomain` with an opt-in
+        // enrollment mode. Honour the org's enrollment_mode:
+        //   automatic_invitation → join immediately
+        //   automatic_suggestion → leave as a suggested org (surfaced via
+        //                          User.suggested_organizations[] at the
+        //                          /v1/me layer; nothing to do here)
+        //   manual_invitation    → no auto-action
+        if ($identifier !== null && $conn->default_role !== null && $conn->default_role !== '') {
+            $domain = $this->extractDomain($identifier);
+            if ($domain !== null) {
+                $orgDomains = OrganizationDomain::query()
+                    ->withoutGlobalScopes()
+                    ->where('environment_id', $conn->environment_id)
+                    ->where('name', $domain)
+                    ->where('verified', true)
+                    ->get();
+                foreach ($orgDomains as $orgDomain) {
+                    if ($orgDomain->enrollment_mode === OrganizationDomain::MODE_AUTOMATIC_INVITATION) {
+                        $this->createMembershipIfMissing($conn->environment_id, $orgDomain->organization_id, $conn->default_role, $user);
+                    }
+                }
+            }
+        }
+    }
+
+    private function createMembershipIfMissing(string $environmentId, string $organizationId, string $roleKey, User $user): void
+    {
         $existing = OrganizationMembership::query()->withoutGlobalScopes()
-            ->where('organization_id', $conn->organization_id)
+            ->where('organization_id', $organizationId)
             ->where('user_id', $user->id)
             ->exists();
         if ($existing) {
             return;
         }
         $role = Role::query()->withoutGlobalScopes()
-            ->where('environment_id', $conn->environment_id)
-            ->where('key', $conn->default_role)
+            ->where('environment_id', $environmentId)
+            ->where('key', $roleKey)
             ->first();
         if ($role === null) {
             return;
         }
         OrganizationMembership::query()->withoutGlobalScopes()->create([
-            'environment_id' => $conn->environment_id,
-            'organization_id' => $conn->organization_id,
+            'environment_id' => $environmentId,
+            'organization_id' => $organizationId,
             'user_id' => $user->id,
             'role_id' => $role->id,
         ]);
+    }
+
+    private function extractDomain(string $identifier): ?string
+    {
+        $at = strrpos($identifier, '@');
+        if ($at === false) {
+            return null;
+        }
+        $domain = strtolower(trim(substr($identifier, $at + 1)));
+
+        return $domain === '' ? null : $domain;
     }
 
     /**

--- a/app/Http/Resources/SignInResource.php
+++ b/app/Http/Resources/SignInResource.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Resources;
 
+use App\Auth\EnterpriseSso\EnterpriseConnectionService;
 use App\Models\BackupCode;
 use App\Models\EmailAddress;
+use App\Models\EnterpriseConnection;
 use App\Models\Passkey;
 use App\Models\PhoneNumber;
 use App\Models\SignInAttempt;
@@ -28,6 +30,7 @@ final class SignInResource
         }
 
         $transferable = $attempt->status === SignInAttempt::STATUS_TRANSFERABLE;
+        $matchedConnection = self::matchedEnterpriseConnection($attempt);
 
         return [
             'object' => 'sign_in_attempt',
@@ -35,29 +38,52 @@ final class SignInResource
             'status' => $attempt->status,
             'identifier' => $attempt->identifier,
             'supported_identifiers' => ['email_address'],
-            'supported_strategies' => self::supportedStrategies($attempt),
+            'supported_strategies' => self::supportedStrategies($attempt, $matchedConnection),
             'current_challenge_id' => $attempt->current_challenge_id,
             'user_data' => self::userDataPreview($attempt),
             'created_session_id' => $attempt->created_session_id,
             'abandon_at' => $attempt->abandon_at->getTimestampMs(),
             'transferable_to_signup' => $transferable,
             'target_flow' => $transferable ? 'sign_up' : null,
+            'enterprise_connection_id' => $matchedConnection?->id,
         ];
     }
 
     /**
      * Strategies the client may issue next via `POST /sign-ins/{sid}/challenges`.
      * Narrowed by the SignIn's current status — terminal states return [].
+     * AU-8: when the identifier domain routes to exactly one enabled
+     * `EnterpriseConnection`, narrow to `[enterprise_sso]` so the SDK
+     * jumps to the IdP without showing other options.
      *
      * @return list<string>
      */
-    private static function supportedStrategies(SignInAttempt $attempt): array
+    private static function supportedStrategies(SignInAttempt $attempt, ?EnterpriseConnection $matchedConnection): array
     {
+        if ($attempt->status === SignInAttempt::STATUS_NEEDS_FIRST_FACTOR && $matchedConnection !== null) {
+            return [Verification::STRATEGY_ENTERPRISE_SSO];
+        }
+
         return match ($attempt->status) {
             SignInAttempt::STATUS_NEEDS_FIRST_FACTOR => self::firstFactorStrategies($attempt),
             SignInAttempt::STATUS_NEEDS_SECOND_FACTOR => self::secondFactorStrategies($attempt),
             default => [],
         };
+    }
+
+    /**
+     * AU-8 domain routing: resolve the env's `EnterpriseConnection` that
+     * covers the identifier domain (prefers org-scoped, falls back to
+     * instance-wide). Returns `null` when no connection matches.
+     */
+    private static function matchedEnterpriseConnection(SignInAttempt $attempt): ?EnterpriseConnection
+    {
+        $env = $attempt->environment;
+        if ($env === null || ! is_string($attempt->identifier) || $attempt->identifier === '') {
+            return null;
+        }
+
+        return app(EnterpriseConnectionService::class)->findByIdentifierDomain($env, $attempt->identifier);
     }
 
     /**

--- a/tests/Feature/Http/SignIn/DomainRoutedSignInTest.php
+++ b/tests/Feature/Http/SignIn/DomainRoutedSignInTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\EnterpriseConnection;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationDomain;
+use App\Models\Project;
+use App\Models\User;
+use App\Services\Client\ClientResolver;
+use App\Services\Keys\SigningKeyGenerator;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+function bootEnvForDomainRouting(): array
+{
+    config([
+        'authn.routing_mode' => 'subdomain',
+        'authn.app_host' => 'authn.local',
+        'authn.app_scheme' => 'https',
+        'authn.app_port_suffix' => '',
+        'authn.bapi_host' => 'api.authn.local',
+        'authn.dashboard_host' => 'dashboard.authn.local',
+    ]);
+    $router = app('router');
+    $router->setRoutes(new RouteCollection);
+    Route::middleware('fapi')->domain('{env_slug}.authn.local')->group(base_path('routes/fapi.php'));
+
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.uniqid()]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'acme',
+        'routing_label' => 'acme',
+        'allowed_origins' => ['https://app.example.com'],
+    ]);
+    (new SigningKeyGenerator)->generate($env);
+
+    $client = Client::create(['environment_id' => $env->id]);
+    $cookie = app(ClientResolver::class)->mintCookieValue($client);
+
+    return ['env' => $env, 'origin' => 'https://app.example.com', 'cookie' => $cookie];
+}
+
+it('narrows supported_strategies to [enterprise_sso] when the identifier domain matches an instance-wide connection', function (): void {
+    $f = bootEnvForDomainRouting();
+    $user = User::create(['environment_id' => $f['env']->id]);
+    $user->setPassword('super-secret-password');
+    $user->save();
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'email_address' => 'alice@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+    EnterpriseConnection::factory()->create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => null,
+        'domains' => ['acme.test'],
+    ]);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $f['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'alice@acme.test',
+        ]);
+
+    $r->assertOk()
+        ->assertJsonPath('response.status', 'needs_first_factor')
+        ->assertJsonPath('response.supported_strategies', ['enterprise_sso']);
+    expect($r->json('response.enterprise_connection_id'))->not->toBeNull();
+});
+
+it('prefers the org-scoped connection over an instance-wide one when both cover the domain', function (): void {
+    $f = bootEnvForDomainRouting();
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Acme', 'slug' => 'acme']);
+    OrganizationDomain::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'name' => 'acme.test',
+        'verified' => true,
+        'enrollment_mode' => OrganizationDomain::MODE_MANUAL_INVITATION,
+    ]);
+
+    $user = User::create(['environment_id' => $f['env']->id]);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'email_address' => 'alice@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+    EnterpriseConnection::factory()->create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => null,
+        'domains' => ['acme.test'],
+    ]);
+    $orgConn = EnterpriseConnection::factory()->create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'domains' => ['acme.test'],
+    ]);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $f['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'alice@acme.test',
+        ]);
+
+    $r->assertOk()
+        ->assertJsonPath('response.enterprise_connection_id', $orgConn->id)
+        ->assertJsonPath('response.supported_strategies', ['enterprise_sso']);
+});
+
+it('keeps the full first-factor strategy list when no enterprise connection covers the identifier domain', function (): void {
+    $f = bootEnvForDomainRouting();
+    $user = User::create(['environment_id' => $f['env']->id]);
+    $user->setPassword('super-secret-password');
+    $user->save();
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'email_address' => 'bob@other.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $f['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'bob@other.test',
+        ]);
+
+    $r->assertOk()
+        ->assertJsonPath('response.enterprise_connection_id', null);
+    $strategies = $r->json('response.supported_strategies');
+    expect($strategies)->toContain('password');
+    expect($strategies)->toContain('email_code');
+    expect($strategies)->not->toContain('enterprise_sso');
+});
+
+it('skips a disabled enterprise connection when narrowing strategies', function (): void {
+    $f = bootEnvForDomainRouting();
+    $user = User::create(['environment_id' => $f['env']->id]);
+    $user->setPassword('super-secret-password');
+    $user->save();
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'email_address' => 'alice@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+    EnterpriseConnection::factory()->disabled()->create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => null,
+        'domains' => ['acme.test'],
+    ]);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $f['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Origin' => $f['origin']])
+        ->postJson('https://acme.authn.local/v1/client/sign-ins', [
+            'identifier' => 'alice@acme.test',
+        ]);
+
+    $r->assertOk()
+        ->assertJsonPath('response.enterprise_connection_id', null);
+    expect($r->json('response.supported_strategies'))->not->toContain('enterprise_sso');
+});


### PR DESCRIPTION
Closes #199. Stacks on #224 (AU-7) — will rebase onto \`main\` after that lands.

## Summary

### SignInResource
- New nullable `enterprise_connection_id` field on the SignIn snapshot. Resolution prefers org-scoped over instance-wide via `EnterpriseConnectionService::findByIdentifierDomain`. Disabled connections are skipped.
- When status is `needs_first_factor` AND the domain matched a connection, `supported_strategies` is narrowed to `["enterprise_sso"]` only so the SDK redirects to the IdP immediately.

### EnterpriseSsoCallbackController (extension)
`autojoinOrgIfApplicable()` now handles both paths:
- Path A (existing, org-scoped connection with `default_role`): auto-join the connection's org.
- Path B (AU-8, instance-wide connection): if the identifier domain matches a verified `OrganizationDomain` with `enrollment_mode = automatic_invitation`, auto-join *that* org. `automatic_suggestion` is left for a future `User.suggested_organizations[]` view-field (lands alongside JS-5).

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `php artisan test tests/Feature/Http/SignIn/DomainRoutedSignInTest.php` — 4 passed (instance-wide narrowing, org-scoped preference, no-match preserves full strategy list, disabled-connection skip)
- [x] No regressions across other enterprise-sso tests (29 passed)

## Out of scope

- DNS TXT verification flow (shipped in v0.2 already).
- Verified-domain CRUD UI (JS-5 in javascript repo).