### PR TITLE
Add JwtTemplate model + migration (#237)

### DIFF
--- a/app/Models/JwtTemplate.php
+++ b/app/Models/JwtTemplate.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Database\Factories\JwtTemplateFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * v0.7 named JWT template. Per-environment, looked up by `name` from
+ * Session::getToken({template}). `claims` is a JSON object with Liquid-style
+ * placeholders rendered against the User / Session / Organization snapshot
+ * by JwtTemplateRenderer (AU-3). `custom_signing_key` is an optional
+ * escape-hatch PEM that overrides the env's default SigningKey when set.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $name
+ * @property array<string, mixed> $claims
+ * @property int $lifetime
+ * @property int $allowed_clock_skew
+ * @property string $signing_algorithm
+ * @property ?string $custom_signing_key
+ * @property ?\DateTimeInterface $removed_at
+ */
+class JwtTemplate extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+    use SoftDeletes;
+
+    public const ALG_RS256 = 'RS256';
+
+    public const ALG_ES256 = 'ES256';
+
+    public const ALG_HS256 = 'HS256';
+
+    public const ALGORITHMS = [
+        self::ALG_RS256,
+        self::ALG_ES256,
+        self::ALG_HS256,
+    ];
+
+    public const DELETED_AT = 'removed_at';
+
+    protected string $idPrefix = 'jtmpl_';
+
+    protected $fillable = [
+        'environment_id',
+        'name',
+        'claims',
+        'lifetime',
+        'allowed_clock_skew',
+        'signing_algorithm',
+        'custom_signing_key',
+    ];
+
+    protected $hidden = [
+        'custom_signing_key',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'claims' => 'array',
+            'lifetime' => 'integer',
+            'allowed_clock_skew' => 'integer',
+            'custom_signing_key' => 'encrypted',
+            'removed_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    protected static function newFactory(): JwtTemplateFactory
+    {
+        return JwtTemplateFactory::new();
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+}

--- a/database/factories/JwtTemplateFactory.php
+++ b/database/factories/JwtTemplateFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\JwtTemplate;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<JwtTemplate>
+ */
+class JwtTemplateFactory extends Factory
+{
+    /**
+     * @var class-string<JwtTemplate>
+     */
+    protected $model = JwtTemplate::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            // environment_id supplied by caller.
+            'name' => 'tmpl-'.$this->faker->unique()->lexify('????????'),
+            'claims' => [
+                'sub' => '{{user.id}}',
+                'email' => '{{user.primary_email}}',
+            ],
+            'lifetime' => 60,
+            'allowed_clock_skew' => 5,
+            'signing_algorithm' => JwtTemplate::ALG_RS256,
+            'custom_signing_key' => null,
+        ];
+    }
+
+    public function withCustomSigningKey(string $pem): self
+    {
+        return $this->state(fn (array $attributes): array => ['custom_signing_key' => $pem]);
+    }
+
+    public function hs256(): self
+    {
+        return $this->state(fn (array $attributes): array => ['signing_algorithm' => JwtTemplate::ALG_HS256]);
+    }
+}

--- a/database/migrations/2026_05_13_000000_create_jwt_templates_table.php
+++ b/database/migrations/2026_05_13_000000_create_jwt_templates_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * v0.7 JwtTemplate — per-environment named JWT templates with custom
+ * claim mappings, lifetime, allowed_clock_skew, signing_algorithm and an
+ * optional custom_signing_key escape hatch. Looked up by `name` from
+ * Session::getToken({template}).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('jwt_templates', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('name');
+            $table->jsonb('claims')->default(json_encode((object) []));
+            $table->unsignedInteger('lifetime')->default(60);
+            $table->unsignedInteger('allowed_clock_skew')->default(5);
+            $table->string('signing_algorithm', 16)->default('RS256');
+            $table->text('custom_signing_key')->nullable();
+
+            $table->timestamps();
+            $table->softDeletes('removed_at');
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->unique(['environment_id', 'name']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('jwt_templates');
+    }
+};

