### PR TITLE
Add OauthApplication + AuthorizationGrant models (#238)

### DIFF
--- a/app/Models/AuthorizationGrant.php
+++ b/app/Models/AuthorizationGrant.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use Database\Factories\AuthorizationGrantFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * v0.7 OAuth provider mode — per-user consent record for an
+ * OauthApplication. Created when the user accepts the consent screen
+ * (AU-9); revoked from the Account Portal Authorized Apps panel (AU-10)
+ * or implicitly when the parent OauthApplication is soft-deleted.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $oauth_application_id
+ * @property string $user_id
+ * @property array<int, string> $scopes
+ * @property string $scopes_hash
+ * @property \DateTimeInterface $granted_at
+ * @property ?\DateTimeInterface $revoked_at
+ */
+class AuthorizationGrant extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+
+    protected string $idPrefix = 'authgrant_';
+
+    protected $fillable = [
+        'environment_id',
+        'oauth_application_id',
+        'user_id',
+        'scopes',
+        'scopes_hash',
+        'granted_at',
+        'revoked_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'scopes' => 'array',
+            'granted_at' => 'immutable_datetime',
+            'revoked_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+
+        static::creating(function (self $grant): void {
+            if (empty($grant->scopes_hash)) {
+                $grant->scopes_hash = self::hashScopes($grant->scopes ?? []);
+            }
+            if (empty($grant->granted_at)) {
+                $grant->granted_at = now();
+            }
+        });
+    }
+
+    protected static function newFactory(): AuthorizationGrantFactory
+    {
+        return AuthorizationGrantFactory::new();
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function oauthApplication(): BelongsTo
+    {
+        return $this->belongsTo(OauthApplication::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function isActive(): bool
+    {
+        return $this->revoked_at === null;
+    }
+
+    public function revoke(): void
+    {
+        if ($this->revoked_at === null) {
+            $this->revoked_at = now();
+            $this->save();
+        }
+    }
+
+    /**
+     * Stable hash of the granted scope set so a partial-unique index can
+     * keep one active row per (user, app, scope-set). Sorted to make the
+     * hash order-independent.
+     *
+     * @param  array<int, string>  $scopes
+     */
+    public static function hashScopes(array $scopes): string
+    {
+        $sorted = array_values(array_unique($scopes));
+        sort($sorted);
+
+        return hash('sha256', implode(' ', $sorted));
+    }
+
+    /**
+     * @param  Builder<AuthorizationGrant>  $query
+     * @return Builder<AuthorizationGrant>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->whereNull('revoked_at');
+    }
+
+    /**
+     * @param  Builder<AuthorizationGrant>  $query
+     * @return Builder<AuthorizationGrant>
+     */
+    public function scopeRevoked(Builder $query): Builder
+    {
+        return $query->whereNotNull('revoked_at');
+    }
+}

--- a/app/Models/OauthApplication.php
+++ b/app/Models/OauthApplication.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Concerns\HasPrefixedUlid;
+use App\Database\Scopes\EnvironmentScope;
+use App\Support\Base64Url;
+use Database\Factories\OauthApplicationFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * v0.7 OAuth provider mode — registered third-party application that
+ * authenticates against authn.sh as the IdP. `client_id` is public
+ * (`oac_pub_...`); the plaintext client secret is returned exactly once
+ * on create / rotate-secret and only `hashed_client_secret` (sha256 of
+ * the plaintext) is persisted. Public clients (`is_public=true`) skip
+ * the secret entirely and rely on PKCE.
+ *
+ * @property string $id
+ * @property string $environment_id
+ * @property string $name
+ * @property string $client_id
+ * @property ?string $hashed_client_secret
+ * @property array<int, string> $callback_urls
+ * @property array<int, string> $scopes
+ * @property bool $is_public
+ * @property ?\DateTimeInterface $removed_at
+ */
+class OauthApplication extends Model
+{
+    use HasFactory;
+    use HasPrefixedUlid;
+    use SoftDeletes;
+
+    public const CLIENT_ID_PREFIX = 'oac_pub_';
+
+    public const SECRET_PREFIX = 'oac_sec_';
+
+    public const SECRET_BYTES = 32;
+
+    public const DELETED_AT = 'removed_at';
+
+    protected string $idPrefix = 'oac_';
+
+    protected $fillable = [
+        'environment_id',
+        'name',
+        'client_id',
+        'hashed_client_secret',
+        'callback_urls',
+        'scopes',
+        'is_public',
+    ];
+
+    protected $hidden = [
+        'hashed_client_secret',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'callback_urls' => 'array',
+            'scopes' => 'array',
+            'is_public' => 'boolean',
+            'removed_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnvironmentScope);
+    }
+
+    protected static function newFactory(): OauthApplicationFactory
+    {
+        return OauthApplicationFactory::new();
+    }
+
+    public function environment(): BelongsTo
+    {
+        return $this->belongsTo(Environment::class);
+    }
+
+    public function authorizationGrants(): HasMany
+    {
+        return $this->hasMany(AuthorizationGrant::class);
+    }
+
+    /**
+     * Mint a fresh public `client_id`. Always called on create so callers
+     * never have to remember the prefix discipline.
+     */
+    public static function mintClientId(): string
+    {
+        return self::CLIENT_ID_PREFIX.Base64Url::encode(random_bytes(16));
+    }
+
+    /**
+     * Mint a fresh plaintext client secret and return both it and its
+     * sha256 hash. Callers persist the hash; the plaintext is shown to
+     * the operator exactly once at create / rotate time.
+     *
+     * @return array{plaintext: string, hash: string}
+     */
+    public static function mintClientSecret(): array
+    {
+        $plaintext = self::SECRET_PREFIX.Base64Url::encode(random_bytes(self::SECRET_BYTES));
+
+        return [
+            'plaintext' => $plaintext,
+            'hash' => hash('sha256', $plaintext),
+        ];
+    }
+
+    /**
+     * Constant-time check of a plaintext client secret against the stored
+     * hash. Returns false for public clients (no secret on file).
+     */
+    public function verifyClientSecret(string $plaintext): bool
+    {
+        if ($this->is_public || $this->hashed_client_secret === null) {
+            return false;
+        }
+
+        return hash_equals($this->hashed_client_secret, hash('sha256', $plaintext));
+    }
+}

--- a/app/Support/IdPrefix.php
+++ b/app/Support/IdPrefix.php
@@ -32,7 +32,7 @@ final class IdPrefix
 
         // Restrictions and platform settings
         'inv_', 'redir_', 'allow_', 'block_',
-        'jtmpl_', 'oac_', 'oat_', 'ort_', 'oauthp_', 'entcon_',
+        'jtmpl_', 'oac_', 'oat_', 'ort_', 'oauthp_', 'authgrant_', 'entcon_',
         'scimt_', 'scimm_', 'wait_',
 
         // Webhooks + delivery

--- a/database/factories/AuthorizationGrantFactory.php
+++ b/database/factories/AuthorizationGrantFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\AuthorizationGrant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AuthorizationGrant>
+ */
+class AuthorizationGrantFactory extends Factory
+{
+    /**
+     * @var class-string<AuthorizationGrant>
+     */
+    protected $model = AuthorizationGrant::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $scopes = ['openid', 'profile', 'email'];
+
+        return [
+            // environment_id, oauth_application_id, user_id supplied by caller.
+            'scopes' => $scopes,
+            'scopes_hash' => AuthorizationGrant::hashScopes($scopes),
+            'granted_at' => now(),
+            'revoked_at' => null,
+        ];
+    }
+
+    public function revoked(): self
+    {
+        return $this->state(fn (array $attributes): array => ['revoked_at' => now()]);
+    }
+}

--- a/database/factories/OauthApplicationFactory.php
+++ b/database/factories/OauthApplicationFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\OauthApplication;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<OauthApplication>
+ */
+class OauthApplicationFactory extends Factory
+{
+    /**
+     * @var class-string<OauthApplication>
+     */
+    protected $model = OauthApplication::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $secret = OauthApplication::mintClientSecret();
+
+        return [
+            // environment_id supplied by caller.
+            'name' => 'App '.$this->faker->unique()->lexify('????????'),
+            'client_id' => OauthApplication::mintClientId(),
+            'hashed_client_secret' => $secret['hash'],
+            'callback_urls' => ['https://example.test/oauth/callback'],
+            'scopes' => ['openid', 'profile', 'email'],
+            'is_public' => false,
+        ];
+    }
+
+    public function public(): self
+    {
+        return $this->state(fn (array $attributes): array => [
+            'is_public' => true,
+            'hashed_client_secret' => null,
+        ]);
+    }
+}

--- a/database/migrations/2026_05_13_000001_create_oauth_applications_and_grants.php
+++ b/database/migrations/2026_05_13_000001_create_oauth_applications_and_grants.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * v0.7 OAuth provider mode — registers third-party applications that
+ * authenticate against authn.sh as the IdP, and tracks per-user consent
+ * grants. `oauth_applications` holds the registered app (client_id +
+ * hashed_client_secret + callback_urls[] + scopes[] + is_public).
+ * `authorization_grants` holds the user's accepted consent for each
+ * app, including the scopes granted at consent time.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('oauth_applications', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('name');
+            $table->string('client_id')->unique();
+            $table->text('hashed_client_secret')->nullable();
+            $table->jsonb('callback_urls')->default(json_encode([]));
+            $table->jsonb('scopes')->default(json_encode([]));
+            $table->boolean('is_public')->default(false);
+
+            $table->timestamps();
+            $table->softDeletes('removed_at');
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->index(['environment_id']);
+        });
+
+        Schema::create('authorization_grants', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('oauth_application_id', 64);
+            $table->string('user_id', 64);
+            $table->jsonb('scopes')->default(json_encode([]));
+            $table->string('scopes_hash', 64);
+            $table->timestamp('granted_at');
+            $table->timestamp('revoked_at')->nullable();
+
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('oauth_application_id')->references('id')->on('oauth_applications')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->index(['user_id']);
+            $table->index(['oauth_application_id']);
+        });
+
+        // Partial unique index: at most one active (non-revoked) grant per
+        // (user, app, scopes_hash). Revoked rows are intentionally kept for
+        // audit purposes, so we filter them out of the uniqueness constraint.
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('CREATE UNIQUE INDEX authorization_grants_active_unique ON authorization_grants (user_id, oauth_application_id, scopes_hash) WHERE revoked_at IS NULL');
+        } else {
+            Schema::table('authorization_grants', function (Blueprint $table): void {
+                $table->unique(['user_id', 'oauth_application_id', 'scopes_hash'], 'authorization_grants_active_unique');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('authorization_grants');
+        Schema::dropIfExists('oauth_applications');
+    }
+};

--- a/tests/Feature/Models/AuthorizationGrantTest.php
+++ b/tests/Feature/Models/AuthorizationGrantTest.php
@@ -111,7 +111,7 @@ it('allows re-granting once an old grant has been revoked', function (): void {
 
     expect($second->id)->not->toBe($first->id);
     expect($second->isActive())->toBeTrue();
-})->skip(DB::connection()->getDriverName() !== 'pgsql', 'partial unique index only enforced on pgsql');
+})->skip(fn () => DB::connection()->getDriverName() !== 'pgsql', 'partial unique index only enforced on pgsql');
 
 it('exposes oauthApplication + user relations', function (): void {
     $env = makeEnvForAuthGrant();

--- a/tests/Feature/Models/AuthorizationGrantTest.php
+++ b/tests/Feature/Models/AuthorizationGrantTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\AuthorizationGrant;
+use App\Models\Environment;
+use App\Models\OauthApplication;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+
+function makeEnvForAuthGrant(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('mints an authgrant_ prefixed id, computes scopes_hash on create, and stamps granted_at', function (): void {
+    $env = makeEnvForAuthGrant();
+    $user = User::create(['environment_id' => $env->id]);
+    $app = OauthApplication::factory()->create(['environment_id' => $env->id]);
+
+    $grant = AuthorizationGrant::factory()->create([
+        'environment_id' => $env->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $user->id,
+        'scopes' => ['openid', 'profile'],
+        'scopes_hash' => '',
+    ]);
+
+    expect($grant->id)->toStartWith('authgrant_');
+    expect($grant->scopes)->toBe(['openid', 'profile']);
+    expect($grant->scopes_hash)->toBe(AuthorizationGrant::hashScopes(['openid', 'profile']));
+    expect($grant->granted_at)->not->toBeNull();
+    expect($grant->isActive())->toBeTrue();
+});
+
+it('produces an order-independent scopes_hash', function (): void {
+    $h1 = AuthorizationGrant::hashScopes(['openid', 'profile', 'email']);
+    $h2 = AuthorizationGrant::hashScopes(['email', 'openid', 'profile']);
+    $h3 = AuthorizationGrant::hashScopes(['openid', 'profile']);
+
+    expect($h1)->toBe($h2);
+    expect($h1)->not->toBe($h3);
+});
+
+it('revokes an active grant and is filtered out of the active scope', function (): void {
+    $env = makeEnvForAuthGrant();
+    app()->instance(Environment::class, $env);
+    $user = User::create(['environment_id' => $env->id]);
+    $app = OauthApplication::factory()->create(['environment_id' => $env->id]);
+
+    $grant = AuthorizationGrant::factory()->create([
+        'environment_id' => $env->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $user->id,
+    ]);
+
+    $grant->revoke();
+    expect($grant->fresh()->isActive())->toBeFalse();
+    expect(AuthorizationGrant::query()->active()->pluck('id')->all())->toBe([]);
+    expect(AuthorizationGrant::query()->revoked()->pluck('id')->all())->toBe([$grant->id]);
+    app()->forgetInstance(Environment::class);
+});
+
+it('refuses a duplicate active (user, app, scopes_hash) row', function (): void {
+    $env = makeEnvForAuthGrant();
+    $user = User::create(['environment_id' => $env->id]);
+    $app = OauthApplication::factory()->create(['environment_id' => $env->id]);
+
+    AuthorizationGrant::factory()->create([
+        'environment_id' => $env->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $user->id,
+        'scopes' => ['openid', 'profile'],
+    ]);
+
+    expect(fn () => AuthorizationGrant::factory()->create([
+        'environment_id' => $env->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $user->id,
+        'scopes' => ['openid', 'profile'],
+    ]))->toThrow(QueryException::class);
+});
+
+it('allows re-granting once an old grant has been revoked', function (): void {
+    $env = makeEnvForAuthGrant();
+    $user = User::create(['environment_id' => $env->id]);
+    $app = OauthApplication::factory()->create(['environment_id' => $env->id]);
+
+    $first = AuthorizationGrant::factory()->create([
+        'environment_id' => $env->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $user->id,
+        'scopes' => ['openid', 'profile'],
+    ]);
+    $first->revoke();
+
+    $second = AuthorizationGrant::factory()->create([
+        'environment_id' => $env->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $user->id,
+        'scopes' => ['openid', 'profile'],
+    ]);
+
+    expect($second->id)->not->toBe($first->id);
+    expect($second->isActive())->toBeTrue();
+})->skip(DB::connection()->getDriverName() !== 'pgsql', 'partial unique index only enforced on pgsql');
+
+it('exposes oauthApplication + user relations', function (): void {
+    $env = makeEnvForAuthGrant();
+    $user = User::create(['environment_id' => $env->id]);
+    $app = OauthApplication::factory()->create(['environment_id' => $env->id]);
+
+    $grant = AuthorizationGrant::factory()->create([
+        'environment_id' => $env->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $user->id,
+    ]);
+
+    expect($grant->oauthApplication->id)->toBe($app->id);
+    expect($grant->user->id)->toBe($user->id);
+});

--- a/tests/Feature/Models/OauthApplicationTest.php
+++ b/tests/Feature/Models/OauthApplicationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\AuthorizationGrant;
+use App\Models\Environment;
+use App\Models\OauthApplication;
+use App\Models\Project;
+use App\Models\User;
+
+function makeEnvForOauthApp(string $slug = 'env'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+
+    return Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+    ]);
+}
+
+it('mints an oac_ prefixed id and an oac_pub_ prefixed client_id', function (): void {
+    $env = makeEnvForOauthApp();
+
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $env->id,
+        'name' => 'My App',
+    ]);
+
+    expect($app->id)->toStartWith('oac_');
+    expect($app->client_id)->toStartWith('oac_pub_');
+    expect($app->callback_urls)->toBe(['https://example.test/oauth/callback']);
+    expect($app->scopes)->toBe(['openid', 'profile', 'email']);
+    expect($app->is_public)->toBeFalse();
+});
+
+it('mints a hashed client secret + verifies the plaintext + hides hashed_client_secret', function (): void {
+    $env = makeEnvForOauthApp();
+    $secret = OauthApplication::mintClientSecret();
+
+    expect($secret['plaintext'])->toStartWith('oac_sec_');
+    expect($secret['hash'])->toBe(hash('sha256', $secret['plaintext']));
+
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $env->id,
+        'hashed_client_secret' => $secret['hash'],
+    ]);
+
+    expect($app->verifyClientSecret($secret['plaintext']))->toBeTrue();
+    expect($app->verifyClientSecret('wrong-secret'))->toBeFalse();
+    expect(array_key_exists('hashed_client_secret', $app->toArray()))->toBeFalse();
+});
+
+it('treats public clients as having no secret', function (): void {
+    $env = makeEnvForOauthApp();
+
+    $app = OauthApplication::factory()->public()->create(['environment_id' => $env->id]);
+
+    expect($app->is_public)->toBeTrue();
+    expect($app->hashed_client_secret)->toBeNull();
+    expect($app->verifyClientSecret('anything'))->toBeFalse();
+});
+
+it('soft-deletes via removed_at', function (): void {
+    $env = makeEnvForOauthApp();
+    app()->instance(Environment::class, $env);
+
+    $app = OauthApplication::factory()->create(['environment_id' => $env->id]);
+    $app->delete();
+
+    expect(OauthApplication::query()->find($app->id))->toBeNull();
+    expect(OauthApplication::withTrashed()->find($app->id)?->removed_at)->not->toBeNull();
+    app()->forgetInstance(Environment::class);
+});
+
+it('honours EnvironmentScope', function (): void {
+    $env1 = makeEnvForOauthApp('one');
+    $env2 = makeEnvForOauthApp('two');
+
+    $a1 = OauthApplication::factory()->create(['environment_id' => $env1->id, 'name' => 'a1']);
+    OauthApplication::factory()->create(['environment_id' => $env2->id, 'name' => 'a2']);
+
+    app()->instance(Environment::class, $env1);
+    expect(OauthApplication::query()->pluck('id')->all())->toBe([$a1->id]);
+    app()->forgetInstance(Environment::class);
+});
+
+it('exposes authorizationGrants relation', function (): void {
+    $env = makeEnvForOauthApp();
+    $user = User::create(['environment_id' => $env->id]);
+    $app = OauthApplication::factory()->create(['environment_id' => $env->id]);
+
+    AuthorizationGrant::factory()->create([
+        'environment_id' => $env->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $user->id,
+    ]);
+
+    expect($app->refresh()->authorizationGrants)->toHaveCount(1);
+});


