### PR TITLE
Add BAPI /v1/enterprise-accounts (read + unlink)

### DIFF
--- a/app/Http/Controllers/Bapi/EnterpriseAccountController.php
+++ b/app/Http/Controllers/Bapi/EnterpriseAccountController.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Http\Resources\EnterpriseAccountResource;
+use App\Models\EnterpriseAccount;
+use App\Models\Environment;
+use App\Webhooks\Emitter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * BAPI admin enterprise-accounts. Mirrors the v0.4 ExternalAccountController
+ * shape for SDK consistency. Read + unlink only — provisioning happens
+ * automatically through `EnterpriseSsoCallbackController` (AU-7) on the
+ * SSO callback, not via BAPI.
+ *
+ *   GET    /v1/enterprise-accounts             — list (filter user_id, enterprise_connection_id)
+ *   GET    /v1/enterprise-accounts/{id}
+ *   DELETE /v1/enterprise-accounts/{id}        — soft-delete + emit unlink event
+ */
+final class EnterpriseAccountController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $query = EnterpriseAccount::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->orderBy('linked_at', 'desc');
+
+        if (is_string($request->input('user_id'))) {
+            $query->where('user_id', (string) $request->input('user_id'));
+        }
+        if (is_string($request->input('enterprise_connection_id'))) {
+            $query->where('enterprise_connection_id', (string) $request->input('enterprise_connection_id'));
+        }
+
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (EnterpriseAccount $r) => EnterpriseAccountResource::from($r))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function show(Request $request): JsonResponse
+    {
+        $row = $this->find((string) $request->route('enterprise_account_id'));
+        if ($row === null) {
+            return $this->error(404, 'enterprise_account_not_found', 'No enterprise account matches that id in this environment.');
+        }
+
+        return response()->json(EnterpriseAccountResource::from($row))->header('Cache-Control', 'no-store');
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $row = $this->find((string) $request->route('enterprise_account_id'));
+        if ($row === null) {
+            return $this->error(404, 'enterprise_account_not_found', 'No enterprise account matches that id in this environment.');
+        }
+
+        $snapshot = EnterpriseAccountResource::from($row);
+        $row->delete();
+
+        Log::info('audit:bapi.enterprise_account.unlinked', [
+            'environment_id' => $env->id,
+            'enterprise_account_id' => $row->id,
+            'enterprise_connection_id' => $row->enterprise_connection_id,
+        ]);
+        app(Emitter::class)->emit('enterpriseAccount.unlinked', $snapshot, $env);
+
+        return response()->json(null, 204);
+    }
+
+    private function find(string $enterpriseAccountId): ?EnterpriseAccount
+    {
+        $env = app(Environment::class);
+
+        return EnterpriseAccount::query()->withoutGlobalScopes()
+            ->where('id', $enterpriseAccountId)
+            ->where('environment_id', $env->id)
+            ->first();
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [['code' => $code, 'long_message' => $message, 'message' => $message]],
+        ], $status);
+    }
+}

