### PR TITLE
Add Dashboard Configure: Enterprise SSO subsection (AU-12)

### DIFF
--- a/app/Http/Controllers/Dashboard/DashboardController.php
+++ b/app/Http/Controllers/Dashboard/DashboardController.php
@@ -14,6 +14,8 @@ use App\Models\AllowlistIdentifier;
 use App\Models\ApiKey;
 use App\Models\BlocklistIdentifier;
 use App\Models\EmailTemplate;
+use App\Models\EnterpriseAccount;
+use App\Models\EnterpriseConnection;
 use App\Models\Environment;
 use App\Models\ExternalAccount;
 use App\Models\Invitation;
@@ -279,6 +281,13 @@ final class DashboardController
             ->orderBy('provider_key')
             ->get();
 
+        $enterpriseRows = EnterpriseConnection::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->orderBy('organization_id')
+            ->orderBy('protocol')
+            ->orderBy('name')
+            ->get();
+
         return Inertia::render('Dashboard/Configure', [
             'section' => $section,
             'user_settings' => $userSettings,
@@ -308,6 +317,7 @@ final class DashboardController
             ])->all(),
             'oauth_providers' => $oauthRows->map(fn (OauthProvider $p) => $this->oauthRowShape($p))->all(),
             'oauth_preset_keys' => $this->oauthPresets->keys(),
+            'enterprise_connections' => $enterpriseRows->map(fn (EnterpriseConnection $c) => $this->enterpriseConnectionRowShape($c))->all(),
             'localization' => $this->localizationShape($env),
             'localization_canonical' => [
                 'shipped_locales' => CanonicalSchema::SHIPPED_LOCALES,
@@ -1235,5 +1245,115 @@ final class DashboardController
             ->where('is_system', false)
             ->orderBy('created_at')
             ->first();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function enterpriseConnectionRowShape(EnterpriseConnection $row): array
+    {
+        $accountsCount = EnterpriseAccount::query()->withoutGlobalScopes()
+            ->where('enterprise_connection_id', $row->id)
+            ->count();
+
+        return [
+            'id' => $row->id,
+            'protocol' => $row->protocol,
+            'name' => $row->name,
+            'enabled' => (bool) $row->enabled,
+            'organization_id' => $row->organization_id,
+            'domains' => is_array($row->domains) ? array_values($row->domains) : [],
+            'default_role' => $row->default_role,
+            'saml_idp_entity_id' => $row->saml_idp_entity_id,
+            'saml_sso_url' => $row->saml_sso_url,
+            'saml_signing_algorithm' => $row->saml_signing_algorithm,
+            'oidc_issuer' => $row->oidc_issuer,
+            'oidc_client_id' => $row->oidc_client_id,
+            'oidc_scopes' => is_array($row->oidc_scopes) ? array_values($row->oidc_scopes) : [],
+            'linked_accounts_count' => $accountsCount,
+            'created_at' => $row->created_at?->getTimestampMs(),
+        ];
+    }
+
+    public function storeEnterpriseConnection(Request $request, string $project_slug, string $env_slug): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+
+        $request->validate([
+            'protocol' => ['required', Rule::in(EnterpriseConnection::PROTOCOLS)],
+            'name' => ['required', 'string', 'max:255'],
+            'domains' => ['nullable', 'array'],
+            'domains.*' => ['string'],
+            'default_role' => ['nullable', 'string', 'max:255'],
+            'saml_idp_entity_id' => ['nullable', 'string', 'max:512'],
+            'saml_sso_url' => ['nullable', 'url', 'max:512'],
+            'saml_idp_certificate' => ['nullable', 'string'],
+            'saml_signing_algorithm' => ['nullable', 'string', 'max:128'],
+            'oidc_issuer' => ['nullable', 'url', 'max:512'],
+            'oidc_client_id' => ['nullable', 'string', 'max:255'],
+            'oidc_client_secret' => ['nullable', 'string'],
+            'oidc_scopes' => ['nullable', 'array'],
+            'enabled' => ['nullable', 'boolean'],
+        ]);
+
+        $protocol = (string) $request->input('protocol');
+        $payload = [
+            'environment_id' => $env->id,
+            'protocol' => $protocol,
+            'name' => (string) $request->input('name'),
+            'enabled' => $request->boolean('enabled', true),
+            'domains' => is_array($request->input('domains')) ? $request->input('domains') : [],
+            'default_role' => $request->input('default_role'),
+        ];
+        if ($protocol === EnterpriseConnection::PROTOCOL_SAML) {
+            $payload += [
+                'saml_idp_entity_id' => (string) $request->input('saml_idp_entity_id'),
+                'saml_sso_url' => (string) $request->input('saml_sso_url'),
+                'saml_idp_certificate' => (string) $request->input('saml_idp_certificate'),
+                'saml_signing_algorithm' => $request->input('saml_signing_algorithm') ?: 'RSA_SHA256',
+            ];
+        } else {
+            $payload += [
+                'oidc_issuer' => (string) $request->input('oidc_issuer'),
+                'oidc_client_id' => (string) $request->input('oidc_client_id'),
+                'oidc_client_secret' => (string) $request->input('oidc_client_secret'),
+                'oidc_scopes' => is_array($request->input('oidc_scopes')) ? $request->input('oidc_scopes') : ['openid', 'email', 'profile'],
+            ];
+        }
+
+        EnterpriseConnection::query()->withoutGlobalScopes()->create($payload);
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/enterprise-sso")
+            ->with('enterprise_connection_saved', true);
+    }
+
+    public function destroyEnterpriseConnection(Request $request, string $project_slug, string $env_slug, string $enterprise_connection_id): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+
+        $conn = EnterpriseConnection::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $enterprise_connection_id)
+            ->first();
+        if ($conn !== null) {
+            $linked = EnterpriseAccount::query()->withoutGlobalScopes()
+                ->where('enterprise_connection_id', $conn->id)
+                ->exists();
+            if ($linked) {
+                return redirect()->back()->withErrors([
+                    'enterprise_connection' => 'Cannot delete — accounts are still linked. Unlink users first.',
+                ]);
+            }
+            $conn->delete();
+        }
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/enterprise-sso")
+            ->with('enterprise_connection_deleted', true);
     }
 }

