### PR TITLE
Add BAPI /v1/jwt-templates CRUD + delete-in-use rejection (#240)

### DIFF
--- a/app/Http/Controllers/Bapi/JwtTemplateController.php
+++ b/app/Http/Controllers/Bapi/JwtTemplateController.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Http\Resources\JwtTemplateResource;
+use App\Models\Environment;
+use App\Models\JwtTemplate;
+use App\Webhooks\Emitter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * BAPI `/v1/jwt-templates` CRUD (OA-1). Operator-scoped: bearer-secret
+ * authenticated, env-pinned by the same middleware that drives every
+ * other BAPI route.
+ *
+ *   GET    /v1/jwt-templates
+ *   POST   /v1/jwt-templates
+ *   GET    /v1/jwt-templates/{jwt_template_id}
+ *   PATCH  /v1/jwt-templates/{jwt_template_id}
+ *   DELETE /v1/jwt-templates/{jwt_template_id}
+ *
+ * `name` and `signing_algorithm` are immutable on PATCH per spec —
+ * sending a different value returns 422. DELETE soft-removes via the
+ * `removed_at` column and refuses (`409 jwt_template_in_use`) when the
+ * template was used to mint a token within the grace window
+ * (max(lifetime + allowed_clock_skew, 40h)).
+ */
+final class JwtTemplateController
+{
+    /** RFC 5322-shaped slug per the openapi spec. */
+    public const NAME_PATTERN = '/^[a-z][a-z0-9_-]{0,63}$/';
+
+    public function index(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        $query = JwtTemplate::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->whereNull('removed_at')
+            ->orderBy('created_at');
+
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (JwtTemplate $t) => JwtTemplateResource::from($t))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        $validator = Validator::make($request->all(), [
+            'name' => ['required', 'string', 'max:64', 'regex:'.self::NAME_PATTERN],
+            'claims' => ['required', 'array'],
+            'lifetime' => ['sometimes', 'integer', 'between:1,86400'],
+            'allowed_clock_skew' => ['sometimes', 'integer', 'between:0,300'],
+            'signing_algorithm' => ['sometimes', 'string', 'in:RS256,ES256,HS256'],
+            'custom_signing_key' => ['sometimes', 'nullable', 'string'],
+        ]);
+        if ($validator->fails()) {
+            return $this->validationError($validator->errors()->toArray());
+        }
+        $data = $validator->validated();
+
+        $duplicate = JwtTemplate::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('name', $data['name'])
+            ->whereNull('removed_at')
+            ->exists();
+        if ($duplicate) {
+            return $this->error(409, 'jwt_template_name_taken',
+                "Another JwtTemplate in this environment already uses the name `{$data['name']}`.");
+        }
+
+        $row = JwtTemplate::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'name' => $data['name'],
+            'claims' => $data['claims'],
+            'lifetime' => $data['lifetime'] ?? 60,
+            'allowed_clock_skew' => $data['allowed_clock_skew'] ?? 5,
+            'signing_algorithm' => $data['signing_algorithm'] ?? JwtTemplate::ALG_RS256,
+            'custom_signing_key' => $data['custom_signing_key'] ?? null,
+        ]);
+
+        Log::info('audit:bapi.jwt_template.created', [
+            'environment_id' => $env->id,
+            'jwt_template_id' => $row->id,
+        ]);
+        app(Emitter::class)->emit('jwtTemplate.created', JwtTemplateResource::from($row->fresh()), $env);
+
+        return response()->json(JwtTemplateResource::from($row->fresh()), 201)
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function show(Request $request, string $jwtTemplateId): JsonResponse
+    {
+        $row = $this->find($jwtTemplateId);
+        if ($row === null) {
+            return $this->notFound($jwtTemplateId);
+        }
+
+        return response()->json(JwtTemplateResource::from($row))->header('Cache-Control', 'no-store');
+    }
+
+    public function update(Request $request, string $jwtTemplateId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $row = $this->find($jwtTemplateId);
+        if ($row === null) {
+            return $this->notFound($jwtTemplateId);
+        }
+
+        if ($request->has('name') && $request->input('name') !== $row->name) {
+            return $this->error(422, 'name_immutable',
+                'name cannot change after a JwtTemplate is created — re-create under a new name to rename.');
+        }
+        if ($request->has('signing_algorithm') && $request->input('signing_algorithm') !== $row->signing_algorithm) {
+            return $this->error(422, 'signing_algorithm_immutable',
+                'signing_algorithm cannot change after a JwtTemplate is created — re-create under a new name to migrate.');
+        }
+
+        $validator = Validator::make($request->all(), [
+            'claims' => ['sometimes', 'array'],
+            'lifetime' => ['sometimes', 'integer', 'between:1,86400'],
+            'allowed_clock_skew' => ['sometimes', 'integer', 'between:0,300'],
+            'custom_signing_key' => ['sometimes', 'nullable', 'string'],
+        ]);
+        if ($validator->fails()) {
+            return $this->validationError($validator->errors()->toArray());
+        }
+        $data = $validator->validated();
+
+        $row->fill(array_intersect_key($data, array_flip(['claims', 'lifetime', 'allowed_clock_skew'])));
+        if (array_key_exists('custom_signing_key', $data)) {
+            // Explicit `null` reverts to the env signing key; any string
+            // rotates to the supplied PEM / secret.
+            $row->custom_signing_key = $data['custom_signing_key'];
+        }
+        $row->save();
+
+        Log::info('audit:bapi.jwt_template.updated', [
+            'environment_id' => $env->id,
+            'jwt_template_id' => $row->id,
+        ]);
+        app(Emitter::class)->emit('jwtTemplate.updated', JwtTemplateResource::from($row->fresh()), $env);
+
+        return response()->json(JwtTemplateResource::from($row->fresh()))->header('Cache-Control', 'no-store');
+    }
+
+    public function destroy(Request $request, string $jwtTemplateId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $row = $this->find($jwtTemplateId);
+        if ($row === null) {
+            return $this->notFound($jwtTemplateId);
+        }
+
+        if ($row->last_used_at !== null) {
+            $graceEndsAt = $row->last_used_at->copy()->addSeconds($row->deleteGraceSeconds());
+            if ($graceEndsAt->isFuture()) {
+                $retryAfter = (int) ceil($graceEndsAt->diffInRealSeconds(now()));
+
+                return $this->error(409, 'jwt_template_in_use',
+                    "Cannot delete — the template was used to mint a token at {$row->last_used_at}; ".
+                    "long-lived verifier caches may still hold rendered tokens. Retry after {$retryAfter}s.",
+                    ['Retry-After' => (string) max(1, $retryAfter)],
+                );
+            }
+        }
+
+        $snapshot = JwtTemplateResource::from($row);
+        $row->delete();
+
+        Log::info('audit:bapi.jwt_template.deleted', [
+            'environment_id' => $env->id,
+            'jwt_template_id' => $row->id,
+        ]);
+        app(Emitter::class)->emit('jwtTemplate.deleted', $snapshot, $env);
+
+        return response()->json(null, 204);
+    }
+
+    private function find(string $jwtTemplateId): ?JwtTemplate
+    {
+        $env = app(Environment::class);
+
+        // withoutGlobalScopes() drops both EnvironmentScope (we filter by
+        // environment_id manually) and SoftDeletingScope — re-add the
+        // soft-delete filter so tombstoned rows stay hidden from BAPI reads.
+        return JwtTemplate::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $jwtTemplateId)
+            ->whereNull('removed_at')
+            ->first();
+    }
+
+    private function notFound(string $id): JsonResponse
+    {
+        return $this->error(404, 'jwt_template_not_found', "JwtTemplate {$id} not found.");
+    }
+
+    /**
+     * @param  array<string, string>  $headers
+     */
+    private function error(int $status, string $code, string $message, array $headers = []): JsonResponse
+    {
+        $response = response()->json([
+            'errors' => [['code' => $code, 'message' => $message, 'long_message' => $message]],
+        ], $status)->header('Cache-Control', 'no-store');
+        foreach ($headers as $key => $value) {
+            $response->header($key, $value);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param  array<string, list<string>>  $errors
+     */
+    private function validationError(array $errors): JsonResponse
+    {
+        $flat = [];
+        foreach ($errors as $field => $messages) {
+            foreach ($messages as $message) {
+                $flat[] = [
+                    'code' => 'form_param_invalid',
+                    'message' => $message,
+                    'long_message' => $message,
+                    'meta' => ['param' => $field],
+                ];
+            }
+        }
+
+        return response()->json(['errors' => $flat], 422)->header('Cache-Control', 'no-store');
+    }
+}

--- a/app/Http/Resources/JwtTemplateResource.php
+++ b/app/Http/Resources/JwtTemplateResource.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\JwtTemplate;
+
+/**
+ * BAPI shape for `JwtTemplate`. Mirrors OA-1's `JwtTemplate` schema —
+ * `additionalProperties: false`, so we emit exactly the spec-narrow set
+ * and never `custom_signing_key` (writeOnly per spec, encrypted at rest
+ * per the model `$hidden` array).
+ */
+final class JwtTemplateResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function from(JwtTemplate $template): array
+    {
+        return [
+            'id' => $template->id,
+            'object' => 'jwt_template',
+            'name' => $template->name,
+            'claims' => is_array($template->claims) ? $template->claims : [],
+            'lifetime' => $template->lifetime,
+            'allowed_clock_skew' => $template->allowed_clock_skew,
+            'signing_algorithm' => $template->signing_algorithm,
+            'created_at' => $template->created_at?->getTimestampMs(),
+            'updated_at' => $template->updated_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/app/Models/JwtTemplate.php
+++ b/app/Models/JwtTemplate.php
@@ -27,6 +27,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property int $allowed_clock_skew
  * @property string $signing_algorithm
  * @property ?string $custom_signing_key
+ * @property ?\DateTimeInterface $last_used_at
  * @property ?\DateTimeInterface $removed_at
  */
 class JwtTemplate extends Model
@@ -51,6 +52,9 @@ class JwtTemplate extends Model
 
     protected string $idPrefix = 'jtmpl_';
 
+    /** Minimum delete-grace window per OA-1 spec — 40h floor on top of `lifetime + allowed_clock_skew`. */
+    public const DELETE_GRACE_FLOOR_SECONDS = 40 * 3600;
+
     protected $fillable = [
         'environment_id',
         'name',
@@ -59,6 +63,7 @@ class JwtTemplate extends Model
         'allowed_clock_skew',
         'signing_algorithm',
         'custom_signing_key',
+        'last_used_at',
     ];
 
     protected $hidden = [
@@ -72,8 +77,19 @@ class JwtTemplate extends Model
             'lifetime' => 'integer',
             'allowed_clock_skew' => 'integer',
             'custom_signing_key' => 'encrypted',
+            'last_used_at' => 'immutable_datetime',
             'removed_at' => 'immutable_datetime',
         ];
+    }
+
+    /**
+     * The window during which delete must be refused with
+     * `jwt_template_in_use` after a recent render. Floors at 40h per
+     * OA-1 spec so long-lived verifier caches always have time to flush.
+     */
+    public function deleteGraceSeconds(): int
+    {
+        return max($this->lifetime + $this->allowed_clock_skew, self::DELETE_GRACE_FLOOR_SECONDS);
     }
 
     protected static function booted(): void

--- a/app/Services/Sessions/SessionTokenIssuer.php
+++ b/app/Services/Sessions/SessionTokenIssuer.php
@@ -74,6 +74,10 @@ final class SessionTokenIssuer
                 $session,
                 $this->orgForSession($session),
             );
+            // Stamp last_used_at so AU-4's BAPI DELETE can enforce the
+            // grace window before this template name vanishes from a
+            // long-lived verifier cache.
+            $row->forceFill(['last_used_at' => now()])->save();
             $expiresAt = now()->addSeconds($row->lifetime > 0 ? $row->lifetime : 60)->getTimestamp();
 
             return [

--- a/database/migrations/2026_05_14_000000_add_last_used_at_to_jwt_templates.php
+++ b/database/migrations/2026_05_14_000000_add_last_used_at_to_jwt_templates.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * v0.7 AU-4: track when each `JwtTemplate` was last used to render a
+ * token. The BAPI delete endpoint refuses with 409 `jwt_template_in_use`
+ * while `now - last_used_at < max(lifetime + allowed_clock_skew, 40h)`
+ * — long-lived verifier caches may still be carrying tokens minted
+ * under this name.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('jwt_templates', function (Blueprint $table): void {
+            $table->timestamp('last_used_at')->nullable()->after('custom_signing_key');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('jwt_templates', function (Blueprint $table): void {
+            $table->dropColumn('last_used_at');
+        });
+    }
+};

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Bapi\InstanceAppearanceController;
 use App\Http\Controllers\Bapi\InstanceController;
 use App\Http\Controllers\Bapi\InstanceLocalizationController;
 use App\Http\Controllers\Bapi\InvitationsController;
+use App\Http\Controllers\Bapi\JwtTemplateController;
 use App\Http\Controllers\Bapi\OauthProviderController;
 use App\Http\Controllers\Bapi\OrganizationController;
 use App\Http\Controllers\Bapi\OrganizationDomainChallengeController;
@@ -93,6 +94,13 @@ Route::get('/redirect-urls', [RedirectUrlsController::class, 'index'])->middlewa
 Route::post('/redirect-urls', [RedirectUrlsController::class, 'store'])->middleware(RateLimit::class.':redirect_urls.create,60,60');
 Route::get('/redirect-urls/{id}', [RedirectUrlsController::class, 'show'])->middleware(RateLimit::class.':redirect_urls.read,300,60');
 Route::delete('/redirect-urls/{id}', [RedirectUrlsController::class, 'destroy'])->middleware(RateLimit::class.':redirect_urls.destroy,60,60');
+
+// JWT templates (OA-1).
+Route::get('/jwt-templates', [JwtTemplateController::class, 'index'])->middleware(RateLimit::class.':jwt_templates.list,300,60')->name('bapi.jwt_templates.index');
+Route::post('/jwt-templates', [JwtTemplateController::class, 'store'])->middleware(RateLimit::class.':jwt_templates.create,30,60')->name('bapi.jwt_templates.store');
+Route::get('/jwt-templates/{jwt_template_id}', [JwtTemplateController::class, 'show'])->middleware(RateLimit::class.':jwt_templates.read,300,60')->name('bapi.jwt_templates.show');
+Route::patch('/jwt-templates/{jwt_template_id}', [JwtTemplateController::class, 'update'])->middleware(RateLimit::class.':jwt_templates.update,60,60')->name('bapi.jwt_templates.update');
+Route::delete('/jwt-templates/{jwt_template_id}', [JwtTemplateController::class, 'destroy'])->middleware(RateLimit::class.':jwt_templates.destroy,30,60')->name('bapi.jwt_templates.destroy');
 
 // Webhooks
 Route::get('/webhooks/endpoints', [WebhookEndpointsController::class, 'index'])->middleware(RateLimit::class.':webhooks.list,300,60');

--- a/tests/Feature/Http/Bapi/JwtTemplatesTest.php
+++ b/tests/Feature/Http/Bapi/JwtTemplatesTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\JwtTemplate;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+
+it('lists JWT templates filtered by env, paginated', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    JwtTemplate::factory()->create(['environment_id' => $f['env']->id, 'name' => 'one']);
+    JwtTemplate::factory()->create(['environment_id' => $f['env']->id, 'name' => 'two']);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/jwt-templates'));
+
+    $r->assertOk()
+        ->assertJsonPath('total_count', 2)
+        ->assertJsonPath('data.0.object', 'jwt_template');
+    expect($r->json('data.0.name'))->toBeIn(['one', 'two']);
+});
+
+it('creates a JWT template with defaults applied', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/jwt-templates'), [
+            'name' => 'supabase',
+            'claims' => [
+                'sub' => '{{user.id}}',
+                'email' => '{{user.primary_email}}',
+                'role' => 'authenticated',
+            ],
+        ]);
+
+    $r->assertCreated()
+        ->assertJsonPath('object', 'jwt_template')
+        ->assertJsonPath('name', 'supabase')
+        ->assertJsonPath('lifetime', 60)
+        ->assertJsonPath('allowed_clock_skew', 5)
+        ->assertJsonPath('signing_algorithm', 'RS256');
+    expect($r->json('claims.role'))->toBe('authenticated');
+    expect($r->headers->get('Cache-Control'))->toContain('no-store');
+});
+
+it('refuses a duplicate (env, name) with 409', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    JwtTemplate::factory()->create(['environment_id' => $f['env']->id, 'name' => 'pinned']);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/jwt-templates'), [
+            'name' => 'pinned',
+            'claims' => ['sub' => '{{user.id}}'],
+        ]);
+
+    $r->assertStatus(409)->assertJsonPath('errors.0.code', 'jwt_template_name_taken');
+});
+
+it('rejects names that do not match the slug pattern with 422', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    foreach (['NotLowercase', 'has space', '0starts-with-digit', str_repeat('a', 65)] as $bad) {
+        $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+            ->postJson(BapiTestSupport::url('/jwt-templates'), [
+                'name' => $bad,
+                'claims' => ['sub' => '{{user.id}}'],
+            ]);
+        $r->assertStatus(422);
+    }
+});
+
+it('shows + hides custom_signing_key on GET', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $template = JwtTemplate::factory()->withCustomSigningKey('--PEM--secret--')->create([
+        'environment_id' => $f['env']->id,
+        'name' => 'rotated',
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/jwt-templates/'.$template->id));
+
+    $r->assertOk()->assertJsonPath('name', 'rotated');
+    expect($r->json())->not->toHaveKey('custom_signing_key');
+});
+
+it('refuses PATCH that changes name or signing_algorithm with 422', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $template = JwtTemplate::factory()->create([
+        'environment_id' => $f['env']->id,
+        'name' => 'frozen',
+        'signing_algorithm' => 'RS256',
+    ]);
+
+    $r1 = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/jwt-templates/'.$template->id), ['name' => 'renamed']);
+    $r1->assertStatus(422)->assertJsonPath('errors.0.code', 'name_immutable');
+
+    $r2 = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/jwt-templates/'.$template->id), ['signing_algorithm' => 'HS256']);
+    $r2->assertStatus(422)->assertJsonPath('errors.0.code', 'signing_algorithm_immutable');
+});
+
+it('PATCH updates lifetime + claims and accepts no-op name / signing_algorithm', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $template = JwtTemplate::factory()->create([
+        'environment_id' => $f['env']->id,
+        'name' => 'apikit',
+        'signing_algorithm' => 'RS256',
+        'lifetime' => 60,
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/jwt-templates/'.$template->id), [
+            'name' => 'apikit', // same name allowed (no-op)
+            'signing_algorithm' => 'RS256', // same alg allowed
+            'lifetime' => 900,
+            'claims' => ['sub' => '{{user.external_id}}'],
+        ]);
+
+    $r->assertOk()->assertJsonPath('lifetime', 900);
+    expect($r->json('claims.sub'))->toBe('{{user.external_id}}');
+});
+
+it('PATCH custom_signing_key:null reverts to the env default signing key', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $template = JwtTemplate::factory()->withCustomSigningKey('--initial--')->create([
+        'environment_id' => $f['env']->id,
+        'name' => 'revertible',
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/jwt-templates/'.$template->id), [
+            'custom_signing_key' => null,
+        ]);
+
+    $r->assertOk();
+    expect($template->fresh()->custom_signing_key)->toBeNull();
+});
+
+it('DELETE soft-removes a never-used template and 404s subsequent GETs', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $template = JwtTemplate::factory()->create([
+        'environment_id' => $f['env']->id,
+        'name' => 'unused',
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->deleteJson(BapiTestSupport::url('/jwt-templates/'.$template->id));
+    $r->assertNoContent();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/jwt-templates/'.$template->id));
+    $r->assertStatus(404)->assertJsonPath('errors.0.code', 'jwt_template_not_found');
+});
+
+it('DELETE refuses with 409 jwt_template_in_use while inside the grace window', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $template = JwtTemplate::factory()->create([
+        'environment_id' => $f['env']->id,
+        'name' => 'busy',
+        'lifetime' => 600,
+        'allowed_clock_skew' => 10,
+    ]);
+    // Stamp a recent render — well inside the 40h floor.
+    $template->forceFill(['last_used_at' => now()->subMinutes(10)])->save();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->deleteJson(BapiTestSupport::url('/jwt-templates/'.$template->id));
+
+    $r->assertStatus(409)
+        ->assertJsonPath('errors.0.code', 'jwt_template_in_use');
+    expect($r->headers->get('Retry-After'))->not->toBeNull();
+});
+
+it('DELETE allows deletion once the grace window has elapsed', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $template = JwtTemplate::factory()->create([
+        'environment_id' => $f['env']->id,
+        'name' => 'expired-grace',
+        'lifetime' => 60,
+        'allowed_clock_skew' => 5,
+    ]);
+    // Last use beyond the 40h floor — fine to drop.
+    $template->forceFill(['last_used_at' => now()->subHours(41)])->save();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->deleteJson(BapiTestSupport::url('/jwt-templates/'.$template->id));
+
+    $r->assertNoContent();
+});
+
+it('GET / PATCH / DELETE return 404 for a JwtTemplate in another env', function (): void {
+    $f = BapiTestSupport::bootEnv('one');
+    $other = BapiTestSupport::bootEnv('two');
+    $template = JwtTemplate::factory()->create([
+        'environment_id' => $other['env']->id,
+        'name' => 'cross-env',
+    ]);
+
+    foreach (['GET', 'PATCH', 'DELETE'] as $method) {
+        $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+            ->json($method, BapiTestSupport::url('/jwt-templates/'.$template->id), $method === 'PATCH' ? ['lifetime' => 90] : []);
+        $r->assertStatus(404)->assertJsonPath('errors.0.code', 'jwt_template_not_found');
+    }
+});