--- a/app/Http/Resources/EnterpriseAccountResource.php
+++ b/app/Http/Resources/EnterpriseAccountResource.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\EnterpriseAccount;
+
+/**
+ * BAPI shape for `EnterpriseAccount`. Mirrors OA-2. The encrypted
+ * `id_token` is never returned; `public_metadata` carries the raw IdP
+ * attributes the connection's `attribute_mapping` didn't map onto a
+ * User field.
+ */
+final class EnterpriseAccountResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function from(EnterpriseAccount $row): array
+    {
+        return [
+            'object' => 'enterprise_account',
+            'id' => $row->id,
+            'enterprise_connection_id' => $row->enterprise_connection_id,
+            'provider_user_id' => $row->provider_user_id,
+            'email_address' => $row->email_address,
+            'verified' => (bool) $row->verified,
+            'public_metadata' => is_array($row->public_metadata) ? $row->public_metadata : [],
+            'linked_at' => $row->linked_at->getTimestampMs(),
+            'last_signed_in_at' => $row->last_signed_in_at?->getTimestampMs(),
+            'created_at' => $row->created_at?->getTimestampMs(),
+            'updated_at' => $row->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\Bapi\AllowlistIdentifiersController;
 use App\Http\Controllers\Bapi\BlocklistIdentifiersController;
+use App\Http\Controllers\Bapi\EnterpriseAccountController;
 use App\Http\Controllers\Bapi\EnterpriseConnectionController;
 use App\Http\Controllers\Bapi\ExternalAccountController;
 use App\Http\Controllers\Bapi\InstanceAppearanceController;
@@ -125,6 +126,11 @@ Route::get('/enterprise-connections/{enterprise_connection_id}', [EnterpriseConn
 Route::patch('/enterprise-connections/{enterprise_connection_id}', [EnterpriseConnectionController::class, 'update'])->middleware(RateLimit::class.':enterprise_connections.update,60,60')->name('bapi.enterprise_connections.update');
 Route::delete('/enterprise-connections/{enterprise_connection_id}', [EnterpriseConnectionController::class, 'destroy'])->middleware(RateLimit::class.':enterprise_connections.destroy,30,60')->name('bapi.enterprise_connections.destroy');
 Route::post('/enterprise-connections/{enterprise_connection_id}/test', [EnterpriseConnectionController::class, 'test'])->middleware(RateLimit::class.':enterprise_connections.test,30,60')->name('bapi.enterprise_connections.test');
+
+// Enterprise accounts (admin read + unlink). Provisioning happens via the SSO callback, not BAPI.
+Route::get('/enterprise-accounts', [EnterpriseAccountController::class, 'index'])->middleware(RateLimit::class.':enterprise_accounts.list,300,60')->name('bapi.enterprise_accounts.index');
+Route::get('/enterprise-accounts/{enterprise_account_id}', [EnterpriseAccountController::class, 'show'])->middleware(RateLimit::class.':enterprise_accounts.read,300,60')->name('bapi.enterprise_accounts.show');
+Route::delete('/enterprise-accounts/{enterprise_account_id}', [EnterpriseAccountController::class, 'destroy'])->middleware(RateLimit::class.':enterprise_accounts.destroy,30,60')->name('bapi.enterprise_accounts.destroy');
 
 // Passkeys (admin) — sdk-php SP-1 wraps this.
 Route::get('/passkeys', [PasskeyController::class, 'index'])->middleware(RateLimit::class.':passkeys.list,300,60')->name('bapi.passkeys.index');

--- a/tests/Feature/Http/Bapi/EnterpriseAccountsTest.php
+++ b/tests/Feature/Http/Bapi/EnterpriseAccountsTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\EnterpriseAccount;
+use App\Models\EnterpriseConnection;
+use App\Models\User;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+
+it('lists enterprise accounts in the env', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+    $alice = User::create(['environment_id' => $f['env']->id]);
+    $bob = User::create(['environment_id' => $f['env']->id]);
+    EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $alice->id,
+        'enterprise_connection_id' => $conn->id,
+    ]);
+    EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bob->id,
+        'enterprise_connection_id' => $conn->id,
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/enterprise-accounts'));
+
+    $r->assertOk()
+        ->assertJsonPath('total_count', 2)
+        ->assertJsonPath('data.0.object', 'enterprise_account');
+});
+
+it('filters list by user_id', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+    $alice = User::create(['environment_id' => $f['env']->id]);
+    $bob = User::create(['environment_id' => $f['env']->id]);
+    EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $alice->id,
+        'enterprise_connection_id' => $conn->id,
+    ]);
+    EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $bob->id,
+        'enterprise_connection_id' => $conn->id,
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/enterprise-accounts?user_id='.$alice->id));
+
+    $r->assertOk()->assertJsonPath('total_count', 1);
+});
+
+it('filters list by enterprise_connection_id', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $connA = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+    $connB = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+    $user = User::create(['environment_id' => $f['env']->id]);
+    EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'enterprise_connection_id' => $connA->id,
+    ]);
+    EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'enterprise_connection_id' => $connB->id,
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/enterprise-accounts?enterprise_connection_id='.$connA->id));
+
+    $r->assertOk()->assertJsonPath('total_count', 1)->assertJsonPath('data.0.enterprise_connection_id', $connA->id);
+});
+
+it('returns 404 for unknown enterprise_account_id', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/enterprise-accounts/entacc_nope'));
+
+    $r->assertStatus(404)->assertJsonPath('errors.0.code', 'enterprise_account_not_found');
+});
+
+it('shows an enterprise account by id', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+    $user = User::create(['environment_id' => $f['env']->id]);
+    $account = EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'enterprise_connection_id' => $conn->id,
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/enterprise-accounts/'.$account->id));
+
+    $r->assertOk()
+        ->assertJsonPath('id', $account->id)
+        ->assertJsonPath('object', 'enterprise_account')
+        ->assertJsonPath('enterprise_connection_id', $conn->id);
+});
+
+it('soft-deletes on destroy', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+    $user = User::create(['environment_id' => $f['env']->id]);
+    $account = EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'enterprise_connection_id' => $conn->id,
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->deleteJson(BapiTestSupport::url('/enterprise-accounts/'.$account->id));
+
+    $r->assertNoContent();
+    expect(EnterpriseAccount::withTrashed()->withoutGlobalScopes()->where('id', $account->id)->first()?->removed_at)
+        ->not->toBeNull();
+});
+
+it('never returns the encrypted id_token', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $conn = EnterpriseConnection::factory()->create(['environment_id' => $f['env']->id]);
+    $user = User::create(['environment_id' => $f['env']->id]);
+    $account = EnterpriseAccount::factory()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $user->id,
+        'enterprise_connection_id' => $conn->id,
+        'id_token' => 'secret-id-token-value',
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/enterprise-accounts/'.$account->id));
+
+    $r->assertOk();
+    expect($r->json())->not->toHaveKey('id_token');
+});


### PR DESCRIPTION
Follow-up flagged by sdk-php SP-1: the SP-1 spec expects an `EnterpriseAccountsManager` (`list` with `user_id` / `enterprise_connection_id` filters + `get` + `delete`), but the v0.6 surface only shipped `/v1/enterprise-connections`. This adds the matching admin route.

## Summary

Mirrors the v0.4 `ExternalAccountController` shape for SDK consistency:

- `GET /v1/enterprise-accounts` — list, filter by `user_id` or `enterprise_connection_id`, paginated.
- `GET /v1/enterprise-accounts/{id}`.
- `DELETE /v1/enterprise-accounts/{id}` — soft-delete + emit `enterpriseAccount.unlinked` webhook + audit log.

Provisioning still happens automatically through `EnterpriseSsoCallbackController` (AU-7) on the SSO callback — there is no admin POST. The encrypted `id_token` is never returned (the resource shape strips it).

Note: there's no matching openapi spec yet (`paths/bapi/enterprise-accounts.yaml` is missing). Flagging for `openapi-impl` — a small follow-up there to document the surface would be welcome but the routes are runnable today.

## Test plan

- [x] `vendor/bin/pint --test`
- [x] `php artisan test tests/Feature/Http/Bapi/EnterpriseAccountsTest.php` — 7 passed (list, user_id filter, connection_id filter, 404 on unknown id, show, soft-delete, id_token never leaked)