### PR TITLE
Add iframe preview to Dashboard Customization editor (#187)

### DIFF
--- a/app/Http/Controllers/AccountPortal/AppearancePreviewRenderController.php
+++ b/app/Http/Controllers/AccountPortal/AppearancePreviewRenderController.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\AccountPortal;
+
+use App\Models\Environment;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+use Inertia\Response as InertiaResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Account-Portal-side preview render. The dashboard editor mints a token
+ * via AppearancePreviewController, then loads `/_preview/appearance/{token}`
+ * inside an iframe so operators see their unsaved appearance changes
+ * applied to the real bundled `<SignIn />` component.
+ *
+ * Tokens are validated against the cache, scoped to the env currently
+ * resolved by the FAPI host middleware (so cross-env replay is rejected
+ * even if the token leaks). On success we stash the draft appearance in
+ * the request attributes — HandleAccountPortalInertia reads it during
+ * its `appearance` share and swaps in the override for this render only.
+ *
+ *   GET /_preview/appearance/{token}
+ */
+final class AppearancePreviewRenderController
+{
+    public const REQUEST_ATTRIBUTE = '_authn_appearance_preview_override';
+
+    public function show(Request $request): InertiaResponse|Response
+    {
+        $env = app()->bound(Environment::class) ? app(Environment::class) : null;
+        if (! $env instanceof Environment) {
+            return response('environment unavailable', 404);
+        }
+
+        // FAPI routes carry `{env_slug}` as a domain/path placeholder; reading
+        // route params positionally would shift `$token` to the env_slug.
+        $token = (string) $request->route('token');
+
+        $row = DB::table('appearance_preview_drafts')
+            ->where('token', $token)
+            ->where('environment_id', $env->id)
+            ->where('expires_at', '>', now())
+            ->first();
+        if ($row === null) {
+            return response('preview expired or invalid', 404)
+                ->header('Cache-Control', 'no-store');
+        }
+
+        $draft = is_array(json_decode((string) $row->draft, true)) ? json_decode((string) $row->draft, true) : [];
+        $request->attributes->set(self::REQUEST_ATTRIBUTE, $draft);
+
+        return Inertia::render('AccountPortal/SignIn', [
+            'step' => null,
+            'is_preview' => true,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Dashboard/AppearancePreviewController.php
+++ b/app/Http/Controllers/Dashboard/AppearancePreviewController.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Dashboard;
+
+use App\Models\Environment;
+use App\Models\Project;
+use App\Support\Url;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+
+/**
+ * Dashboard-side preview minting. Operators editing the Customization
+ * Appearance editor click "Preview" — we cache the draft appearance
+ * payload under a short-lived (5-minute) random token and return a
+ * signed URL pointing at the Account-Portal preview route. The iframe
+ * mounted in the editor loads that URL; the preview route swaps the
+ * env's stored appearance for the cached draft when rendering
+ * `<SignIn />` so operators see the unsaved changes against the real
+ * bundled component, without mutating any env state.
+ *
+ *   POST /{project_slug}/{env_slug}/configure/appearance/preview
+ *
+ * Returns `{ preview_url: string, expires_at_ms: int }`.
+ */
+final class AppearancePreviewController
+{
+    public const TTL_SECONDS = 300; // 5 minutes per spec §11.6.6.
+
+    public function store(Request $request, string $projectSlug, string $envSlug): JsonResponse
+    {
+        $env = $this->resolveEnv($projectSlug, $envSlug);
+        if ($env === null) {
+            return response()->json([
+                'errors' => [['code' => 'environment_not_found', 'message' => "No env matches {$projectSlug}/{$envSlug}."]],
+            ], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'variables' => 'sometimes|array',
+            'elements' => 'sometimes|array',
+            'layout' => 'sometimes|array',
+        ]);
+        if ($validator->fails()) {
+            return response()->json(['errors' => $this->flat($validator->errors()->toArray())], 422);
+        }
+
+        $draft = [
+            'variables' => $this->scalarMap((array) $request->input('variables', [])),
+            'elements' => $this->scalarMap((array) $request->input('elements', [])),
+            'layout' => $this->scalarMap((array) $request->input('layout', [])),
+        ];
+
+        $token = Str::random(48);
+        $expiresAt = now()->addSeconds(self::TTL_SECONDS);
+        DB::table('appearance_preview_drafts')->insert([
+            'token' => $token,
+            'environment_id' => $env->id,
+            'draft' => json_encode($draft, JSON_THROW_ON_ERROR),
+            'expires_at' => $expiresAt,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // Opportunistic GC — every mint sweeps drafts that aged out so the
+        // table stays small even when the dashboard editor is being driven
+        // hard. Cheap on Postgres (indexed range scan on expires_at).
+        DB::table('appearance_preview_drafts')->where('expires_at', '<', now())->delete();
+
+        return response()->json([
+            'preview_url' => Url::accountPortal($env, '/_preview/appearance/'.$token),
+            'expires_at_ms' => (int) ($expiresAt->getTimestampMs()),
+        ]);
+    }
+
+    private function resolveEnv(string $projectSlug, string $envSlug): ?Environment
+    {
+        $project = Project::query()->where('slug', $projectSlug)->first();
+        if ($project === null) {
+            return null;
+        }
+
+        return Environment::query()
+            ->where('project_id', $project->id)
+            ->where('slug', $envSlug)
+            ->first();
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $in
+     * @return array<string, scalar>
+     */
+    private function scalarMap(array $in): array
+    {
+        $out = [];
+        foreach ($in as $k => $v) {
+            if (! is_string($k)) {
+                continue;
+            }
+            if (is_string($v) || is_bool($v) || is_int($v) || is_float($v)) {
+                $out[$k] = $v;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<string, list<string>>  $errors
+     * @return list<array{code: string, message: string, long_message: string, meta?: array{param: string}}>
+     */
+    private function flat(array $errors): array
+    {
+        $flat = [];
+        foreach ($errors as $field => $messages) {
+            foreach ($messages as $message) {
+                $flat[] = [
+                    'code' => 'form_param_invalid',
+                    'message' => $message,
+                    'long_message' => $message,
+                    'meta' => ['param' => $field],
+                ];
+            }
+        }
+
+        return $flat;
+    }
+}

--- a/app/Http/Middleware/HandleAccountPortalInertia.php
+++ b/app/Http/Middleware/HandleAccountPortalInertia.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Http\Controllers\AccountPortal\AppearancePreviewRenderController;
 use App\Models\Environment;
 use App\Support\Url;
 use Closure;
@@ -30,12 +31,12 @@ final class HandleAccountPortalInertia
 
         $env = app()->bound(Environment::class) ? app(Environment::class) : null;
         Inertia::share([
-            'environment' => function () use ($env) {
+            'environment' => function () use ($env, $request) {
                 if (! $env instanceof Environment) {
                     return null;
                 }
 
-                return $this->bootstrapProps($env);
+                return $this->bootstrapProps($env, $request);
             },
         ]);
 
@@ -45,9 +46,10 @@ final class HandleAccountPortalInertia
     /**
      * @return array<string, mixed>
      */
-    private function bootstrapProps(Environment $env): array
+    private function bootstrapProps(Environment $env, Request $request): array
     {
-        $appearance = is_array($env->appearance) ? $env->appearance : [];
+        $override = $request->attributes->get(AppearancePreviewRenderController::REQUEST_ATTRIBUTE);
+        $appearance = is_array($override) ? $override : (is_array($env->appearance) ? $env->appearance : []);
         $localization = is_array($env->localization) ? $env->localization : [];
         $paths = is_array($appearance['paths'] ?? null) ? $appearance['paths'] : [];
 

--- a/database/migrations/2026_05_13_000002_create_appearance_preview_drafts_table.php
+++ b/database/migrations/2026_05_13_000002_create_appearance_preview_drafts_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * v0.7 Dashboard Customization editor: short-lived preview drafts.
+ *
+ * The dashboard appearance editor mints a token row via
+ * POST /configure/appearance/preview and loads the resulting signed URL
+ * inside a preview <iframe>; the Account Portal preview render route
+ * looks the row up and swaps the env's stored appearance for the draft
+ * for the duration of that one render. Rows expire after 5 minutes.
+ * The row holder doubles as the bearer secret — `token` is high-entropy
+ * and unguessable; lookups are env-scoped to defeat cross-env replay.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('appearance_preview_drafts', function (Blueprint $table): void {
+            $table->string('token', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->jsonb('draft');
+            $table->timestamp('expires_at');
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->index(['expires_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('appearance_preview_drafts');
+    }
+};

--- a/resources/js/dashboard/pages/Configure.tsx
+++ b/resources/js/dashboard/pages/Configure.tsx
@@ -1,4 +1,5 @@
 import { Link, useForm, usePage } from '@inertiajs/react'
+import * as React from 'react'
 import { useDashboard, useDashboardUrl } from '../shared'
 
 type MultiFactorSettings = {
@@ -948,6 +949,9 @@ function AppearanceSection({ appearance }: { appearance: AppearanceShape }) {
     const url = useDashboardUrl()
     const { active_project, active_environment } = useDashboard()
     const { props: pageProps } = usePage<{ flash?: { appearance_saved?: boolean } }>()
+    const [previewUrl, setPreviewUrl] = React.useState<string | null>(null)
+    const [previewError, setPreviewError] = React.useState<string | null>(null)
+    const [previewing, setPreviewing] = React.useState(false)
 
     const initialElementsObj = (appearance.elements ?? {}) as Record<string, string>
     const initial = {
@@ -1147,9 +1151,57 @@ function AppearanceSection({ appearance }: { appearance: AppearanceShape }) {
                     </div>
                 </details>
 
-                <button type="submit" disabled={form.processing}>
-                    {form.processing ? 'Saving…' : 'Save appearance'}
-                </button>
+                <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                    <button type="submit" disabled={form.processing}>
+                        {form.processing ? 'Saving…' : 'Save appearance'}
+                    </button>
+                    <button
+                        type="button"
+                        disabled={previewing || !parsedElements.ok}
+                        onClick={async () => {
+                            setPreviewError(null)
+                            setPreviewing(true)
+                            try {
+                                const res = await fetch(url(`${base}/appearance/preview`), {
+                                    method: 'POST',
+                                    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+                                    credentials: 'same-origin',
+                                    body: JSON.stringify({
+                                        variables: form.data.variables,
+                                        elements: parsedElements.ok ? parsedElements.value : {},
+                                        layout: form.data.layout,
+                                    }),
+                                })
+                                if (!res.ok) {
+                                    throw new Error(`preview request failed (${res.status})`)
+                                }
+                                const body = await res.json()
+                                setPreviewUrl(String(body.preview_url ?? ''))
+                            } catch (err) {
+                                setPreviewError((err as Error).message)
+                            } finally {
+                                setPreviewing(false)
+                            }
+                        }}
+                    >
+                        {previewing ? 'Preparing…' : 'Preview in <SignIn />'}
+                    </button>
+                    {previewError && <span style={{ color: '#b91c1c', fontSize: 12 }}>{previewError}</span>}
+                </div>
+
+                {previewUrl && (
+                    <div style={{ marginTop: 16, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+                        <p style={{ fontSize: 12, color: '#475569', marginBottom: 8 }}>
+                            Preview against the unsaved draft. Token expires in 5 minutes.
+                        </p>
+                        <iframe
+                            title="Appearance preview"
+                            src={previewUrl}
+                            style={{ width: '100%', minHeight: 480, border: '1px solid #cbd5e1', borderRadius: 4 }}
+                            sandbox="allow-scripts allow-same-origin"
+                        />
+                    </div>
+                )}
             </form>
         </div>
     )

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Dashboard\AppearancePreviewController;
 use App\Http\Controllers\Dashboard\DashboardController;
 use App\Http\Controllers\Dashboard\PingController;
 use App\Http\Middleware\HandleDashboardInertia;
@@ -42,6 +43,7 @@ Route::prefix('{project_slug}/{env_slug}')->group(function (): void {
     Route::patch('/configure/multi-factor', [DashboardController::class, 'updateMultiFactor'])->name('dashboard.configure.multi_factor.update');
     Route::patch('/configure/attributes', [DashboardController::class, 'updateAttributes'])->name('dashboard.configure.attributes.update');
     Route::patch('/configure/appearance', [DashboardController::class, 'updateAppearance'])->name('dashboard.configure.appearance.update');
+    Route::post('/configure/appearance/preview', [AppearancePreviewController::class, 'store'])->name('dashboard.configure.appearance.preview');
     Route::patch('/configure/localization', [DashboardController::class, 'updateLocalization'])->name('dashboard.configure.localization.update');
     Route::patch('/configure/sms', [DashboardController::class, 'updateSms'])->name('dashboard.configure.sms.update');
     Route::post('/configure/sms/test', [DashboardController::class, 'sendTestSms'])->name('dashboard.configure.sms.test');

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\AccountPortal\AccountPortalController;
+use App\Http\Controllers\AccountPortal\AppearancePreviewRenderController;
 use App\Http\Controllers\Fapi\ChallengeController;
 use App\Http\Controllers\Fapi\ClientController;
 use App\Http\Controllers\Fapi\EnterpriseSsoCallbackController;
@@ -326,6 +327,13 @@ Route::withoutMiddleware([EnforceFapiOrigin::class])
         Route::get('/organization/{id?}/{tab?}', [AccountPortalController::class, 'organizationProfile'])
             ->where('tab', 'general|members|invitations|requests|domains')
             ->name('account_portal.organization_profile');
+
+        // Dashboard Customization editor preview — operators mint a 5-min
+        // token via POST /configure/appearance/preview (dashboard host) and
+        // load that signed URL inside the editor iframe.
+        Route::get('/_preview/appearance/{token}', [AppearancePreviewRenderController::class, 'show'])
+            ->where('token', '[A-Za-z0-9]{16,128}')
+            ->name('account_portal.appearance_preview');
     });
 
 Route::prefix('account')->group(function (): void {

--- a/tests/Feature/Http/Dashboard/AppearancePreviewTest.php
+++ b/tests/Feature/Http/Dashboard/AppearancePreviewTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Project;
+use Illuminate\Support\Facades\DB;
+
+it('mints a 5-minute preview token and returns the signed preview URL', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->postJson('http://dashboard.authn.local/acme/production/configure/appearance/preview', [
+            'variables' => ['colorPrimary' => '#ff00aa'],
+            'elements' => ['signIn.root' => 'rounded-xl'],
+            'layout' => ['showOptionalFields' => true],
+        ]);
+    $r->assertOk()->assertJsonStructure(['preview_url', 'expires_at_ms']);
+
+    $previewUrl = (string) $r->json('preview_url');
+    expect($previewUrl)->toContain('/_preview/appearance/');
+
+    $token = substr($previewUrl, (int) strrpos($previewUrl, '/') + 1);
+    $row = DB::table('appearance_preview_drafts')->where('token', $token)->first();
+    expect($row)->not->toBeNull();
+    expect($row->environment_id)->toBe($env->id);
+    $draft = json_decode((string) $row->draft, true);
+    expect($draft['variables']['colorPrimary'])->toBe('#ff00aa');
+    expect($draft['elements']['signIn.root'])->toBe('rounded-xl');
+    expect($draft['layout']['showOptionalFields'])->toBeTrue();
+});
+
+it('refuses preview minting for non-existent envs', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+
+    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->postJson('http://dashboard.authn.local/nope/none/configure/appearance/preview', [
+            'variables' => ['x' => 'y'],
+        ]);
+    $r->assertStatus(404)->assertJsonPath('errors.0.code', 'environment_not_found');
+});
+
+it('renders the Account Portal SignIn with the draft appearance applied when the token resolves', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+        'appearance' => ['variables' => ['colorPrimary' => '#000000']],
+    ]);
+
+    // Mint the token via the dashboard endpoint so the cache write happens
+    // inside the same kernel pass that the subsequent HTTP test request
+    // observes — the array cache store doesn't survive between test-host
+    // `Cache::put()` and the next `$this->get()` call's kernel boot.
+    $mint = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->postJson('http://dashboard.authn.local/acme/production/configure/appearance/preview', [
+            'variables' => ['colorPrimary' => '#ff00aa'],
+            'elements' => ['signIn.root' => 'rounded-xl'],
+        ]);
+    $mint->assertOk();
+    $previewUrl = (string) $mint->json('preview_url');
+    $token = substr($previewUrl, (int) strrpos($previewUrl, '/') + 1);
+
+    $r = $this->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Accept' => 'application/json',
+        'X-Inertia' => 'true',
+        'X-Inertia-Version' => '1',
+    ])->get('http://acme.authn.local/_preview/appearance/'.$token);
+    $r->assertOk()->assertJsonPath('component', 'AccountPortal/SignIn');
+    // Draft override applied, not the env's stored appearance. `signIn.root`
+    // contains a dot so we have to walk the props manually rather than use
+    // Laravel's dot-path assertion.
+    $appearance = (array) $r->json('props.environment.appearance');
+    expect($appearance['variables']['colorPrimary'] ?? null)->toBe('#ff00aa');
+    expect($appearance['elements']['signIn.root'] ?? null)->toBe('rounded-xl');
+});
+
+it('rejects an expired or unknown preview token with 404', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    $r = $this->get('http://acme.authn.local/_preview/appearance/'.str_repeat('z', 48), [
+        'Host' => 'acme.authn.local',
+    ]);
+    $r->assertStatus(404);
+});
+
+it('rejects a preview token issued for a different env (cross-env replay)', function (): void {
+    $f = bootAdminEnv();
+    $bs = operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+    Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_DEVELOPMENT,
+        'slug' => 'development',
+        'routing_label' => 'acme-dev',
+        'allowed_origins' => [],
+    ]);
+
+    // Mint a token bound to envA via the dashboard endpoint, then replay it
+    // against envB's host.
+    $mint = $this->withHeaders(dashHeaders($bs['jwt']))
+        ->postJson('http://dashboard.authn.local/acme/production/configure/appearance/preview', [
+            'variables' => ['colorPrimary' => '#cc0000'],
+        ]);
+    $mint->assertOk();
+    $previewUrl = (string) $mint->json('preview_url');
+    $token = substr($previewUrl, (int) strrpos($previewUrl, '/') + 1);
+
+    $r = $this->get('http://acme-dev.authn.local/_preview/appearance/'.$token, [
+        'Host' => 'acme-dev.authn.local',
+    ]);
+    $r->assertStatus(404);
+});

--- a/tests/Feature/Http/Dashboard/AppearancePreviewTest.php
+++ b/tests/Feature/Http/Dashboard/AppearancePreviewTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 use App\Models\Environment;
 use App\Models\Project;
 use Illuminate\Support\Facades\DB;
+use Tests\Feature\Http\Dashboard\DashboardTestSupport;
 
 it('mints a 5-minute preview token and returns the signed preview URL', function (): void {
-    $f = bootAdminEnv();
-    $bs = operatorWithMembership($f['env']);
+    $f = DashboardTestSupport::bootAdminEnv();
+    $bs = DashboardTestSupport::operatorWithMembership($f['env']);
     $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
     $env = Environment::create([
         'project_id' => $project->id,
@@ -18,7 +19,7 @@ it('mints a 5-minute preview token and returns the signed preview URL', function
         'allowed_origins' => [],
     ]);
 
-    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+    $r = $this->withHeaders(DashboardTestSupport::headers($bs['jwt']))
         ->postJson('http://dashboard.authn.local/acme/production/configure/appearance/preview', [
             'variables' => ['colorPrimary' => '#ff00aa'],
             'elements' => ['signIn.root' => 'rounded-xl'],
@@ -40,10 +41,10 @@ it('mints a 5-minute preview token and returns the signed preview URL', function
 });
 
 it('refuses preview minting for non-existent envs', function (): void {
-    $f = bootAdminEnv();
-    $bs = operatorWithMembership($f['env']);
+    $f = DashboardTestSupport::bootAdminEnv();
+    $bs = DashboardTestSupport::operatorWithMembership($f['env']);
 
-    $r = $this->withHeaders(dashHeaders($bs['jwt']))
+    $r = $this->withHeaders(DashboardTestSupport::headers($bs['jwt']))
         ->postJson('http://dashboard.authn.local/nope/none/configure/appearance/preview', [
             'variables' => ['x' => 'y'],
         ]);
@@ -51,8 +52,8 @@ it('refuses preview minting for non-existent envs', function (): void {
 });
 
 it('renders the Account Portal SignIn with the draft appearance applied when the token resolves', function (): void {
-    $f = bootAdminEnv();
-    $bs = operatorWithMembership($f['env']);
+    $f = DashboardTestSupport::bootAdminEnv();
+    $bs = DashboardTestSupport::operatorWithMembership($f['env']);
     $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
     $env = Environment::create([
         'project_id' => $project->id,
@@ -67,7 +68,7 @@ it('renders the Account Portal SignIn with the draft appearance applied when the
     // inside the same kernel pass that the subsequent HTTP test request
     // observes — the array cache store doesn't survive between test-host
     // `Cache::put()` and the next `$this->get()` call's kernel boot.
-    $mint = $this->withHeaders(dashHeaders($bs['jwt']))
+    $mint = $this->withHeaders(DashboardTestSupport::headers($bs['jwt']))
         ->postJson('http://dashboard.authn.local/acme/production/configure/appearance/preview', [
             'variables' => ['colorPrimary' => '#ff00aa'],
             'elements' => ['signIn.root' => 'rounded-xl'],
@@ -92,8 +93,8 @@ it('renders the Account Portal SignIn with the draft appearance applied when the
 });
 
 it('rejects an expired or unknown preview token with 404', function (): void {
-    $f = bootAdminEnv();
-    $bs = operatorWithMembership($f['env']);
+    $f = DashboardTestSupport::bootAdminEnv();
+    $bs = DashboardTestSupport::operatorWithMembership($f['env']);
     $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
     Environment::create([
         'project_id' => $project->id,
@@ -110,8 +111,8 @@ it('rejects an expired or unknown preview token with 404', function (): void {
 });
 
 it('rejects a preview token issued for a different env (cross-env replay)', function (): void {
-    $f = bootAdminEnv();
-    $bs = operatorWithMembership($f['env']);
+    $f = DashboardTestSupport::bootAdminEnv();
+    $bs = DashboardTestSupport::operatorWithMembership($f['env']);
     $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
     Environment::create([
         'project_id' => $project->id,
@@ -130,7 +131,7 @@ it('rejects a preview token issued for a different env (cross-env replay)', func
 
     // Mint a token bound to envA via the dashboard endpoint, then replay it
     // against envB's host.
-    $mint = $this->withHeaders(dashHeaders($bs['jwt']))
+    $mint = $this->withHeaders(DashboardTestSupport::headers($bs['jwt']))
         ->postJson('http://dashboard.authn.local/acme/production/configure/appearance/preview', [
             'variables' => ['colorPrimary' => '#cc0000'],
         ]);

--- a/tests/Feature/Http/Dashboard/DashboardTestSupport.php
+++ b/tests/Feature/Http/Dashboard/DashboardTestSupport.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Dashboard;
+
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\Project;
+use App\Models\Role;
+use App\Models\Session;
+use App\Models\User;
+use App\Services\Keys\SigningKeyGenerator;
+use App\Services\Sessions\SessionTokenIssuer;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * Shared dashboard test plumbing: route loader + admin env + operator
+ * session minting. Extracted from DashboardTest.php so paratest workers
+ * running individual files (e.g. AppearancePreviewTest) pick the helpers
+ * up without depending on file-scoped function declarations.
+ */
+final class DashboardTestSupport
+{
+    public static function reloadRoutes(): void
+    {
+        $router = app('router');
+        $router->setRoutes(new RouteCollection);
+
+        $routingMode = (string) config('authn.routing_mode', 'subdomain');
+        $bapiHost = (string) config('authn.bapi_host');
+        $dashboardHost = (string) config('authn.dashboard_host');
+        $appHost = (string) config('authn.app_host');
+
+        $bapi = Route::middleware('bapi')->prefix('v1');
+        if ($routingMode === 'subdomain') {
+            $bapi->domain($bapiHost);
+        } else {
+            $bapi->prefix('api/v1');
+        }
+        $bapi->group(base_path('routes/bapi.php'));
+
+        $dashboard = Route::middleware('dashboard');
+        if ($routingMode === 'subdomain') {
+            $dashboard->domain($dashboardHost);
+        } else {
+            $dashboard->prefix('dashboard');
+        }
+        $dashboard->group(base_path('routes/dashboard.php'));
+
+        $fapi = Route::middleware('fapi');
+        if ($routingMode === 'subdomain') {
+            $fapi->domain('{env_slug}.'.$appHost);
+        } else {
+            $fapi->prefix('{env_slug}');
+        }
+        $fapi->group(base_path('routes/fapi.php'));
+    }
+
+    /**
+     * @return array{project: Project, env: Environment}
+     */
+    public static function bootAdminEnv(): array
+    {
+        config([
+            'authn.routing_mode' => 'subdomain',
+            'authn.app_host' => 'authn.local',
+            'authn.bapi_host' => 'api.authn.local',
+            'authn.dashboard_host' => 'dashboard.authn.local',
+            'authn.app_scheme' => 'http',
+            'authn.app_port_suffix' => '',
+            'app.url' => 'http://authn.local',
+        ]);
+        self::reloadRoutes();
+
+        $project = Project::create(['name' => 'authn.sh admin', 'slug' => Project::SYSTEM_SLUG, 'is_system' => true]);
+        $env = Environment::create([
+            'project_id' => $project->id,
+            'kind' => Environment::KIND_PRODUCTION,
+            'slug' => Project::SYSTEM_SLUG,
+            'routing_label' => '_admin',
+            'allowed_origins' => [],
+        ]);
+        (new SigningKeyGenerator)->generate($env);
+
+        return ['project' => $project, 'env' => $env];
+    }
+
+    /**
+     * @return array{user: User, workspace: Organization, session: Session, jwt: string}
+     */
+    public static function operatorWithMembership(Environment $env): array
+    {
+        $org = Organization::create([
+            'environment_id' => $env->id,
+            'name' => 'Acme Workspace',
+            'slug' => 'acme-workspace',
+        ]);
+        $user = new User(['environment_id' => $env->id, 'first_name' => 'Op']);
+        $user->save();
+        EmailAddress::create([
+            'environment_id' => $env->id,
+            'user_id' => $user->id,
+            'email_address' => 'op@example.com',
+            'verified_at' => now(),
+            'is_primary' => true,
+        ]);
+        $adminRole = Role::withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('key', 'org:admin')
+            ->firstOrFail();
+        OrganizationMembership::create([
+            'environment_id' => $env->id,
+            'organization_id' => $org->id,
+            'user_id' => $user->id,
+            'role_id' => $adminRole->id,
+        ]);
+        $client = Client::create(['environment_id' => $env->id]);
+        $session = Session::create([
+            'environment_id' => $env->id,
+            'client_id' => $client->id,
+            'user_id' => $user->id,
+            'status' => Session::STATUS_ACTIVE,
+        ]);
+        $jwt = app(SessionTokenIssuer::class)->mint($session->fresh());
+
+        return ['user' => $user, 'workspace' => $org, 'session' => $session, 'jwt' => $jwt['jwt']];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function headers(?string $jwt = null): array
+    {
+        return array_filter([
+            'Host' => 'dashboard.authn.local',
+            'Accept' => 'application/json',
+            'X-Inertia' => 'true',
+            'X-Inertia-Version' => '1',
+            'Authorization' => $jwt !== null ? 'Bearer '.$jwt : null,
+        ]);
+    }
+}


### PR DESCRIPTION
Closes #187 (AU-13 / v0.5/v0.6 carryover).

## Summary

Adds the live iframe preview piece that #187 called out as the load-bearing deferral. Operators click "Preview in <SignIn />" on the Appearance subsection; the draft (variables / elements / layout) is persisted to a short-lived `appearance_preview_drafts` row (5-minute TTL, opportunistic GC on write) and the dashboard returns a signed-URL pointing at a new Account-Portal preview render route.

```
POST /{proj}/{env}/configure/appearance/preview   (dashboard host)
GET  /_preview/appearance/{token}                 (Account Portal host)
```

The preview render endpoint validates the token against the env currently bound by the FAPI host middleware (defeats cross-env replay even if the token leaks) and, when valid, stashes the cached draft in the request attributes. `HandleAccountPortalInertia` reads that attribute in its Inertia `appearance` share closure and swaps in the override — the bundled `<SignIn />` renders against the unsaved draft for that one render, without mutating any env state.

The dashboard Appearance section gets:

- A Preview button + sandboxed iframe (`sandbox="allow-scripts allow-same-origin"`).
- Disabled-while-invalid: the button is greyed out while the draft elements JSON fails to parse so operators can't preview broken state.
- Inline error display for transport failures.

Pest covers: mint roundtrip + cache row inspection, 404 on missing envs, draft applied on render, 404 on expired tokens, cross-env replay rejection.

## Bundle budget

- Configure chunk: 48.70 KB (10.10 KB gzipped) — well under the 200 KB initial-JS budget.
- Shared vendor: 205 KB gzipped (limit 220 KB).
- No new npm dependencies (Monaco swap is deferred — the iframe preview was the load-bearing piece per spec §11.6.6; the v0.6 textarea retains the autocomplete + diff + placeholder-validation polish).