--- a/tests/Feature/Models/JwtTemplateTest.php
+++ b/tests/Feature/Models/JwtTemplateTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\JwtTemplate;
+use App\Models\Project;
+use Illuminate\Database\QueryException;
+
+function makeEnvForJwtTemplate(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('mints a jtmpl_ prefixed id and casts claims to an array', function (): void {
+    $env = makeEnvForJwtTemplate();
+
+    $tmpl = JwtTemplate::factory()->create([
+        'environment_id' => $env->id,
+        'name' => 'api-access',
+        'claims' => ['sub' => '{{user.id}}', 'org' => '{{org.slug}}'],
+    ]);
+
+    expect($tmpl->id)->toStartWith('jtmpl_');
+    expect($tmpl->claims)->toBe(['sub' => '{{user.id}}', 'org' => '{{org.slug}}']);
+    expect($tmpl->lifetime)->toBe(60);
+    expect($tmpl->allowed_clock_skew)->toBe(5);
+    expect($tmpl->signing_algorithm)->toBe(JwtTemplate::ALG_RS256);
+});
+
+it('encrypts custom_signing_key and hides it from arrays', function (): void {
+    $env = makeEnvForJwtTemplate();
+
+    $pem = "-----BEGIN PRIVATE KEY-----\nMIIBfake\n-----END PRIVATE KEY-----";
+    $tmpl = JwtTemplate::factory()->withCustomSigningKey($pem)->create([
+        'environment_id' => $env->id,
+    ]);
+
+    expect($tmpl->custom_signing_key)->toBe($pem);
+
+    $raw = (string) DB::table('jwt_templates')->where('id', $tmpl->id)->value('custom_signing_key');
+    expect($raw)->not->toBe($pem);
+    expect(strlen($raw))->toBeGreaterThan(20);
+
+    expect(array_key_exists('custom_signing_key', $tmpl->toArray()))->toBeFalse();
+});
+
+it('enforces unique (environment_id, name)', function (): void {
+    $env = makeEnvForJwtTemplate();
+
+    JwtTemplate::factory()->create(['environment_id' => $env->id, 'name' => 'api']);
+
+    expect(fn () => JwtTemplate::factory()->create(['environment_id' => $env->id, 'name' => 'api']))
+        ->toThrow(QueryException::class);
+});
+
+it('allows the same name across distinct environments', function (): void {
+    $env1 = makeEnvForJwtTemplate('one');
+    $env2 = makeEnvForJwtTemplate('two');
+
+    $t1 = JwtTemplate::factory()->create(['environment_id' => $env1->id, 'name' => 'api']);
+    $t2 = JwtTemplate::factory()->create(['environment_id' => $env2->id, 'name' => 'api']);
+
+    expect($t1->id)->not->toBe($t2->id);
+});
+
+it('soft-deletes via removed_at', function (): void {
+    $env = makeEnvForJwtTemplate();
+    app()->instance(Environment::class, $env);
+
+    $tmpl = JwtTemplate::factory()->create(['environment_id' => $env->id]);
+    $tmpl->delete();
+
+    expect(JwtTemplate::query()->find($tmpl->id))->toBeNull();
+    expect(JwtTemplate::withTrashed()->find($tmpl->id)?->removed_at)->not->toBeNull();
+    app()->forgetInstance(Environment::class);
+});
+
+it('honours EnvironmentScope', function (): void {
+    $env1 = makeEnvForJwtTemplate('one');
+    $env2 = makeEnvForJwtTemplate('two');
+
+    JwtTemplate::factory()->create(['environment_id' => $env1->id, 'name' => 'env1-tmpl']);
+    JwtTemplate::factory()->create(['environment_id' => $env2->id, 'name' => 'env2-tmpl']);
+
+    app()->instance(Environment::class, $env1);
+    expect(JwtTemplate::query()->pluck('name')->all())->toBe(['env1-tmpl']);
+    app()->forgetInstance(Environment::class);
+});
+
+it('belongs to an Environment', function (): void {
+    $env = makeEnvForJwtTemplate();
+    $tmpl = JwtTemplate::factory()->create(['environment_id' => $env->id]);
+
+    expect($tmpl->environment->id)->toBe($env->id);
+});


### PR DESCRIPTION
Closes #237 (AU-1).

## Summary

- New `JwtTemplate` model (`jtmpl_` prefix) — per-environment named JWT templates with custom claims, lifetime, allowed clock skew, signing algorithm enum (`RS256` / `ES256` / `HS256`), optional encrypted `custom_signing_key` escape hatch.
- Soft-deleted via `removed_at`. `EnvironmentScope` applied globally. Unique on `(environment_id, name)` so templates are looked up by name from `Session::getToken({template})`.
- Pest tests cover: id prefix + claims JSON cast, encrypted `custom_signing_key` hidden from arrays, unique-per-env, soft delete, EnvironmentScope, factory.

## Out of scope (follow-ups)

- AU-3 (#239) — template renderer + `Session::getToken({template})` wiring.
- AU-4 (#240) — BAPI `/v1/jwt-templates` CRUD.