### PR TITLE
Wire audit log + webhook events for enterprise SSO + SCIM (AU-15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Enterprise SSO (SAML + OIDC)** — unified `EnterpriseConnection` model (`entcon_`) carries both protocols. `EnterpriseAccount` (`entacc_`) links a User to a connection. BAPI `/v1/enterprise-connections` (instance-wide CRUD + dry-run probe) + FAPI `/v1/organizations/{org_id}/enterprise-connections` (per-org, gated on `org:sys_sso:manage`).
+- **SAML engine** — `litesaml/lightsaml` integration. `SamlConnectionService` emits SP metadata, builds AuthnRequests, verifies SAMLResponses (signature against `saml_idp_certificate`, audience, `NotOnOrAfter` with 60s clock-skew tolerance).
+- **OIDC engine** — `OidcConnectionService` handles discovery (5-min cache), PKCE-S256 authorize URL minting, token exchange, id_token JWS verification against IdP JWKS with `iss` / `aud` / `nonce` / `exp` / `iat` validation.
+- **Enterprise sign-in flow** — `enterprise_sso` + `saml` first-factor strategies on `StrategyResolver`. Callback endpoints `GET /v1/enterprise-sso-callback` (OIDC) + `POST /v1/saml/{connection_id}/acs` (SAML ACS). Auto-joins the org via `OrganizationMembership` when the connection is org-scoped + has a `default_role`. Honours `OrganizationDomain.enrollment_mode` (`automatic_invitation` joins the matching org; `automatic_suggestion` surfaces it for later; `manual_invitation` is opt-in).
+- **Domain-routed sign-in** — `SignIn.supported_strategies` narrows to `["enterprise_sso"]` when the identifier domain matches an enabled `EnterpriseConnection`; `SignIn.enterprise_connection_id` carries the matched id.
+- **SCIM 2.0 server (RFC 7644)** — `/scim/v2/Users` (GET filter/pagination/projection + POST + GET-by-id + DELETE) and `/scim/v2/Groups` (read-only role-aggregated). Bearer-authenticated via `ScimToken` (one-time plaintext at issue).
+- **Per-org SCIM management** — `/v1/organizations/{org_id}/scim/tokens` (list / issue / revoke), `/scim/attribute-mappings` (read / replace), `/scim/endpoint` (URL surface for IdP-side handoff). Gated by `org:sys_provisioning:manage`.
+- **Transferable sign-up <-> sign-in handoff** — carryover from v0.5. `SignUp` for an existing identifier returns `status: "transferable"` with `target_flow: "sign_in"`; `SignIn` for an unknown identifier returns `status: "transferable"` with `target_flow: "sign_up"` (when `Environment.signup_mode` is `public`/`restricted` and there's no enabled OAuth provider). New snapshot booleans `transferable_to_signin` / `transferable_to_signup`.
+- **Compact JWT claims** — session tokens emit `entcon` (`EnterpriseConnection.id`) + `entacc` (`EnterpriseAccount.id`) when the parent SignIn was verified via `enterprise_sso` / `saml`. Absent for every other strategy.
+- **Dashboard Configure → Enterprise SSO** — instance-wide connection list + add-connection form (SAML + OIDC fields). Per-org connections shown read-only.
+- **Dashboard Customization editor polish** — autocomplete + parse validation + unknown-key warnings + diff view on `appearance.elements`; placeholder validation warnings + cell-level diff summary on `localization.overrides`; "Coming soon" chips for planned-but-unshipped locales. (Monaco editor + signed-URL live-preview iframe deferred to v0.7 per authn-sh/authn#187.)
+- **InstanceSetting toggles** — `authentication_strategies.enterprise_sso.enabled` (strict-semantic — gates new enrollments, never breaks existing accounts) + `multi_factor.enterprise_sso_counts_as_mfa` (when on and the IdP advertises MFA via OIDC `amr` or SAML `<AuthnContextClassRef>`, the session is stamped second-factor-satisfied).
+- **Audit log + webhook events** — `enterpriseConnection.{created,updated,deleted}`, `enterpriseAccount.connected`, `scimToken.{issued,revoked}`, `scimUser.{provisioned,deprovisioned}`. Audit-log entries `auth.enterprise_sso.signin_succeeded` / `signin_failed` / `scim_provisioned` / `scim_deprovisioned`.
+
+### Changed
+
+- **SignUp duplicate-identifier handling** — shifted from `422 form_identifier_exists` to `200 status: "transferable" target_flow: "sign_in"`. Consumers should branch on `signUp.status === "transferable"` rather than catching the 422.
+- `Verification::STRATEGIES` extends with `enterprise_sso` + `saml`. `SignInAttempt::STATUS_TRANSFERABLE` is now a valid status (existing transitions allow it from `needs_identifier` and `needs_first_factor`).
+- `Challenge` resource exposes `enterprise_connection_id` (populated by AU-7 callbacks; `null` everywhere else).
+- `SessionTokenIssuer` mints `entcon` + `entacc` claims when applicable.
+
 ## [0.5.0] — 2026-05-11
 
 Account Portal v1: Passkeys + Theming + Localization + six new OAuth presets.

--- a/app/Http/Controllers/Bapi/EnterpriseConnectionController.php
+++ b/app/Http/Controllers/Bapi/EnterpriseConnectionController.php
@@ -10,8 +10,10 @@ use App\Http\Resources\EnterpriseConnectionResource;
 use App\Models\EnterpriseAccount;
 use App\Models\EnterpriseConnection;
 use App\Models\Environment;
+use App\Webhooks\Emitter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Throwable;
 
@@ -77,6 +79,13 @@ final class EnterpriseConnectionController
 
         $conn = EnterpriseConnection::query()->withoutGlobalScopes()->create($data);
 
+        Log::info('audit:bapi.enterprise_connection.created', [
+            'environment_id' => $env->id,
+            'enterprise_connection_id' => $conn->id,
+            'protocol' => $conn->protocol,
+        ]);
+        app(Emitter::class)->emit('enterpriseConnection.created', EnterpriseConnectionResource::from($conn->fresh()), $env);
+
         return response()->json(EnterpriseConnectionResource::from($conn->fresh()), 201)
             ->header('Cache-Control', 'no-store');
     }
@@ -117,6 +126,12 @@ final class EnterpriseConnectionController
         ])));
         $conn->save();
 