### PR DESCRIPTION
Closes #238 (AU-2).

## Summary

- `OauthApplication` model (`oac_` prefix) — third-party application registration on the authn.sh IdP. Public `client_id` (`oac_pub_...`), sha256-hashed `hashed_client_secret` (plaintext returned once on create/rotate), JSON `callback_urls` + `scopes`, `is_public` for PKCE-only public clients (no secret).
- `AuthorizationGrant` model (`authgrant_` prefix) — per-user consent record for an `OauthApplication`. Granted scope set + stable `scopes_hash`, `granted_at`, `revoked_at`. Partial unique index (Postgres) keeps at most one active row per `(user_id, oauth_application_id, scopes_hash)`; revoked rows are retained for audit.
- `authgrant_` added to `IdPrefix::PREFIXES`.
- `EnvironmentScope` applied to both models; soft-delete on `OauthApplication`, revoked_at on `AuthorizationGrant`.
- Pest tests cover id prefixes, secret minting + verification, public-client semantics, soft-delete, scope hashing, partial uniqueness, scopes (active / revoked).

## Out of scope (follow-ups)

- AU-5 (#241) — BAPI `/v1/oauth-applications` CRUD + rotate-secret.
- AU-6 (#242) — FAPI `GET /oauth/authorize`.
- AU-10 (#246) — Account Portal Authorized Apps panel.