### PR TITLE
Add JWT template rendering engine + Session::getToken({template}) (#239)

### DIFF
--- a/app/Auth/Jwt/JwtTemplateNotFound.php
+++ b/app/Auth/Jwt/JwtTemplateNotFound.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Jwt;
+
+use RuntimeException;
+
+/**
+ * Thrown when `Session::getToken($name)` resolves no `JwtTemplate` row
+ * by `(environment_id, name)`. Surfaces as a 404
+ * `template_not_found` error on FAPI / BAPI session-token endpoints.
+ */
+final class JwtTemplateNotFound extends RuntimeException
+{
+    public function __construct(public readonly string $templateName)
+    {
+        parent::__construct("JwtTemplate `{$templateName}` not found in this environment.");
+    }
+}

--- a/app/Auth/Jwt/JwtTemplateRenderer.php
+++ b/app/Auth/Jwt/JwtTemplateRenderer.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Jwt;
+
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\JwtTemplate;
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\PhoneNumber;
+use App\Models\Session;
+use App\Models\SigningKey;
+use App\Models\User;
+use App\Support\Url;
+use InvalidArgumentException;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer;
+use Lcobucci\JWT\Signer\Ecdsa\Sha256 as EcdsaSha256;
+use Lcobucci\JWT\Signer\Hmac\Sha256 as HmacSha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256 as RsaSha256;
+use RuntimeException;
+
+/**
+ * v0.7 JWT template rendering engine. Walks the `claims` JSON of a
+ * `JwtTemplate`, substitutes `{{path}}`-style Liquid placeholders against
+ * a snapshot of the User / Session / Organization at mint time, and signs
+ * the resulting payload with either the env's active SigningKey (default
+ * RS256) or the template's `custom_signing_key` escape hatch.
+ *
+ * The placeholder grammar is intentionally narrow:
+ *
+ *   - `{{user.id}}`, `{{user.first_name}}`, `{{user.public_metadata.foo}}`
+ *   - `{{session.id}}`, `{{session.status}}`
+ *   - `{{org.id}}`, `{{org.slug}}`, `{{org.role}}`
+ *   - `{{env.id}}`
+ *
+ * Whitespace inside the braces is allowed: `{{ user.id }}`. Missing
+ * paths render as an empty string in string-typed claim values; in
+ * scalar-typed root claim values (number / boolean) the literal "" is
+ * the safe fallback per JWT shape stability.
+ *
+ * `user.private_metadata` is rejected by design — operators have to opt
+ * in by toggling a future per-template flag (out of scope for v0.7;
+ * tracked in PLAN §10.5 follow-up).
+ *
+ * Hand-rolled rather than depending on `liquid/liquid` to avoid the
+ * MIT/LGPL license discussion and to keep the renderer's attack surface
+ * small (~ 100 LOC of substitution).
+ */
+final class JwtTemplateRenderer
+{
+    public const PRIVATE_METADATA_REJECTED = 'jwt_template_private_metadata_rejected';
+
+    public function render(
+        JwtTemplate $template,
+        User $user,
+        Session $session,
+        ?Organization $organization = null,
+    ): string {
+        $snapshot = $this->snapshot($user, $session, $organization);
+        $rendered = $this->walk($template->claims, $snapshot);
+        $config = $this->configFor($template);
+        $now = now();
+        $lifetime = $template->lifetime > 0 ? $template->lifetime : 60;
+        $expiresAt = $now->copy()->addSeconds($lifetime);
+
+        $builder = $config->builder()
+            ->issuedBy(Url::fapi($user->environment, ''))
+            ->relatedTo($user->id)
+            ->identifiedBy($this->mintJti())
+            ->issuedAt($now->toDateTimeImmutable())
+            ->canOnlyBeUsedAfter($now->copy()->subSeconds($template->allowed_clock_skew)->toDateTimeImmutable())
+            ->expiresAt($expiresAt->toDateTimeImmutable());
+
+        $kid = $this->kidFor($template, $user->environment);
+        if ($kid !== null) {
+            $builder = $builder->withHeader('kid', $kid);
+        }
+
+        foreach ($rendered as $name => $value) {
+            // Reserved JWT claim names that lcobucci/jwt manages on the
+            // builder go through the typed setters; everything else rides
+            // as a free-form custom claim.
+            $builder = match ($name) {
+                'sub' => $builder->relatedTo(is_string($value) ? $value : (string) $value),
+                'aud' => $builder->permittedFor(...$this->audArray($value)),
+                'iss' => $builder->issuedBy(is_string($value) ? $value : (string) $value),
+                default => $builder->withClaim($name, $value),
+            };
+        }
+
+        return $builder->getToken($config->signer(), $config->signingKey())->toString();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function snapshot(User $user, Session $session, ?Organization $organization): array
+    {
+        $primaryEmail = EmailAddress::query()
+            ->where('user_id', $user->id)
+            ->where('is_primary', true)
+            ->value('email_address');
+
+        $primaryPhone = PhoneNumber::query()
+            ->where('user_id', $user->id)
+            ->where('is_primary', true)
+            ->value('phone_number');
+
+        $userPublic = is_array($user->public_metadata ?? null) ? $user->public_metadata : [];
+        $userUnsafe = is_array($user->unsafe_metadata ?? null) ? $user->unsafe_metadata : [];
+
+        $orgSnapshot = null;
+        if ($organization !== null) {
+            $membership = OrganizationMembership::query()
+                ->where('organization_id', $organization->id)
+                ->where('user_id', $user->id)
+                ->with('role')
+                ->first();
+            $orgSnapshot = [
+                'id' => $organization->id,
+                'slug' => $organization->slug,
+                'name' => $organization->name,
+                'role' => $membership?->role?->key,
+                'public_metadata' => is_array($organization->public_metadata ?? null) ? $organization->public_metadata : [],
+            ];
+        }
+
+        return [
+            'user' => [
+                'id' => $user->id,
+                'first_name' => $user->first_name,
+                'last_name' => $user->last_name,
+                'email' => $primaryEmail,
+                'primary_email' => $primaryEmail,
+                'phone' => $primaryPhone,
+                'primary_phone' => $primaryPhone,
+                'public_metadata' => $userPublic,
+                'unsafe_metadata' => $userUnsafe,
+            ],
+            'session' => [
+                'id' => $session->id,
+                'status' => $session->status,
+            ],
+            'org' => $orgSnapshot,
+            'organization' => $orgSnapshot,
+            'env' => [
+                'id' => $user->environment_id,
+            ],
+        ];
+    }
+
+    /**
+     * @param  mixed  $value
+     * @param  array<string, mixed>  $snapshot
+     * @return mixed
+     */
+    private function walk($value, array $snapshot)
+    {
+        if (is_string($value)) {
+            return $this->renderString($value, $snapshot);
+        }
+        if (is_array($value)) {
+            $out = [];
+            foreach ($value as $k => $v) {
+                $out[$k] = $this->walk($v, $snapshot);
+            }
+
+            return $out;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $snapshot
+     */
+    private function renderString(string $template, array $snapshot): string
+    {
+        return (string) preg_replace_callback(
+            '/\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}/',
+            function (array $m) use ($snapshot): string {
+                $path = (string) $m[1];
+                if (str_starts_with($path, 'user.private_metadata')) {
+                    throw new InvalidArgumentException(self::PRIVATE_METADATA_REJECTED);
+                }
+                $value = $this->resolvePath($snapshot, $path);
+
+                if ($value === null) {
+                    return '';
+                }
+                if (is_scalar($value)) {
+                    return (string) $value;
+                }
+
+                return (string) json_encode($value);
+            },
+            $template,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $tree
+     */
+    private function resolvePath(array $tree, string $path): mixed
+    {
+        $segments = explode('.', $path);
+        $node = $tree;
+        foreach ($segments as $segment) {
+            if (! is_array($node) || ! array_key_exists($segment, $node)) {
+                return null;
+            }
+            $node = $node[$segment];
+        }
+
+        return $node;
+    }
+
+    private function configFor(JwtTemplate $template): Configuration
+    {
+        $signer = $this->signer($template);
+
+        if ($template->custom_signing_key !== null && $template->custom_signing_key !== '') {
+            return Configuration::forAsymmetricSigner(
+                $signer,
+                InMemory::plainText($template->custom_signing_key),
+                InMemory::plainText('public-not-needed-for-signing'),
+            );
+        }
+
+        // Default: env's active session-signing key. RS256 only — operators
+        // that need ES256 / HS256 must supply a custom_signing_key.
+        $signingKey = $template->environment->signingKeys()
+            ->where('status', SigningKey::STATUS_ACTIVE)
+            ->latest('activated_at')
+            ->first();
+        if ($signingKey === null) {
+            throw new RuntimeException('No active SigningKey for env '.$template->environment_id);
+        }
+
+        if ($template->signing_algorithm !== JwtTemplate::ALG_RS256) {
+            throw new RuntimeException(
+                "Template `{$template->name}` requests {$template->signing_algorithm} but no custom_signing_key is set; ".
+                'either set a custom_signing_key or switch the algorithm to RS256.'
+            );
+        }
+
+        return Configuration::forAsymmetricSigner(
+            new RsaSha256,
+            InMemory::plainText($signingKey->privatePem()),
+            InMemory::plainText('public-not-needed-for-signing'),
+        );
+    }
+
+    private function signer(JwtTemplate $template): Signer
+    {
+        return match ($template->signing_algorithm) {
+            JwtTemplate::ALG_ES256 => new EcdsaSha256,
+            JwtTemplate::ALG_HS256 => new HmacSha256,
+            default => new RsaSha256,
+        };
+    }
+
+    private function kidFor(JwtTemplate $template, Environment $env): ?string
+    {
+        if ($template->custom_signing_key !== null && $template->custom_signing_key !== '') {
+            // Custom key: there's no SigningKey row that corresponds, so we
+            // surface the template id as the kid so consumers can correlate
+            // back. JWKS / verification paths know that `jtmpl_*` kids
+            // resolve via the JwtTemplate.custom_signing_key public half
+            // rather than the env's SigningKey table.
+            return $template->id;
+        }
+        $signingKey = $env->signingKeys()
+            ->where('status', SigningKey::STATUS_ACTIVE)
+            ->latest('activated_at')
+            ->first();
+
+        return $signingKey?->id;
+    }
+
+    /**
+     * @param  mixed  $aud
+     * @return list<string>
+     */
+    private function audArray($aud): array
+    {
+        if (is_array($aud)) {
+            return array_map(static fn ($v) => is_string($v) ? $v : (string) $v, array_values($aud));
+        }
+
+        return [is_string($aud) ? $aud : (string) $aud];
+    }
+
+    private function mintJti(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(16)), '+/', '-_'), '=');
+    }
+}

--- a/app/Http/Controllers/Bapi/SessionsController.php
+++ b/app/Http/Controllers/Bapi/SessionsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Bapi;
 
+use App\Auth\Jwt\JwtTemplateNotFound;
 use App\Models\Environment;
 use App\Models\Session;
 use App\Models\SessionActivity;
@@ -11,7 +12,6 @@ use App\Services\Sessions\SessionLifecycle;
 use App\Services\Sessions\SessionTokenIssuer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use InvalidArgumentException;
 
 /**
  * BAPI sessions surface.
@@ -89,11 +89,8 @@ final class SessionsController
 
         try {
             $minted = $this->issuer->mint($session, is_string($template) ? $template : null, $request);
-        } catch (InvalidArgumentException $e) {
-            if (str_starts_with($e->getMessage(), 'template_not_found:')) {
-                return $this->error(404, 'template_not_found', 'JWT template '.substr($e->getMessage(), strlen('template_not_found:')).' is not configured (custom JWT templates land in v0.7).');
-            }
-            throw $e;
+        } catch (JwtTemplateNotFound $e) {
+            return $this->error(404, 'template_not_found', "JWT template `{$e->templateName}` is not configured for this environment.");
         }
 
         return response()->json([

--- a/app/Http/Controllers/Fapi/SessionTokenController.php
+++ b/app/Http/Controllers/Fapi/SessionTokenController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Fapi;
 
+use App\Auth\Jwt\JwtTemplateNotFound;
 use App\Models\Client;
 use App\Models\Session;
 use App\Models\User;
@@ -13,7 +14,6 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\RateLimiter;
-use InvalidArgumentException;
 
 /**
  * `POST /v1/client/sessions/{sid}/tokens[/{template}]`
@@ -89,11 +89,8 @@ final class SessionTokenController
 
         try {
             $minted = $this->issuer->mint($session, $template, $request);
-        } catch (InvalidArgumentException $e) {
-            if (str_starts_with($e->getMessage(), 'template_not_found:')) {
-                return $this->error(404, 'template_not_found', 'JWT template '.substr($e->getMessage(), strlen('template_not_found:')).' is not configured (custom JWT templates land in v0.7).');
-            }
-            throw $e;
+        } catch (JwtTemplateNotFound $e) {
+            return $this->error(404, 'template_not_found', "JWT template `{$e->templateName}` is not configured for this environment.");
         }
 
         if ($user !== null) {

--- a/app/Models/Session.php
+++ b/app/Models/Session.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Auth\Jwt\JwtTemplateNotFound;
 use App\Concerns\HasPrefixedUlid;
 use App\Database\Scopes\EnvironmentScope;
+use App\Services\Sessions\SessionTokenIssuer;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -198,5 +200,18 @@ class Session extends Model
     public function isImpersonation(): bool
     {
         return $this->actor !== null;
+    }
+
+    /**
+     * Mint a session JWT. With `$template = null` (or `'default'`), returns
+     * the env-default session token shape. With a custom `$template` name,
+     * resolves the matching `JwtTemplate` row and renders custom claims via
+     * `JwtTemplateRenderer`.
+     *
+     * @throws JwtTemplateNotFound when the supplied template name has no matching JwtTemplate row in this environment.
+     */
+    public function getToken(?string $template = null): string
+    {
+        return app(SessionTokenIssuer::class)->mint($this, $template)['jwt'];
     }
 }

--- a/app/Services/Sessions/SessionTokenIssuer.php
+++ b/app/Services/Sessions/SessionTokenIssuer.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\Services\Sessions;
 
+use App\Auth\Jwt\JwtTemplateNotFound;
+use App\Auth\Jwt\JwtTemplateRenderer;
 use App\Models\EnterpriseAccount;
 use App\Models\Environment;
+use App\Models\JwtTemplate;
+use App\Models\Organization;
 use App\Models\OrganizationMembership;
 use App\Models\Passkey;
 use App\Models\PhoneNumber;
@@ -49,6 +53,41 @@ final class SessionTokenIssuer
     {
         $environment = $session->environment;
         $template ??= 'default';
+
+        // v0.7: a non-`default`, non-`flat` template name is a user-defined
+        // JwtTemplate. Look it up by (environment_id, name) and delegate the
+        // render to JwtTemplateRenderer. The "default" + "flat" shapes
+        // continue to ride the legacy session-token path below so v0.1+
+        // consumers don't see any shape change.
+        if ($template !== 'default' && $template !== 'flat') {
+            $row = JwtTemplate::query()
+                ->withoutGlobalScopes()
+                ->where('environment_id', $environment->id)
+                ->where('name', $template)
+                ->first();
+            if ($row === null) {
+                throw new JwtTemplateNotFound($template);
+            }
+            $jwt = (new JwtTemplateRenderer)->render(
+                $row,
+                $session->user,
+                $session,
+                $this->orgForSession($session),
+            );
+            $expiresAt = now()->addSeconds($row->lifetime > 0 ? $row->lifetime : 60)->getTimestamp();
+
+            return [
+                'jwt' => $jwt,
+                'expires_at' => $expiresAt,
+                'kid' => $row->custom_signing_key !== null && $row->custom_signing_key !== ''
+                    ? $row->id
+                    : ($environment->signingKeys()
+                        ->where('status', SigningKey::STATUS_ACTIVE)
+                        ->latest('activated_at')
+                        ->value('id') ?? ''),
+            ];
+        }
+
         $shape = $this->resolveTemplateShape($environment, $template);
 
         $signingKey = $environment->signingKeys()
@@ -134,9 +173,11 @@ final class SessionTokenIssuer
 
     private function resolveTemplateShape(Environment $environment, string $template): string
     {
-        if ($template !== 'default') {
-            // Custom JWT templates land in v0.7; reject everything else for now.
-            throw new InvalidArgumentException("template_not_found:{$template}");
+        // v0.7: the named-JwtTemplate path is resolved upstream in `mint()`.
+        // What lands here is `default` (env-controlled shape) or `flat`
+        // (caller force-overrides via Session::getToken('flat')).
+        if ($template === 'flat') {
+            return 'flat';
         }
 
         $appearance = $environment->appearance ?? [];
@@ -144,6 +185,20 @@ final class SessionTokenIssuer
         $shape = is_array($sessions) ? ($sessions['session_token_template'] ?? 'default') : 'default';
 
         return $shape === 'flat' ? 'flat' : 'default';
+    }
+
+    /**
+     * Resolves the Organization to pin to the JWT-template render snapshot,
+     * if any. Picks `last_active_organization_id` when set; null otherwise.
+     */
+    private function orgForSession(Session $session): ?Organization
+    {
+        $orgId = $session->last_active_organization_id;
+        if (! is_string($orgId) || $orgId === '') {
+            return null;
+        }
+
+        return Organization::query()->withoutGlobalScopes()->find($orgId);
     }
 
     private function configForKey(SigningKey $signingKey): Configuration

--- a/tests/Feature/Auth/Jwt/JwtTemplateRendererTest.php
+++ b/tests/Feature/Auth/Jwt/JwtTemplateRendererTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\Jwt\JwtTemplateNotFound;
+use App\Auth\Jwt\JwtTemplateRenderer;
+use App\Models\Client;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\JwtTemplate;
+use App\Models\Organization;
+use App\Models\OrganizationMembership;
+use App\Models\Project;
+use App\Models\Role;
+use App\Models\Session;
+use App\Models\User;
+use App\Services\Keys\SigningKeyGenerator;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Token\Parser;
+
+function bootJwtTemplateEnv(string $slug = 'jwt'): Environment
+{
+    $project = Project::create(['name' => 'P', 'slug' => 'p-'.$slug]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => $slug,
+        'routing_label' => $slug,
+        'allowed_origins' => [],
+    ]);
+    (new SigningKeyGenerator)->generate($env);
+
+    return $env;
+}
+
+function makeUserAndSession(Environment $env, array $userAttrs = [], array $sessionAttrs = []): array
+{
+    $user = User::create(array_merge([
+        'environment_id' => $env->id,
+        'first_name' => 'Ada',
+        'last_name' => 'Lovelace',
+    ], $userAttrs));
+    EmailAddress::create([
+        'environment_id' => $env->id,
+        'user_id' => $user->id,
+        'email_address' => 'ada@example.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+    $client = Client::create(['environment_id' => $env->id]);
+    $session = Session::create(array_merge([
+        'environment_id' => $env->id,
+        'client_id' => $client->id,
+        'user_id' => $user->id,
+        'status' => Session::STATUS_ACTIVE,
+    ], $sessionAttrs));
+
+    return ['user' => $user->refresh(), 'session' => $session->refresh()];
+}
+
+it('renders simple {{user.id}} / {{user.email}} placeholders using the env signing key', function (): void {
+    $env = bootJwtTemplateEnv();
+    ['user' => $user, 'session' => $session] = makeUserAndSession($env);
+
+    $template = JwtTemplate::factory()->create([
+        'environment_id' => $env->id,
+        'name' => 'api-access',
+        'claims' => [
+            'sub' => '{{user.id}}',
+            'email' => '{{user.primary_email}}',
+            'session_id' => '{{session.id}}',
+        ],
+    ]);
+
+    $jwt = (new JwtTemplateRenderer)->render($template, $user, $session);
+    $parsed = (new Parser(new JoseEncoder))->parse($jwt);
+
+    expect($parsed->claims()->get('sub'))->toBe($user->id);
+    expect($parsed->claims()->get('email'))->toBe('ada@example.test');
+    expect($parsed->claims()->get('session_id'))->toBe($session->id);
+});
+
+it('renders org-scoped placeholders when an Organization is supplied', function (): void {
+    $env = bootJwtTemplateEnv();
+    ['user' => $user, 'session' => $session] = makeUserAndSession($env);
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => 'acme']);
+    $role = Role::withoutGlobalScopes()->where('environment_id', $env->id)->where('key', 'org:admin')->firstOrFail();
+    OrganizationMembership::create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'user_id' => $user->id,
+        'role_id' => $role->id,
+    ]);
+
+    $template = JwtTemplate::factory()->create([
+        'environment_id' => $env->id,
+        'name' => 'org-token',
+        'claims' => [
+            'sub' => '{{user.id}}',
+            'org' => '{{org.slug}}',
+            'role' => '{{org.role}}',
+        ],
+    ]);
+
+    $jwt = (new JwtTemplateRenderer)->render($template, $user, $session, $org);
+    $parsed = (new Parser(new JoseEncoder))->parse($jwt);
+
+    expect($parsed->claims()->get('org'))->toBe('acme');
+    expect($parsed->claims()->get('role'))->toBe('org:admin');
+});
+
+it('falls back to an empty string when a placeholder path is missing', function (): void {
+    $env = bootJwtTemplateEnv();
+    ['user' => $user, 'session' => $session] = makeUserAndSession($env);
+
+    $template = JwtTemplate::factory()->create([
+        'environment_id' => $env->id,
+        'claims' => [
+            'sub' => '{{user.id}}',
+            'department' => '{{user.public_metadata.department}}',
+        ],
+    ]);
+
+    $jwt = (new JwtTemplateRenderer)->render($template, $user, $session);
+    $parsed = (new Parser(new JoseEncoder))->parse($jwt);
+
+    expect($parsed->claims()->get('department'))->toBe('');
+});
+
+it('rejects {{user.private_metadata.*}} access by throwing PRIVATE_METADATA_REJECTED', function (): void {
+    $env = bootJwtTemplateEnv();
+    ['user' => $user, 'session' => $session] = makeUserAndSession($env);
+
+    $template = JwtTemplate::factory()->create([
+        'environment_id' => $env->id,
+        'claims' => ['sub' => '{{user.id}}', 'pm' => '{{user.private_metadata.foo}}'],
+    ]);
+
+    expect(fn () => (new JwtTemplateRenderer)->render($template, $user, $session))
+        ->toThrow(InvalidArgumentException::class, JwtTemplateRenderer::PRIVATE_METADATA_REJECTED);
+});
+
+it('honours the template lifetime when minting expiry', function (): void {
+    $env = bootJwtTemplateEnv();
+    ['user' => $user, 'session' => $session] = makeUserAndSession($env);
+
+    $template = JwtTemplate::factory()->create([
+        'environment_id' => $env->id,
+        'lifetime' => 600,
+        'allowed_clock_skew' => 30,
+        'claims' => ['sub' => '{{user.id}}'],
+    ]);
+
+    $before = now();
+    $jwt = (new JwtTemplateRenderer)->render($template, $user, $session);
+    $parsed = (new Parser(new JoseEncoder))->parse($jwt);
+    $exp = $parsed->claims()->get('exp');
+    $iat = $parsed->claims()->get('iat');
+    $nbf = $parsed->claims()->get('nbf');
+
+    expect($exp->getTimestamp() - $iat->getTimestamp())->toBe(600);
+    expect($iat->getTimestamp() - $nbf->getTimestamp())->toBe(30);
+    expect($exp->getTimestamp())->toBeGreaterThanOrEqual($before->getTimestamp() + 599);
+});
+
+it('renders nested array claims with placeholders resolved at every leaf', function (): void {
+    $env = bootJwtTemplateEnv();
+    ['user' => $user, 'session' => $session] = makeUserAndSession($env);
+
+    $template = JwtTemplate::factory()->create([
+        'environment_id' => $env->id,
+        'claims' => [
+            'sub' => '{{user.id}}',
+            'profile' => [
+                'first_name' => '{{user.first_name}}',
+                'email' => '{{user.email}}',
+            ],
+        ],
+    ]);
+
+    $jwt = (new JwtTemplateRenderer)->render($template, $user, $session);
+    $parsed = (new Parser(new JoseEncoder))->parse($jwt);
+
+    $profile = (array) $parsed->claims()->get('profile');
+    expect($profile['first_name'])->toBe('Ada');
+    expect($profile['email'])->toBe('ada@example.test');
+});
+
+it('hooks into Session::getToken({template}) and throws JwtTemplateNotFound for unknown names', function (): void {
+    $env = bootJwtTemplateEnv();
+    ['user' => $user, 'session' => $session] = makeUserAndSession($env);
+
+    JwtTemplate::factory()->create([
+        'environment_id' => $env->id,
+        'name' => 'api',
+        'claims' => ['sub' => '{{user.id}}', 'kind' => 'api'],
+    ]);
+
+    $jwt = $session->getToken('api');
+    $parsed = (new Parser(new JoseEncoder))->parse($jwt);
+    expect($parsed->claims()->get('sub'))->toBe($user->id);
+    expect($parsed->claims()->get('kind'))->toBe('api');
+
+    expect(fn () => $session->getToken('does-not-exist'))->toThrow(JwtTemplateNotFound::class);
+});
+
+it('signs with a custom_signing_key when the template supplies one and sets the kid to the template id', function (): void {
+    $env = bootJwtTemplateEnv();
+    ['user' => $user, 'session' => $session] = makeUserAndSession($env);
+
+    // Generate an RSA keypair for the test.
+    $keyRes = openssl_pkey_new(['private_key_type' => OPENSSL_KEYTYPE_RSA, 'private_key_bits' => 2048]);
+    openssl_pkey_export($keyRes, $privatePem);
+
+    $template = JwtTemplate::factory()->withCustomSigningKey($privatePem)->create([
+        'environment_id' => $env->id,
+        'claims' => ['sub' => '{{user.id}}'],
+    ]);
+
+    $jwt = (new JwtTemplateRenderer)->render($template, $user, $session);
+    $parsed = (new Parser(new JoseEncoder))->parse($jwt);
+    expect($parsed->headers()->get('kid'))->toBe($template->id);
+});
+
+it('returns the env-default session token when template is null (legacy path)', function (): void {
+    $env = bootJwtTemplateEnv();
+    ['user' => $user, 'session' => $session] = makeUserAndSession($env);
+
+    $jwt = $session->getToken();
+    $parsed = (new Parser(new JoseEncoder))->parse($jwt);
+    // v=2 is the v0.1 default session-token shape marker; v0.7 templates
+    // intentionally omit it so consumers can tell the two paths apart.
+    expect($parsed->claims()->get('v'))->toBe(2);
+});

--- a/tests/Feature/Services/Sessions/SessionTokenIssuerTest.php
+++ b/tests/Feature/Services/Sessions/SessionTokenIssuerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Auth\Jwt\JwtTemplateNotFound;
 use App\Models\Client;
 use App\Models\Environment;
 use App\Models\Project;
@@ -89,12 +90,12 @@ it('honours per-environment lifetime override via appearance.sessions.lifetime_s
     expect($minted['expires_at'] - now()->getTimestamp())->toBeLessThanOrEqual(601);
 });
 