+        Log::info('audit:bapi.enterprise_connection.updated', [
+            'environment_id' => app(Environment::class)->id,
+            'enterprise_connection_id' => $conn->id,
+        ]);
+        app(Emitter::class)->emit('enterpriseConnection.updated', EnterpriseConnectionResource::from($conn->fresh()));
+
         return response()->json(EnterpriseConnectionResource::from($conn->fresh()))->header('Cache-Control', 'no-store');
     }
 
@@ -134,7 +149,14 @@ final class EnterpriseConnectionController
             return $this->error(409, 'enterprise_connection_in_use', 'Cannot delete — there are still EnterpriseAccount rows linked to this connection.');
         }
 
+        $snapshot = EnterpriseConnectionResource::from($conn);
         $conn->delete();
+
+        Log::info('audit:bapi.enterprise_connection.deleted', [
+            'environment_id' => app(Environment::class)->id,
+            'enterprise_connection_id' => $conn->id,
+        ]);
+        app(Emitter::class)->emit('enterpriseConnection.deleted', $snapshot);
 
         return response()->json(null, 204);
     }

--- a/app/Http/Controllers/Fapi/EnterpriseSsoCallbackController.php
+++ b/app/Http/Controllers/Fapi/EnterpriseSsoCallbackController.php
@@ -21,6 +21,7 @@ use App\Models\User;
 use App\Models\Verification;
 use App\Services\Sessions\SessionLifecycle;
 use App\Settings\EnterpriseSsoSettings;
+use App\Webhooks\Emitter;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -234,6 +235,23 @@ final class EnterpriseSsoCallbackController
         $target = $redirectUrlComplete ?? $redirectUrl ?? '/';
         unset($session); // touched so PHPStan is happy
 
+        Log::info('audit:auth.enterprise_sso.signin_succeeded', [
+            'environment_id' => $env->id,
+            'enterprise_connection_id' => $conn->id,
+            'enterprise_account_id' => $provisioned['account']->id,
+            'user_id' => $provisioned['user']->id,
+            'was_created' => $provisioned['was_created'],
+        ]);
+        if ($provisioned['was_created']) {
+            app(Emitter::class)->emit('enterpriseAccount.connected', [
+                'object' => 'enterprise_account',
+                'id' => $provisioned['account']->id,
+                'enterprise_connection_id' => $conn->id,
+                'user_id' => $provisioned['user']->id,
+                'provider_user_id' => $provisioned['account']->provider_user_id,
+            ], $env);
+        }
+
         return redirect()->away($target);
     }
 