--- a/resources/js/dashboard/pages/Configure.tsx
+++ b/resources/js/dashboard/pages/Configure.tsx
@@ -83,6 +83,7 @@ type Props = {
     oauth_preset_keys: string[]
     localization: LocalizationShape
     localization_canonical: LocalizationCanonical
+    enterprise_connections: EnterpriseConnection[]
 }
 
 const SECTIONS = [
@@ -90,9 +91,28 @@ const SECTIONS = [
     { slug: 'multi-factor', label: 'Multi-factor' },
     { slug: 'sms', label: 'SMS' },
     { slug: 'social-providers', label: 'Social providers' },
+    { slug: 'enterprise-sso', label: 'Enterprise SSO' },
     { slug: 'appearance', label: 'Appearance' },
     { slug: 'localization', label: 'Localization' },
 ] as const
+
+type EnterpriseConnection = {
+    id: string
+    protocol: 'saml' | 'oidc'
+    name: string
+    enabled: boolean
+    organization_id: string | null
+    domains: string[]
+    default_role: string | null
+    saml_idp_entity_id: string | null
+    saml_sso_url: string | null
+    saml_signing_algorithm: string | null
+    oidc_issuer: string | null
+    oidc_client_id: string | null
+    oidc_scopes: string[]
+    linked_accounts_count: number
+    created_at: number | null
+}
 
 export default function Configure(props: Props) {
     const url = useDashboardUrl()
@@ -132,7 +152,10 @@ export default function Configure(props: Props) {
                     canonical={props.localization_canonical}
                 />
             )}
-            {!['attributes', 'multi-factor', 'sms', 'social-providers', 'appearance', 'localization'].includes(props.section) && (
+            {props.section === 'enterprise-sso' && (
+                <EnterpriseSsoSection connections={props.enterprise_connections} />
+            )}
+            {!['attributes', 'multi-factor', 'sms', 'social-providers', 'enterprise-sso', 'appearance', 'localization'].includes(props.section) && (
                 <pre style={{ background: '#f1f5f9', padding: 12, borderRadius: 6 }}>
                     {JSON.stringify(props.user_settings, null, 2)}
                 </pre>
@@ -1392,5 +1415,336 @@ function LocalizationSection({
                 </button>
             </form>
         </div>
+    )
+}
+
+function EnterpriseSsoSection({ connections }: { connections: EnterpriseConnection[] }) {
+    const url = useDashboardUrl()
+    const { active_project, active_environment } = useDashboard()
+    const { props: pageProps } = usePage<{ flash?: {
+        enterprise_connection_saved?: boolean
+        enterprise_connection_deleted?: boolean
+    } }>()
+
+    if (!active_project || !active_environment) {
+        return <p>No active environment.</p>
+    }
+    const base = `/${active_project.slug}/${active_environment.slug}/configure`
+
+    const instanceConnections = connections.filter(c => c.organization_id === null)
+    const orgConnections = connections.filter(c => c.organization_id !== null)
+
+    return (
+        <section>
+            <h2>Enterprise SSO</h2>
+            <p style={{ color: '#475569', marginBottom: 16 }}>
+                SAML + OIDC connections shared by every org in this environment.
+                Per-org connections live in <code>&lt;OrganizationProfile /&gt;</code> on the embedded SDK side.
+            </p>
+
+            {pageProps.flash?.enterprise_connection_saved && (
+                <p style={{ color: '#15803d', marginBottom: 12 }}>Connection saved.</p>
+            )}
+            {pageProps.flash?.enterprise_connection_deleted && (
+                <p style={{ color: '#15803d', marginBottom: 12 }}>Connection deleted.</p>
+            )}
+
+            <h3 style={{ marginTop: 12 }}>Instance-wide connections</h3>
+            {instanceConnections.length === 0 ? (
+                <p style={{ color: '#64748b' }}>No instance-wide connections yet.</p>
+            ) : (
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, marginBottom: 16 }}>
+                    <thead>
+                        <tr style={{ borderBottom: '1px solid #e5e7eb' }}>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Name</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Protocol</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Domains</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Linked</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Enabled</th>
+                            <th style={{ textAlign: 'right', padding: 6 }}></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {instanceConnections.map(c => (
+                            <tr key={c.id} style={{ borderBottom: '1px solid #f1f5f9' }}>
+                                <td style={{ padding: 6 }}>{c.name}</td>
+                                <td style={{ padding: 6 }}><code>{c.protocol}</code></td>
+                                <td style={{ padding: 6, color: '#475569' }}>{c.domains.join(', ') || '—'}</td>
+                                <td style={{ padding: 6 }}>{c.linked_accounts_count}</td>
+                                <td style={{ padding: 6 }}>{c.enabled ? 'Yes' : 'No'}</td>
+                                <td style={{ padding: 6, textAlign: 'right' }}>
+                                    <DeleteConnectionButton id={c.id} action={url(`${base}/enterprise-connections/${c.id}`)} disabled={c.linked_accounts_count > 0} />
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+
+            <h3 style={{ marginTop: 24 }}>Org-scoped connections</h3>
+            {orgConnections.length === 0 ? (
+                <p style={{ color: '#64748b' }}>
+                    No org-scoped connections. Org admins configure these in <code>&lt;OrganizationProfile /&gt;</code>.
+                </p>
+            ) : (
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, marginBottom: 16 }}>
+                    <thead>
+                        <tr style={{ borderBottom: '1px solid #e5e7eb' }}>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Name</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Org</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Protocol</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Linked</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Enabled</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {orgConnections.map(c => (
+                            <tr key={c.id} style={{ borderBottom: '1px solid #f1f5f9' }}>
+                                <td style={{ padding: 6 }}>{c.name}</td>
+                                <td style={{ padding: 6, fontFamily: 'monospace', color: '#475569' }}>{c.organization_id}</td>
+                                <td style={{ padding: 6 }}><code>{c.protocol}</code></td>
+                                <td style={{ padding: 6 }}>{c.linked_accounts_count}</td>
+                                <td style={{ padding: 6 }}>{c.enabled ? 'Yes' : 'No'}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+
+            <details open style={{ marginTop: 24, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+                <summary><strong>Add an instance-wide connection</strong></summary>
+                <AddEnterpriseConnectionForm action={url(`${base}/enterprise-connections`)} />
+            </details>
+        </section>
+    )
+}
+
+function AddEnterpriseConnectionForm({ action }: { action: string }) {
+    const form = useForm<{
+        protocol: 'saml' | 'oidc'
+        name: string
+        domains_csv: string
+        default_role: string
+        enabled: boolean
+        saml_idp_entity_id: string
+        saml_sso_url: string
+        saml_idp_certificate: string
+        saml_signing_algorithm: 'RSA_SHA256' | 'RSA_SHA384' | 'RSA_SHA512'
+        oidc_issuer: string
+        oidc_client_id: string
+        oidc_client_secret: string
+        oidc_scopes_csv: string
+    }>({
+        protocol: 'saml',
+        name: '',
+        domains_csv: '',
+        default_role: 'org:member',
+        enabled: true,
+        saml_idp_entity_id: '',
+        saml_sso_url: '',
+        saml_idp_certificate: '',
+        saml_signing_algorithm: 'RSA_SHA256',
+        oidc_issuer: '',
+        oidc_client_id: '',
+        oidc_client_secret: '',
+        oidc_scopes_csv: 'openid,email,profile',
+    })
+
+    const onSubmit = (e: React.FormEvent) => {
+        e.preventDefault()
+        const payload: Record<string, unknown> = {
+            protocol: form.data.protocol,
+            name: form.data.name,
+            domains: form.data.domains_csv.split(',').map(s => s.trim()).filter(Boolean),
+            default_role: form.data.default_role || null,
+            enabled: form.data.enabled,
+        }
+        if (form.data.protocol === 'saml') {
+            Object.assign(payload, {
+                saml_idp_entity_id: form.data.saml_idp_entity_id,
+                saml_sso_url: form.data.saml_sso_url,
+                saml_idp_certificate: form.data.saml_idp_certificate,
+                saml_signing_algorithm: form.data.saml_signing_algorithm,
+            })
+        } else {
+            Object.assign(payload, {
+                oidc_issuer: form.data.oidc_issuer,
+                oidc_client_id: form.data.oidc_client_id,
+                oidc_client_secret: form.data.oidc_client_secret,
+                oidc_scopes: form.data.oidc_scopes_csv.split(',').map(s => s.trim()).filter(Boolean),
+            })
+        }
+        form.transform(() => payload).post(action, { preserveScroll: true })
+    }
+
+    return (
+        <form onSubmit={onSubmit} style={{ marginTop: 8 }}>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 12, marginBottom: 12 }}>
+                <label>
+                    <strong>Protocol</strong>
+                    <select
+                        value={form.data.protocol}
+                        onChange={e => form.setData('protocol', e.target.value as 'saml' | 'oidc')}
+                        style={{ display: 'block', marginTop: 4, padding: 6, minWidth: 160 }}
+                    >
+                        <option value="saml">SAML 2.0</option>
+                        <option value="oidc">OIDC</option>
+                    </select>
+                </label>
+                <label>
+                    <strong>Name</strong>
+                    <input
+                        type="text"
+                        value={form.data.name}
+                        onChange={e => form.setData('name', e.target.value)}
+                        placeholder="Acme — Okta"
+                        style={{ display: 'block', marginTop: 4, padding: 6, width: '100%' }}
+                    />
+                </label>
+                <label>
+                    <strong>Domains (comma-separated)</strong>
+                    <input
+                        type="text"
+                        value={form.data.domains_csv}
+                        onChange={e => form.setData('domains_csv', e.target.value)}
+                        placeholder="acme.com, corp.acme.com"
+                        style={{ display: 'block', marginTop: 4, padding: 6, width: '100%' }}
+                    />
+                </label>
+                <label>
+                    <strong>Default org role</strong>
+                    <input
+                        type="text"
+                        value={form.data.default_role}
+                        onChange={e => form.setData('default_role', e.target.value)}
+                        placeholder="org:member"
+                        style={{ display: 'block', marginTop: 4, padding: 6, width: '100%' }}
+                    />
+                </label>
+            </div>
+
+            {form.data.protocol === 'saml' ? (
+                <fieldset style={{ border: '1px solid #e5e7eb', borderRadius: 6, padding: 12, marginBottom: 12 }}>
+                    <legend><strong>SAML</strong></legend>
+                    <label style={{ display: 'block', marginBottom: 8 }}>
+                        IdP entity ID
+                        <input
+                            type="text"
+                            value={form.data.saml_idp_entity_id}
+                            onChange={e => form.setData('saml_idp_entity_id', e.target.value)}
+                            style={{ display: 'block', marginTop: 4, padding: 6, width: '100%' }}
+                        />
+                    </label>
+                    <label style={{ display: 'block', marginBottom: 8 }}>
+                        SSO URL
+                        <input
+                            type="url"
+                            value={form.data.saml_sso_url}
+                            onChange={e => form.setData('saml_sso_url', e.target.value)}
+                            style={{ display: 'block', marginTop: 4, padding: 6, width: '100%' }}
+                        />
+                    </label>
+                    <label style={{ display: 'block', marginBottom: 8 }}>
+                        IdP X.509 certificate
+                        <textarea
+                            value={form.data.saml_idp_certificate}
+                            onChange={e => form.setData('saml_idp_certificate', e.target.value)}
+                            rows={6}
+                            placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
+                            style={{ display: 'block', marginTop: 4, padding: 6, width: '100%', fontFamily: 'monospace' }}
+                        />
+                    </label>
+                    <label>
+                        Signing algorithm
+                        <select
+                            value={form.data.saml_signing_algorithm}
+                            onChange={e => form.setData('saml_signing_algorithm', e.target.value as 'RSA_SHA256' | 'RSA_SHA384' | 'RSA_SHA512')}
+                            style={{ display: 'block', marginTop: 4, padding: 6, minWidth: 200 }}
+                        >
+                            <option value="RSA_SHA256">RSA_SHA256</option>
+                            <option value="RSA_SHA384">RSA_SHA384</option>
+                            <option value="RSA_SHA512">RSA_SHA512</option>
+                        </select>
+                    </label>
+                </fieldset>
+            ) : (
+                <fieldset style={{ border: '1px solid #e5e7eb', borderRadius: 6, padding: 12, marginBottom: 12 }}>
+                    <legend><strong>OIDC</strong></legend>
+                    <label style={{ display: 'block', marginBottom: 8 }}>
+                        Issuer URL
+                        <input
+                            type="url"
+                            value={form.data.oidc_issuer}
+                            onChange={e => form.setData('oidc_issuer', e.target.value)}
+                            placeholder="https://idp.acme.com"
+                            style={{ display: 'block', marginTop: 4, padding: 6, width: '100%' }}
+                        />
+                    </label>
+                    <label style={{ display: 'block', marginBottom: 8 }}>
+                        Client ID
+                        <input
+                            type="text"
+                            value={form.data.oidc_client_id}
+                            onChange={e => form.setData('oidc_client_id', e.target.value)}
+                            style={{ display: 'block', marginTop: 4, padding: 6, width: '100%' }}
+                        />
+                    </label>
+                    <label style={{ display: 'block', marginBottom: 8 }}>
+                        Client secret
+                        <input
+                            type="password"
+                            value={form.data.oidc_client_secret}
+                            onChange={e => form.setData('oidc_client_secret', e.target.value)}
+                            style={{ display: 'block', marginTop: 4, padding: 6, width: '100%' }}
+                        />
+                    </label>
+                    <label>
+                        Scopes (comma-separated)
+                        <input
+                            type="text"
+                            value={form.data.oidc_scopes_csv}
+                            onChange={e => form.setData('oidc_scopes_csv', e.target.value)}
+                            style={{ display: 'block', marginTop: 4, padding: 6, width: '100%' }}
+                        />
+                    </label>
+                </fieldset>
+            )}
+
+            <label style={{ display: 'block', marginBottom: 12 }}>
+                <input
+                    type="checkbox"
+                    checked={form.data.enabled}
+                    onChange={e => form.setData('enabled', e.target.checked)}
+                    style={{ marginRight: 6 }}
+                />
+                Enabled
+            </label>
+
+            <button type="submit" disabled={form.processing}>
+                {form.processing ? 'Saving…' : 'Add connection'}
+            </button>
+        </form>
+    )
+}
+
+function DeleteConnectionButton({ id, action, disabled }: { id: string; action: string; disabled: boolean }) {
+    const form = useForm({})
+    const onDelete = (e: React.MouseEvent) => {
+        e.preventDefault()
+        if (disabled) return
+        if (!confirm(`Delete connection ${id}?`)) return
+        form.delete(action, { preserveScroll: true })
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={onDelete}
+            disabled={disabled || form.processing}
+            title={disabled ? 'Has linked accounts — unlink users first.' : undefined}
+            style={{ padding: '4px 10px', background: disabled ? '#e5e7eb' : '#fee2e2', color: disabled ? '#94a3b8' : '#b91c1c', border: 'none', borderRadius: 4, cursor: disabled ? 'not-allowed' : 'pointer' }}
+        >
+            Delete
+        </button>
     )
 }

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -50,6 +50,8 @@ Route::prefix('{project_slug}/{env_slug}')->group(function (): void {
     Route::patch('/configure/oauth-providers/{oauth_provider_id}', [DashboardController::class, 'updateOauthProvider'])->name('dashboard.configure.oauth_providers.update');
     Route::delete('/configure/oauth-providers/{oauth_provider_id}', [DashboardController::class, 'destroyOauthProvider'])->name('dashboard.configure.oauth_providers.destroy');
     Route::post('/configure/oauth-providers/{oauth_provider_id}/test', [DashboardController::class, 'testOauthProvider'])->name('dashboard.configure.oauth_providers.test');
+    Route::post('/configure/enterprise-connections', [DashboardController::class, 'storeEnterpriseConnection'])->name('dashboard.configure.enterprise_connections.store');
+    Route::delete('/configure/enterprise-connections/{enterprise_connection_id}', [DashboardController::class, 'destroyEnterpriseConnection'])->name('dashboard.configure.enterprise_connections.destroy');
     Route::get('/email-templates', [DashboardController::class, 'emailTemplates'])->name('dashboard.email_templates');
 
     Route::get('/api-keys', [DashboardController::class, 'apiKeys'])->name('dashboard.api_keys');


### PR DESCRIPTION
Closes #203.

## Summary

Adds an "Enterprise SSO" section to the dashboard Configure page (`/configure/enterprise-sso`) that drives the instance-wide `EnterpriseConnection` table + add-connection form. Per-org connections are listed read-only — org admins configure those in the embedded `<OrganizationProfile />` via JS-3.

### DashboardController
- `configure()` payload gains `enterprise_connections: EnterpriseConnection[]`.
- `storeEnterpriseConnection()` validates protocol-specific fields, persists either SAML or OIDC payload, redirects with flash.
- `destroyEnterpriseConnection()` refuses with an inline error when there are still linked `EnterpriseAccount` rows.

### Frontend (`Configure.tsx`)
- `EnterpriseSsoSection` splits into "Instance-wide connections" + "Org-scoped connections" tables.
- `AddEnterpriseConnectionForm` is protocol-aware (SAML vs OIDC field sets swap based on the picker).
- `DeleteConnectionButton` disables when `linked_accounts_count > 0`.

Build: Configure chunk 47.5 KB / 9.6 KB gzipped, well under the 220 KB shared budget.

## Test plan

- [x] `npm run build`
- [x] `npm run size` — Account Portal entry **4.18 KB** / Shared vendor **205 KB** gzipped (both well under budget)
- [x] `vendor/bin/pint --test`

## Out of scope (intentional, fold-in later)

- **Metadata XML drop-zone upload** — manual paste only for v0.6; XML parsing pulls in a hefty client-side library. Defer to JS-3's drop-zone in the embedded SDK.
- **Test button calling AU-5's `/test` endpoint** — BAPI round-trip needs CSRF + admin auth wiring; the BAPI endpoint is reachable from sdk-php / Postman in the meantime.