-it('throws template_not_found for any template name other than default', function (): void {
+it('throws JwtTemplateNotFound for a custom template name that has no matching row', function (): void {
     $f = tokenFixture();
     $issuer = app(SessionTokenIssuer::class);
 
     expect(fn () => $issuer->mint($f['session'], 'supabase'))
-        ->toThrow(InvalidArgumentException::class, 'template_not_found:supabase');
+        ->toThrow(JwtTemplateNotFound::class);
 });
 
 it('uses the latest active SigningKey for signing', function (): void {


### PR DESCRIPTION
Closes #239 (AU-3).

## Summary

`JwtTemplateRenderer` resolves `{{path}}`-style Liquid placeholders against a snapshot of the User / Session / Organization at mint time, signs with either the env's active SigningKey (default RS256) or the template's `custom_signing_key` escape hatch, and stamps `lifetime` + `allowed_clock_skew` per the `JwtTemplate` row from AU-1.

- Placeholder grammar is intentionally narrow: `{{user.id}}`, `{{user.public_metadata.foo}}`, `{{session.id}}`, `{{org.slug}}`, `{{env.id}}`. Whitespace inside the braces is allowed.
- Hand-rolled (~ 100 LOC) rather than depending on the `liquid/liquid` composer package — keeps the renderer's attack surface small and avoids the license discussion.
- `{{user.private_metadata.*}}` is rejected by design per PLAN §4.6. A future per-template opt-in toggle lands in v0.8.

`SessionTokenIssuer::mint()` now delegates to `JwtTemplateRenderer` for any template name other than `default` / `flat`, raising `JwtTemplateNotFound` when no matching row exists. `Session::getToken(?string $template)` wraps this for SDK consumers.

Pest covers: placeholder resolution (user / session / org), missing-path graceful fallback, nested array claims, `private_metadata` refusal, lifetime + clock-skew enforcement, `custom_signing_key` signing with the template id as the kid, env-default fallback when `$template === null`, `JwtTemplateNotFound` for unknown names.

## Unblocks

- sdk-php SP-3 (`TokenVerifier.customClaims`).
- sdk-js JS-1 (`Session.getToken({template})` wire-up).

## Out of scope (follow-ups)

- AU-4 (#240) — BAPI `/v1/jwt-templates` CRUD.
- AU-15 (#249) — webhook event emission on render.