@@ -393,6 +411,12 @@ final class EnterpriseSsoCallbackController
             'error_code' => $code,
             'error_message' => $message,
         ])->save();
+
+        Log::info('audit:auth.enterprise_sso.signin_failed', [
+            'environment_id' => $verification->environment_id,
+            'verification_id' => $verification->id,
+            'error_code' => $code,
+        ]);
 
         return $this->renderError($redirectUrl, $code, $message);
     }

--- a/app/Http/Controllers/Fapi/OrganizationEnterpriseConnectionController.php
+++ b/app/Http/Controllers/Fapi/OrganizationEnterpriseConnectionController.php
@@ -11,8 +11,10 @@ use App\Models\EnterpriseAccount;
 use App\Models\EnterpriseConnection;
 use App\Models\Environment;
 use App\Models\Organization;
+use App\Webhooks\Emitter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Throwable;
 
@@ -72,6 +74,13 @@ final class OrganizationEnterpriseConnectionController
 
         $conn = EnterpriseConnection::query()->withoutGlobalScopes()->create($data);
 
+        Log::info('audit:fapi.enterprise_connection.created', [
+            'environment_id' => $env->id,
+            'organization_id' => $org->id,
+            'enterprise_connection_id' => $conn->id,
+        ]);
+        app(Emitter::class)->emit('enterpriseConnection.created', EnterpriseConnectionResource::from($conn->fresh()), $env);
+
         return response()->json(EnterpriseConnectionResource::from($conn->fresh()), 201)
             ->header('Cache-Control', 'no-store');
     }
@@ -109,6 +118,12 @@ final class OrganizationEnterpriseConnectionController
         ])));
         $conn->save();
 
+        Log::info('audit:fapi.enterprise_connection.updated', [
+            'environment_id' => app(Environment::class)->id,
+            'enterprise_connection_id' => $conn->id,
+        ]);
+        app(Emitter::class)->emit('enterpriseConnection.updated', EnterpriseConnectionResource::from($conn->fresh()));
+
         return response()->json(EnterpriseConnectionResource::from($conn->fresh()))->header('Cache-Control', 'no-store');
     }
 
@@ -126,7 +141,14 @@ final class OrganizationEnterpriseConnectionController
             return $this->error(409, 'enterprise_connection_in_use', 'Cannot delete — there are still EnterpriseAccount rows linked to this connection.');
         }
 
+        $snapshot = EnterpriseConnectionResource::from($conn);
         $conn->delete();
+
+        Log::info('audit:fapi.enterprise_connection.deleted', [
+            'environment_id' => app(Environment::class)->id,
+            'enterprise_connection_id' => $conn->id,
+        ]);
+        app(Emitter::class)->emit('enterpriseConnection.deleted', $snapshot);
 
         return response()->json(null, 204);
     }

--- a/app/Http/Controllers/Fapi/OrganizationScimController.php
+++ b/app/Http/Controllers/Fapi/OrganizationScimController.php
@@ -10,8 +10,10 @@ use App\Models\ScimAttributeMapping;
 use App\Models\ScimToken;
 use App\Models\User;
 use App\Support\Url;