### PR DESCRIPTION
Closes #240 (AU-4). Stacked on top of #256 (AU-3) — merge that first; this PR's base will retarget to main automatically once it lands.

## Summary

Operator-scoped CRUD for the AU-1 `JwtTemplate` model. Bearer-secret authenticated, env-pinned via the standard BAPI middleware. Response shape mirrors OA-1 spec exactly (`additionalProperties: false`).

```
GET    /v1/jwt-templates                  (paginated list)
POST   /v1/jwt-templates
GET    /v1/jwt-templates/{jwt_template_id}
PATCH  /v1/jwt-templates/{jwt_template_id}
DELETE /v1/jwt-templates/{jwt_template_id}
```

Per spec:

- `name` matches `^[a-z][a-z0-9_-]{0,63}$` (slug-shaped) and is unique within the environment.
- `name` AND `signing_algorithm` are immutable on PATCH — sending a different value returns 422. Same-value (no-op) is accepted so SDKs that round-trip the resource don't trip over their own writes.
- `custom_signing_key: null` on PATCH reverts to the env's default session-signing key.
- `custom_signing_key` is write-only — never returned by any read response.

DELETE soft-removes via `removed_at` and refuses (`409 jwt_template_in_use` + `Retry-After` header) when the template was used to mint a token within `max(lifetime + allowed_clock_skew, 40h)` — long-lived verifier caches may still hold rendered tokens. A new `jwt_templates.last_used_at` column tracks the most recent render; `SessionTokenIssuer` stamps it on every custom-template mint.

## Pest

Covers: list pagination, create + defaults, slug-pattern rejection, duplicate-name 409, `custom_signing_key` never returned, PATCH immutables (`name`, `signing_algorithm`), PATCH `lifetime` / `claims`, PATCH `custom_signing_key: null` revert, DELETE soft-remove, DELETE in-use 409 + `Retry-After`, DELETE allowed once grace elapses, cross-env 404 for GET/PATCH/DELETE.

## Out of scope (follow-ups)

- Webhook event emission (`jwtTemplate.{created,updated,deleted}` is wired but AU-15 will land the full event payload contract).
- Dashboard editor (AU-11).