### PR TITLE
Add per-org SCIM token + mapping + endpoint CRUD (AU-10)

### DIFF
--- a/app/Http/Controllers/Fapi/OrganizationScimController.php
+++ b/app/Http/Controllers/Fapi/OrganizationScimController.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\ScimAttributeMapping;
+use App\Models\ScimToken;
+use App\Models\User;
+use App\Support\Url;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * FAPI per-org SCIM management surface — what `<OrganizationProfile />`'s
+ * Directory Sync section drives. Gated by `org:sys_provisioning:manage`
+ * via `EnsureOrgPermission` (registered on each route).
+ *
+ *   GET    /v1/organizations/{org_id}/scim/tokens
+ *   POST   /v1/organizations/{org_id}/scim/tokens
+ *   POST   /v1/organizations/{org_id}/scim/tokens/{token_id}/revoke
+ *   GET    /v1/organizations/{org_id}/scim/attribute-mappings
+ *   PUT    /v1/organizations/{org_id}/scim/attribute-mappings
+ *   GET    /v1/organizations/{org_id}/scim/endpoint
+ *
+ * The token plaintext is returned **only** on the issue (POST) response;
+ * subsequent list / show responses expose only the visible 12-char prefix
+ * registered with the token at create time.
+ */
+final class OrganizationScimController
+{
+    public function listTokens(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = app(Organization::class);
+
+        $rows = ScimToken::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('organization_id', $org->id)
+            ->orderBy('id')
+            ->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (ScimToken $t) => $this->tokenShape($t))->all(),
+            'total_count' => $rows->count(),
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function issueToken(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = app(Organization::class);
+        $user = app(User::class);
+
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|min:1|max:100',
+            'expires_at' => 'nullable|date',
+            'enterprise_connection_id' => 'nullable|string',
+        ]);
+        if ($validator->fails()) {
+            return $this->validationError($validator->errors()->toArray());
+        }
+        $data = $validator->validated();
+
+        $minted = ScimToken::mintPlaintext();
+        $row = ScimToken::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'organization_id' => $org->id,
+            'enterprise_connection_id' => $data['enterprise_connection_id'] ?? null,
+            'hashed_token' => $minted['hash'],
+            'prefix' => $minted['prefix'],
+            'name' => $data['name'],
+            'created_by_user_id' => $user->id,
+            'expires_at' => $data['expires_at'] ?? null,
+        ]);
+
+        // The plaintext rides on the spec's `token` property of the
+        // ScimToken shape (writeOnly, populated only on this endpoint).
+        return response()->json(array_merge(
+            $this->tokenShape($row->fresh()),
+            ['token' => $minted['plaintext']],
+        ), 201)->header('Cache-Control', 'no-store');
+    }
+
+    public function revokeToken(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = app(Organization::class);
+        $id = (string) $request->route('token_id');
+        $row = ScimToken::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('organization_id', $org->id)
+            ->where('id', $id)
+            ->first();
+        if ($row === null) {
+            return $this->error(404, 'scim_token_not_found', "ScimToken {$id} not found.");
+        }
+        $row->revoke();
+
+        return response()->json($this->tokenShape($row->fresh()))->header('Cache-Control', 'no-store');
+    }
+
+    public function showAttributeMappings(Request $request): JsonResponse
+    {
+        $org = app(Organization::class);
+        $resolved = ScimAttributeMapping::resolveFor($org);
+
+        // Spec shape (OA-7): `{ organization_id, mapping: { <source>: <target> } }`.
+        $mapping = [];
+        foreach ($resolved as $source => $entry) {
+            $mapping[$source] = $entry['target'];
+        }
+
+        return response()->json([
+            'organization_id' => $org->id,
+            'mapping' => $mapping,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function replaceAttributeMappings(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = app(Organization::class);
+
+        $validator = Validator::make($request->all(), [
+            'mapping' => 'present|array',
+        ]);
+        if ($validator->fails()) {
+            return $this->validationError($validator->errors()->toArray());
+        }
+        $mappingInput = (array) $request->input('mapping', []);
+
+        // Atomic replace: drop existing per-org overrides, write the new set.
+        ScimAttributeMapping::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('organization_id', $org->id)
+            ->delete();
+        foreach ($mappingInput as $source => $target) {
+            if (! is_string($source) || ! is_string($target)) {
+                continue;
+            }
+            ScimAttributeMapping::query()->withoutGlobalScopes()->create([
+                'environment_id' => $env->id,
+                'organization_id' => $org->id,
+                'source_attribute' => $source,
+                'target_attribute' => $target,
+            ]);
+        }
+
+        return $this->showAttributeMappings($request);
+    }
+
+    public function showEndpoint(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        return response()->json([
+            'endpoint_url' => Url::fapi($env, '/scim/v2'),
+            'users_url' => Url::fapi($env, '/scim/v2/Users'),
+            'groups_url' => Url::fapi($env, '/scim/v2/Groups'),
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function tokenShape(ScimToken $row): array
+    {
+        return [
+            'object' => 'scim_token',
+            'id' => $row->id,
+            'organization_id' => $row->organization_id,
+            'name' => $row->name,
+            'prefix' => $row->prefix,
+            'revoked_at' => $row->revoked_at?->getTimestampMs(),
+            'created_at' => $row->created_at?->getTimestampMs(),
+        ];
+    }
+
+    /**
+     * @param  array<string, array{target: string, transform: ?string}>  $resolved
+     * @return list<array{source_attribute: string, target_attribute: string, transform: ?string}>
+     */
+    private function shapeResolved(array $resolved): array
+    {
+        $out = [];
+        foreach ($resolved as $source => $entry) {
+            $out[] = [
+                'source_attribute' => $source,
+                'target_attribute' => $entry['target'],
+                'transform' => $entry['transform'],
+            ];
+        }
+
+        return $out;
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [['code' => $code, 'message' => $message, 'long_message' => $message]],
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    /**
+     * @param  array<string, list<string>>  $errors
+     */
+    private function validationError(array $errors): JsonResponse
+    {
+        $flat = [];
+        foreach ($errors as $field => $messages) {
+            foreach ($messages as $message) {
+                $flat[] = [
+                    'code' => 'form_param_invalid',
+                    'message' => $message,
+                    'long_message' => $message,
+                    'meta' => ['param' => $field],
+                ];
+            }
+        }
+
+        return response()->json(['errors' => $flat], 422)->header('Cache-Control', 'no-store');
+    }
+}

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\Fapi\OrganizationEnterpriseConnectionController;
 use App\Http\Controllers\Fapi\OrganizationInvitationController as FapiOrganizationInvitationController;
 use App\Http\Controllers\Fapi\OrganizationMembershipController as FapiOrganizationMembershipController;
 use App\Http\Controllers\Fapi\OrganizationMembershipRequestController as FapiOrganizationMembershipRequestController;
+use App\Http\Controllers\Fapi\OrganizationScimController;
 use App\Http\Controllers\Fapi\PingController;
 use App\Http\Controllers\Fapi\SessionsController;
 use App\Http\Controllers\Fapi\SessionTokenController;
@@ -253,6 +254,27 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/organizations/{organization_id}/enterprise-connections/{enterprise_connection_id}/test', [OrganizationEnterpriseConnectionController::class, 'test'])
             ->middleware(EnsureOrgPermission::class.':org:sys_sso:manage')
             ->name('fapi.organizations.enterprise_connections.test');
+
+        // Per-org SCIM management (AU-10 / OA-7). Drives the
+        // <OrganizationProfile /> Directory Sync section in sdk-react.
+        Route::get('/organizations/{organization_id}/scim/tokens', [OrganizationScimController::class, 'listTokens'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_provisioning:manage')
+            ->name('fapi.organizations.scim.tokens.index');
+        Route::post('/organizations/{organization_id}/scim/tokens', [OrganizationScimController::class, 'issueToken'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_provisioning:manage')
+            ->name('fapi.organizations.scim.tokens.store');
+        Route::post('/organizations/{organization_id}/scim/tokens/{token_id}/revoke', [OrganizationScimController::class, 'revokeToken'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_provisioning:manage')
+            ->name('fapi.organizations.scim.tokens.revoke');
+        Route::get('/organizations/{organization_id}/scim/attribute-mappings', [OrganizationScimController::class, 'showAttributeMappings'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_provisioning:manage')
+            ->name('fapi.organizations.scim.attribute_mappings.show');
+        Route::put('/organizations/{organization_id}/scim/attribute-mappings', [OrganizationScimController::class, 'replaceAttributeMappings'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_provisioning:manage')
+            ->name('fapi.organizations.scim.attribute_mappings.replace');
+        Route::get('/organizations/{organization_id}/scim/endpoint', [OrganizationScimController::class, 'showEndpoint'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_provisioning:manage')
+            ->name('fapi.organizations.scim.endpoint.show');
 
         // /v1/me org-related collections + active-org switching (AU-7).
         Route::get('/me/organization-memberships', [MeOrganizationController::class, 'listMemberships'])->name('fapi.me.organization_memberships');

--- a/tests/Feature/Http/Fapi/OrganizationScimTest.php
+++ b/tests/Feature/Http/Fapi/OrganizationScimTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\ScimAttributeMapping;
+use App\Models\ScimToken;
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function fapiOrgScimReq(string $method, string $path, string $jwt, array $body = []): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+function fapiScimMakeOrg(Environment $env, User $user, string $roleKey = 'org:admin'): Organization
+{
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => 'acme-'.uniqid()]);
+    $role = Role::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('key', $roleKey)
+        ->firstOrFail();
+    OrganizationMembership::create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'user_id' => $user->id,
+        'role_id' => $role->id,
+    ]);
+
+    return $org;
+}
+
+it('rejects non-members with 404 organization_not_found', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Outside', 'slug' => 'outside']);
+
+    $r = fapiOrgScimReq('GET', "/organizations/{$org->id}/scim/tokens", $auth['jwt']);
+    $r->assertStatus(404)->assertJsonPath('errors.0.code', 'organization_not_found');
+});
+
+it('rejects members lacking org:sys_provisioning:manage with 403', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiScimMakeOrg($f['env'], $auth['user'], 'org:member');
+
+    $r = fapiOrgScimReq('GET', "/organizations/{$org->id}/scim/tokens", $auth['jwt']);
+    $r->assertStatus(403)->assertJsonPath('errors.0.code', 'authorization_invalid');
+});
+
+it('issues a SCIM token and returns the plaintext exactly once', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiScimMakeOrg($f['env'], $auth['user']);
+
+    $r = fapiOrgScimReq('POST', "/organizations/{$org->id}/scim/tokens", $auth['jwt'], [
+        'name' => 'Okta sync',
+    ]);
+
+    $r->assertCreated()
+        ->assertJsonPath('object', 'scim_token')
+        ->assertJsonPath('name', 'Okta sync')
+        ->assertJsonPath('organization_id', $org->id);
+    expect($r->json('token'))->toStartWith('scim_');
+    expect($r->json('prefix'))->toStartWith('scim_');
+
+    // The list path never re-exposes the plaintext.
+    $listed = fapiOrgScimReq('GET', "/organizations/{$org->id}/scim/tokens", $auth['jwt']);
+    expect($listed->json('data.0'))->not->toHaveKey('token');
+    expect($listed->json('data.0'))->not->toHaveKey('hashed_token');
+});
+
+it('revokes a SCIM token stamping revoked_at', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiScimMakeOrg($f['env'], $auth['user']);
+    $minted = ScimToken::mintPlaintext();
+    $token = ScimToken::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'hashed_token' => $minted['hash'],
+        'prefix' => $minted['prefix'],
+        'name' => 't',
+        'created_by_user_id' => $auth['user']->id,
+    ]);
+
+    $r = fapiOrgScimReq('POST', "/organizations/{$org->id}/scim/tokens/{$token->id}/revoke", $auth['jwt']);
+
+    $r->assertOk();
+    expect($r->json('revoked_at'))->not->toBeNull();
+});
+
+it('shows + replaces the per-org SCIM attribute mappings (round-trip)', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiScimMakeOrg($f['env'], $auth['user']);
+
+    // Initial GET returns the defaults rolled into the `mapping` blob.
+    $initial = fapiOrgScimReq('GET', "/organizations/{$org->id}/scim/attribute-mappings", $auth['jwt']);
+    $initial->assertOk()
+        ->assertJsonPath('organization_id', $org->id);
+    expect($initial->json('mapping.userName'))->toBe('email_address'); // baked default
+
+    // PUT replaces with a custom override.
+    $replaced = fapiOrgScimReq('PUT', "/organizations/{$org->id}/scim/attribute-mappings", $auth['jwt'], [
+        'mapping' => [
+            'userName' => 'username',
+            'custom.dept' => 'public_metadata.department',
+        ],
+    ]);
+    $replaced->assertOk()
+        ->assertJsonPath('mapping.userName', 'username');
+    expect($replaced->json('mapping'))->toHaveKey('custom.dept');
+    expect($replaced->json('mapping')['custom.dept'])->toBe('public_metadata.department');
+
+    // Subsequent GET reflects the new override set.
+    $after = fapiOrgScimReq('GET', "/organizations/{$org->id}/scim/attribute-mappings", $auth['jwt']);
+    expect($after->json('mapping.userName'))->toBe('username');
+
+    expect(ScimAttributeMapping::query()->withoutGlobalScopes()->where('organization_id', $org->id)->count())->toBe(2);
+});
+
+it('exposes the SCIM endpoint URL for IdP-side handoff', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiScimMakeOrg($f['env'], $auth['user']);
+
+    $r = fapiOrgScimReq('GET', "/organizations/{$org->id}/scim/endpoint", $auth['jwt']);
+    $r->assertOk()
+        ->assertJsonPath('endpoint_url', 'https://acme.authn.local/scim/v2')
+        ->assertJsonPath('users_url', 'https://acme.authn.local/scim/v2/Users');
+});


### PR DESCRIPTION
Closes #201.

## Summary

`OrganizationScimController` mounted under `/v1/organizations/{org_id}/scim/...`, gated by `org:sys_provisioning:manage` via `EnsureOrgPermission`:

- `GET /scim/tokens` — list tokens (prefix only)
- `POST /scim/tokens` — issue. Returns OA-7's `ScimToken` shape with the plaintext bound to the spec's `token` field (writeOnly, populated **only** on this response). Subsequent reads expose `prefix` only.
- `POST /scim/tokens/{token_id}/revoke` — stamp `revoked_at`.
- `GET /scim/attribute-mappings` — returns the resolved `{ organization_id, mapping: { source: target } }` blob with defaults rolled in.
- `PUT /scim/attribute-mappings` — atomic replace of the per-org override set.
- `GET /scim/endpoint` — surfaces `endpoint_url`, `users_url`, `groups_url` for IdP-side admin handoff.

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `php artisan test tests/Feature/Http/Fapi/OrganizationScimTest.php` — 6 passed (non-member 404, missing-permission 403, issue+plaintext, revoke, mapping round-trip, endpoint URL shape)

## Out of scope

- The `/scim/v2/*` endpoints themselves (AU-9 — merged in #223).