+use App\Webhooks\Emitter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 
 /**
@@ -77,6 +79,14 @@ final class OrganizationScimController
             'expires_at' => $data['expires_at'] ?? null,
         ]);
 
+        Log::info('audit:fapi.scim_token.issued', [
+            'environment_id' => $env->id,
+            'organization_id' => $org->id,
+            'scim_token_id' => $row->id,
+            'created_by_user_id' => $user->id,
+        ]);
+        app(Emitter::class)->emit('scimToken.issued', $this->tokenShape($row->fresh()), $env);
+
         // The plaintext rides on the spec's `token` property of the
         // ScimToken shape (writeOnly, populated only on this endpoint).
         return response()->json(array_merge(
@@ -99,6 +109,13 @@ final class OrganizationScimController
             return $this->error(404, 'scim_token_not_found', "ScimToken {$id} not found.");
         }
         $row->revoke();
+
+        Log::info('audit:fapi.scim_token.revoked', [
+            'environment_id' => $env->id,
+            'organization_id' => $org->id,
+            'scim_token_id' => $row->id,
+        ]);
+        app(Emitter::class)->emit('scimToken.revoked', $this->tokenShape($row->fresh()), $env);
 
         return response()->json($this->tokenShape($row->fresh()))->header('Cache-Control', 'no-store');
     }

--- a/app/Http/Controllers/Scim/UsersController.php
+++ b/app/Http/Controllers/Scim/UsersController.php
@@ -14,10 +14,12 @@ use App\Models\User;
 use App\Scim\ScimFilter;
 use App\Scim\ScimFilterParser;
 use App\Scim\ScimUserMapper;
+use App\Webhooks\Emitter;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 /**
  * SCIM 2.0 Users surface (RFC 7644). Bearer-authenticated via
@@ -88,7 +90,7 @@ final class UsersController
             return $this->scimError(409, 'uniqueness', "A User with email {$primaryEmail} already exists.");
         }
 
-        return DB::transaction(function () use ($token, $mapped, $primaryEmail, $organization): JsonResponse {
+        $result = DB::transaction(function () use ($token, $mapped, $primaryEmail, $organization): array {
             /** @var array<string, mixed> $attrs */
             $attrs = $mapped['user'];
             $attrs['environment_id'] = $token->environment_id;
@@ -132,8 +134,23 @@ final class UsersController
                 }
             }
 
-            return $this->scimResponse($this->mapper->toResource($user->fresh()), 201);
+            return ['user' => $user->fresh(), 'response' => $this->scimResponse($this->mapper->toResource($user->fresh()), 201)];
         });
+
+        Log::info('audit:auth.enterprise_sso.scim_provisioned', [
+            'environment_id' => $token->environment_id,
+            'organization_id' => $organization?->id,
+            'scim_token_id' => $token->id,
+            'user_id' => $result['user']->id,
+        ]);
+        app(Emitter::class)->emit('scimUser.provisioned', [
+            'object' => 'user_minimal',
+            'user_id' => $result['user']->id,
+            'organization_id' => $organization?->id,
+            'enterprise_connection_id' => $token->enterprise_connection_id,
+        ]);
+
+        return $result['response'];
     }
 
     public function show(Request $request): JsonResponse
@@ -158,6 +175,19 @@ final class UsersController
         }
 
         $user->delete();
+
+        Log::info('audit:auth.enterprise_sso.scim_deprovisioned', [
+            'environment_id' => $token->environment_id,
+            'organization_id' => $token->organization_id,
+            'scim_token_id' => $token->id,
+            'user_id' => $user->id,
+        ]);
+        app(Emitter::class)->emit('scimUser.deprovisioned', [
+            'object' => 'user_minimal',
+            'user_id' => $user->id,
+            'organization_id' => $token->organization_id,
+            'enterprise_connection_id' => $token->enterprise_connection_id,
+        ]);
 
         return response()->json(null, 204, ['Content-Type' => 'application/scim+json']);
     }


### PR DESCRIPTION
Closes #206.

## Summary

Connects the BAPI / FAPI / SCIM write paths to the existing audit log (`Log::info('audit:...')`) + webhook emitter (`App\Webhooks\Emitter`) so operators + downstream SDKs see the v0.6 events PLAN §14.3 lists.

### Webhook events emitted
| Event | Fires from |
| --- | --- |
| `enterpriseConnection.{created,updated,deleted}` | BAPI `EnterpriseConnectionController` + FAPI `OrganizationEnterpriseConnectionController` |
| `enterpriseAccount.connected` | `EnterpriseSsoCallbackController::finalize()` (only when `was_created: true`) |
| `scimToken.{issued,revoked}` | `OrganizationScimController` |
| `scimUser.{provisioned,deprovisioned}` | `Scim\UsersController::store` / `::destroy` |

### Audit-log entries
- `audit:bapi.enterprise_connection.{created,updated,deleted}` + FAPI mirrors.
- `audit:auth.enterprise_sso.signin_succeeded` / `signin_failed`.
- `audit:auth.enterprise_sso.scim_provisioned` / `scim_deprovisioned`.
- `audit:fapi.scim_token.{issued,revoked}`.

### CHANGELOG
Adds an `[Unreleased]` section documenting the full v0.6 surface — including the breaking SignUp duplicate-identifier contract shift (`422 form_identifier_exists` → `200 status: "transferable" target_flow: "sign_in"`) flagged by team-lead.

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `php artisan test` on every enterprise + SCIM test suite — 53 passed (no regressions)