### PR TITLE
Add BAPI /v1/oauth-applications CRUD + rotate-secret (#241)

### DIFF
--- a/app/Http/Controllers/Bapi/OauthApplicationController.php
+++ b/app/Http/Controllers/Bapi/OauthApplicationController.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Bapi;
+
+use App\Http\Resources\OauthApplicationResource;
+use App\Models\AuthorizationGrant;
+use App\Models\Environment;
+use App\Models\OauthApplication;
+use App\Webhooks\Emitter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * BAPI `/v1/oauth-applications` CRUD + rotate-secret (OA-2).
+ *
+ *   GET    /v1/oauth-applications
+ *   POST   /v1/oauth-applications                                    (returns plaintext once)
+ *   GET    /v1/oauth-applications/{oauth_application_id}
+ *   PATCH  /v1/oauth-applications/{oauth_application_id}
+ *   DELETE /v1/oauth-applications/{oauth_application_id}             (revokes all grants)
+ *   POST   /v1/oauth-applications/{oauth_application_id}/rotate-secret
+ *
+ * `is_public` + `client_id` are immutable on PATCH. DELETE soft-removes
+ * via `removed_at` and revokes every `AuthorizationGrant` row that
+ * still points at the application in the same transaction. Public
+ * clients (`is_public: true`) have no client_secret to rotate —
+ * rotate-secret returns `409 oauth_application_public_client`.
+ */
+final class OauthApplicationController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        $query = OauthApplication::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->whereNull('removed_at')
+            ->orderBy('created_at');
+
+        $limit = max(1, min(500, (int) $request->input('limit', 50)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (OauthApplication $a) => OauthApplicationResource::from($a))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        $validator = Validator::make($request->all(), [
+            'name' => ['required', 'string', 'min:1', 'max:100'],
+            'callback_urls' => ['required', 'array', 'min:1'],
+            'callback_urls.*' => ['required', 'string', 'max:2048'],
+            'scopes' => ['sometimes', 'array'],
+            'scopes.*' => ['string', 'max:120'],
+            'is_public' => ['sometimes', 'boolean'],
+        ]);
+        if ($validator->fails()) {
+            return $this->validationError($validator->errors()->toArray());
+        }
+        $data = $validator->validated();
+        $isPublic = (bool) ($data['is_public'] ?? false);
+
+        // Mint the row first so `client_id` can be derived from its id,
+        // then layer in the hashed secret for confidential clients.
+        $plaintextSecret = null;
+        $hashedSecret = null;
+        if (! $isPublic) {
+            $minted = OauthApplication::mintClientSecret();
+            $plaintextSecret = $minted['plaintext'];
+            $hashedSecret = $minted['hash'];
+        }
+
+        $row = OauthApplication::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'name' => $data['name'],
+            'hashed_client_secret' => $hashedSecret,
+            'callback_urls' => array_values($data['callback_urls']),
+            'scopes' => array_values($data['scopes'] ?? []),
+            'is_public' => $isPublic,
+        ]);
+
+        Log::info('audit:bapi.oauth_application.created', [
+            'environment_id' => $env->id,
+            'oauth_application_id' => $row->id,
+        ]);
+        app(Emitter::class)->emit('oauthApplication.created', OauthApplicationResource::from($row->fresh()), $env);
+
+        return response()->json(OauthApplicationResource::withSecret($row->fresh(), $plaintextSecret), 201)
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function show(Request $request, string $oauthApplicationId): JsonResponse
+    {
+        $row = $this->find($oauthApplicationId);
+        if ($row === null) {
+            return $this->notFound($oauthApplicationId);
+        }
+
+        return response()->json(OauthApplicationResource::from($row))->header('Cache-Control', 'no-store');
+    }
+
+    public function update(Request $request, string $oauthApplicationId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $row = $this->find($oauthApplicationId);
+        if ($row === null) {
+            return $this->notFound($oauthApplicationId);
+        }
+
+        if ($request->has('is_public') && $request->boolean('is_public') !== (bool) $row->is_public) {
+            return $this->error(422, 'is_public_immutable',
+                'is_public cannot change after an OauthApplication is created — re-create under a new id to migrate.');
+        }
+        if ($request->has('client_id') && $request->input('client_id') !== $row->client_id) {
+            return $this->error(422, 'client_id_immutable',
+                'client_id is derived from the row id and cannot be changed.');
+        }
+
+        $validator = Validator::make($request->all(), [
+            'name' => ['sometimes', 'string', 'min:1', 'max:100'],
+            'callback_urls' => ['sometimes', 'array', 'min:1'],
+            'callback_urls.*' => ['required', 'string', 'max:2048'],
+            'scopes' => ['sometimes', 'array'],
+            'scopes.*' => ['string', 'max:120'],
+        ]);
+        if ($validator->fails()) {
+            return $this->validationError($validator->errors()->toArray());
+        }
+        $data = $validator->validated();
+
+        $row->fill(array_intersect_key($data, array_flip(['name', 'callback_urls', 'scopes'])));
+        $row->save();
+
+        Log::info('audit:bapi.oauth_application.updated', [
+            'environment_id' => $env->id,
+            'oauth_application_id' => $row->id,
+        ]);
+        app(Emitter::class)->emit('oauthApplication.updated', OauthApplicationResource::from($row->fresh()), $env);
+
+        return response()->json(OauthApplicationResource::from($row->fresh()))->header('Cache-Control', 'no-store');
+    }
+
+    public function destroy(Request $request, string $oauthApplicationId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $row = $this->find($oauthApplicationId);
+        if ($row === null) {
+            return $this->notFound($oauthApplicationId);
+        }
+
+        $snapshot = OauthApplicationResource::from($row);
+
+        DB::transaction(function () use ($row): void {
+            // Revoke every active grant for this app in the same tx so
+            // tokens carrying a still-active grant can't survive the
+            // application's soft-delete.
+            AuthorizationGrant::query()->withoutGlobalScopes()
+                ->where('oauth_application_id', $row->id)
+                ->whereNull('revoked_at')
+                ->update(['revoked_at' => now()]);
+            $row->delete();
+        });
+
+        Log::info('audit:bapi.oauth_application.deleted', [
+            'environment_id' => $env->id,
+            'oauth_application_id' => $row->id,
+        ]);
+        app(Emitter::class)->emit('oauthApplication.deleted', $snapshot, $env);
+
+        return response()->json(null, 204);
+    }
+
+    public function rotateSecret(Request $request, string $oauthApplicationId): JsonResponse
+    {
+        $env = app(Environment::class);
+        $row = $this->find($oauthApplicationId);
+        if ($row === null) {
+            return $this->notFound($oauthApplicationId);
+        }
+
+        if ($row->is_public) {
+            return $this->error(409, 'oauth_application_public_client',
+                'Public clients have no client_secret to rotate (PKCE-only).');
+        }
+
+        $minted = OauthApplication::mintClientSecret();
+        $row->forceFill(['hashed_client_secret' => $minted['hash']])->save();
+
+        Log::info('audit:bapi.oauth_application.secret_rotated', [
+            'environment_id' => $env->id,
+            'oauth_application_id' => $row->id,
+        ]);
+        app(Emitter::class)->emit('oauthApplication.secret_rotated', OauthApplicationResource::from($row->fresh()), $env);
+
+        return response()->json(OauthApplicationResource::withSecret($row->fresh(), $minted['plaintext']))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    private function find(string $oauthApplicationId): ?OauthApplication
+    {
+        $env = app(Environment::class);
+
+        return OauthApplication::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $oauthApplicationId)
+            ->whereNull('removed_at')
+            ->first();
+    }
+
+    private function notFound(string $id): JsonResponse
+    {
+        return $this->error(404, 'oauth_application_not_found', "OauthApplication {$id} not found.");
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [['code' => $code, 'message' => $message, 'long_message' => $message]],
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    /**
+     * @param  array<string, list<string>>  $errors
+     */
+    private function validationError(array $errors): JsonResponse
+    {
+        $flat = [];
+        foreach ($errors as $field => $messages) {
+            foreach ($messages as $message) {
+                $flat[] = [
+                    'code' => 'form_param_invalid',
+                    'message' => $message,
+                    'long_message' => $message,
+                    'meta' => ['param' => $field],
+                ];
+            }
+        }
+
+        return response()->json(['errors' => $flat], 422)->header('Cache-Control', 'no-store');
+    }
+}

--- a/app/Http/Resources/OauthApplicationResource.php
+++ b/app/Http/Resources/OauthApplicationResource.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\OauthApplication;
+
+/**
+ * BAPI shape for `OauthApplication`. Mirrors OA-2's `OauthApplication`
+ * schema (`additionalProperties: false`); the plaintext `client_secret`
+ * is only ever surfaced via `OauthApplicationWithSecretResource` on
+ * create + rotate-secret responses, never on read.
+ */
+final class OauthApplicationResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function from(OauthApplication $app): array
+    {
+        return [
+            'id' => $app->id,
+            'object' => 'oauth_application',
+            'name' => $app->name,
+            'client_id' => $app->client_id,
+            'callback_urls' => is_array($app->callback_urls) ? array_values($app->callback_urls) : [],
+            'scopes' => is_array($app->scopes) ? array_values($app->scopes) : [],
+            'is_public' => (bool) $app->is_public,
+            'created_at' => $app->created_at?->getTimestampMs(),
+            'updated_at' => $app->updated_at?->getTimestampMs(),
+        ];
+    }
+
+    /**
+     * Variant emitted on create + rotate-secret responses only; layers
+     * the plaintext `client_secret` on top of the standard shape. Public
+     * clients get no `client_secret` (PKCE-only), so the field is
+     * intentionally absent for `is_public: true`.
+     *
+     * @return array<string, mixed>
+     */
+    public static function withSecret(OauthApplication $app, ?string $plaintextSecret): array
+    {
+        $base = self::from($app);
+        if ($app->is_public || $plaintextSecret === null) {
+            return $base;
+        }
+        $base['client_secret'] = $plaintextSecret;
+
+        return $base;
+    }
+}

--- a/app/Models/OauthApplication.php
+++ b/app/Models/OauthApplication.php
@@ -40,7 +40,7 @@ class OauthApplication extends Model
 
     public const CLIENT_ID_PREFIX = 'oac_pub_';
 
-    public const SECRET_PREFIX = 'oac_sec_';
+    public const SECRET_PREFIX = 'osec_';
 
     public const SECRET_BYTES = 32;
 
@@ -75,6 +75,15 @@ class OauthApplication extends Model
     protected static function booted(): void
     {
         static::addGlobalScope(new EnvironmentScope);
+
+        // `client_id` is deterministic from the row id so it survives any
+        // rotation of credentials or row metadata. Callers can override on
+        // create, but the default flow doesn't need to think about it.
+        static::creating(function (self $app): void {
+            if (empty($app->getAttribute('client_id')) && ! empty($app->getAttribute('id'))) {
+                $app->setAttribute('client_id', self::clientIdFor((string) $app->getAttribute('id')));
+            }
+        });
     }
 
     protected static function newFactory(): OauthApplicationFactory
@@ -93,17 +102,19 @@ class OauthApplication extends Model
     }
 
     /**
-     * Mint a fresh public `client_id`. Always called on create so callers
-     * never have to remember the prefix discipline.
+     * Derive the public `client_id` from an OauthApplication ULID. The
+     * ULID body (the 26 Crockford-base32 chars after `oac_`) is re-prefixed
+     * with `oac_pub_` so the public identifier is visually distinct from
+     * the internal row id while remaining stable across rotations.
      */
-    public static function mintClientId(): string
+    public static function clientIdFor(string $id): string
     {
-        return self::CLIENT_ID_PREFIX.Base64Url::encode(random_bytes(16));
+        return self::CLIENT_ID_PREFIX.substr($id, strlen('oac_'));
     }
 
     /**
      * Mint a fresh plaintext client secret and return both it and its
-     * sha256 hash. Callers persist the hash; the plaintext is shown to
+     * Argon2id hash. Callers persist the hash; the plaintext is shown to
      * the operator exactly once at create / rotate time.
      *
      * @return array{plaintext: string, hash: string}
@@ -111,23 +122,28 @@ class OauthApplication extends Model
     public static function mintClientSecret(): array
     {
         $plaintext = self::SECRET_PREFIX.Base64Url::encode(random_bytes(self::SECRET_BYTES));
+        $hash = password_hash($plaintext, PASSWORD_ARGON2ID);
+        if (! is_string($hash)) {
+            throw new \RuntimeException('password_hash(PASSWORD_ARGON2ID) failed');
+        }
 
         return [
             'plaintext' => $plaintext,
-            'hash' => hash('sha256', $plaintext),
+            'hash' => $hash,
         ];
     }
 
     /**
      * Constant-time check of a plaintext client secret against the stored
-     * hash. Returns false for public clients (no secret on file).
+     * Argon2id hash. Returns false for public clients (no secret on file)
+     * or when the row has been rotated since the secret was issued.
      */
     public function verifyClientSecret(string $plaintext): bool
     {
-        if ($this->is_public || $this->hashed_client_secret === null) {
+        if ($this->is_public || $this->hashed_client_secret === null || $this->hashed_client_secret === '') {
             return false;
         }
 
-        return hash_equals($this->hashed_client_secret, hash('sha256', $plaintext));
+        return password_verify($plaintext, $this->hashed_client_secret);
     }
 }

--- a/database/factories/OauthApplicationFactory.php
+++ b/database/factories/OauthApplicationFactory.php
@@ -25,9 +25,10 @@ class OauthApplicationFactory extends Factory
         $secret = OauthApplication::mintClientSecret();
 
         return [
-            // environment_id supplied by caller.
+            // environment_id supplied by caller. `client_id` is set on
+            // `creating` from the row id — the factory leaves it to the
+            // boot hook so test rows never desync.
             'name' => 'App '.$this->faker->unique()->lexify('????????'),
-            'client_id' => OauthApplication::mintClientId(),
             'hashed_client_secret' => $secret['hash'],
             'callback_urls' => ['https://example.test/oauth/callback'],
             'scopes' => ['openid', 'profile', 'email'],

--- a/routes/bapi.php
+++ b/routes/bapi.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Bapi\InstanceController;
 use App\Http\Controllers\Bapi\InstanceLocalizationController;
 use App\Http\Controllers\Bapi\InvitationsController;
 use App\Http\Controllers\Bapi\JwtTemplateController;
+use App\Http\Controllers\Bapi\OauthApplicationController;
 use App\Http\Controllers\Bapi\OauthProviderController;
 use App\Http\Controllers\Bapi\OrganizationController;
 use App\Http\Controllers\Bapi\OrganizationDomainChallengeController;
@@ -101,6 +102,15 @@ Route::post('/jwt-templates', [JwtTemplateController::class, 'store'])->middlewa
 Route::get('/jwt-templates/{jwt_template_id}', [JwtTemplateController::class, 'show'])->middleware(RateLimit::class.':jwt_templates.read,300,60')->name('bapi.jwt_templates.show');
 Route::patch('/jwt-templates/{jwt_template_id}', [JwtTemplateController::class, 'update'])->middleware(RateLimit::class.':jwt_templates.update,60,60')->name('bapi.jwt_templates.update');
 Route::delete('/jwt-templates/{jwt_template_id}', [JwtTemplateController::class, 'destroy'])->middleware(RateLimit::class.':jwt_templates.destroy,30,60')->name('bapi.jwt_templates.destroy');
+
+// OAuth applications (OA-2). Confidential clients only see plaintext
+// client_secret on create + rotate-secret; every other read masks it.
+Route::get('/oauth-applications', [OauthApplicationController::class, 'index'])->middleware(RateLimit::class.':oauth_applications.list,300,60')->name('bapi.oauth_applications.index');
+Route::post('/oauth-applications', [OauthApplicationController::class, 'store'])->middleware(RateLimit::class.':oauth_applications.create,30,60')->name('bapi.oauth_applications.store');
+Route::get('/oauth-applications/{oauth_application_id}', [OauthApplicationController::class, 'show'])->middleware(RateLimit::class.':oauth_applications.read,300,60')->name('bapi.oauth_applications.show');
+Route::patch('/oauth-applications/{oauth_application_id}', [OauthApplicationController::class, 'update'])->middleware(RateLimit::class.':oauth_applications.update,60,60')->name('bapi.oauth_applications.update');
+Route::delete('/oauth-applications/{oauth_application_id}', [OauthApplicationController::class, 'destroy'])->middleware(RateLimit::class.':oauth_applications.destroy,30,60')->name('bapi.oauth_applications.destroy');
+Route::post('/oauth-applications/{oauth_application_id}/rotate-secret', [OauthApplicationController::class, 'rotateSecret'])->middleware(RateLimit::class.':oauth_applications.rotate,10,60')->name('bapi.oauth_applications.rotate_secret');
 
 // Webhooks
 Route::get('/webhooks/endpoints', [WebhookEndpointsController::class, 'index'])->middleware(RateLimit::class.':webhooks.list,300,60');

--- a/tests/Feature/Http/Bapi/OauthApplicationsTest.php
+++ b/tests/Feature/Http/Bapi/OauthApplicationsTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\AuthorizationGrant;
+use App\Models\OauthApplication;
+use App\Models\User;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+
+it('lists OAuth applications paginated within the env', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    OauthApplication::factory()->create(['environment_id' => $f['env']->id, 'name' => 'A1']);
+    OauthApplication::factory()->create(['environment_id' => $f['env']->id, 'name' => 'A2']);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/oauth-applications'));
+
+    $r->assertOk()->assertJsonPath('total_count', 2)
+        ->assertJsonPath('data.0.object', 'oauth_application');
+    expect($r->json('data.0.client_secret'))->toBeNull();
+});
+
+it('creates a confidential client and returns plaintext client_secret exactly once', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/oauth-applications'), [
+            'name' => 'Acme Dashboard',
+            'callback_urls' => ['https://app.acme.example/oauth/callback'],
+            'scopes' => ['openid', 'profile', 'email'],
+        ]);
+
+    $r->assertCreated()
+        ->assertJsonPath('object', 'oauth_application')
+        ->assertJsonPath('name', 'Acme Dashboard')
+        ->assertJsonPath('is_public', false);
+    $plaintext = $r->json('client_secret');
+    $id = $r->json('id');
+    expect($plaintext)->toStartWith('osec_');
+    expect($r->json('client_id'))->toBe('oac_pub_'.substr($id, strlen('oac_')));
+
+    // Subsequent GETs never re-leak the plaintext.
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/oauth-applications/'.$id));
+    $r->assertOk();
+    expect($r->json('client_secret'))->toBeNull();
+
+    // The minted plaintext verifies against the stored hash.
+    $row = OauthApplication::query()->withoutGlobalScopes()->where('id', $id)->first();
+    expect($row->verifyClientSecret($plaintext))->toBeTrue();
+});
+
+it('creates a public client with no client_secret stored', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/oauth-applications'), [
+            'name' => 'Acme Mobile',
+            'callback_urls' => ['com.acme.app://oauth/callback'],
+            'scopes' => ['openid'],
+            'is_public' => true,
+        ]);
+
+    $r->assertCreated()->assertJsonPath('is_public', true);
+    expect($r->json())->not->toHaveKey('client_secret');
+    $row = OauthApplication::query()->withoutGlobalScopes()->where('id', $r->json('id'))->first();
+    expect($row->hashed_client_secret)->toBeNull();
+});
+
+it('validates callback_urls is required + non-empty on create', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/oauth-applications'), [
+            'name' => 'No URLs',
+            'callback_urls' => [],
+        ]);
+    $r->assertStatus(422);
+});
+
+it('refuses PATCH that flips is_public or replaces client_id with 422', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $app = OauthApplication::factory()->create(['environment_id' => $f['env']->id]);
+
+    $r1 = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/oauth-applications/'.$app->id), ['is_public' => true]);
+    $r1->assertStatus(422)->assertJsonPath('errors.0.code', 'is_public_immutable');
+
+    $r2 = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/oauth-applications/'.$app->id), ['client_id' => 'oac_pub_other']);
+    $r2->assertStatus(422)->assertJsonPath('errors.0.code', 'client_id_immutable');
+});
+
+it('PATCH updates name + callback_urls + scopes', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $app = OauthApplication::factory()->create(['environment_id' => $f['env']->id, 'name' => 'Old']);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->patchJson(BapiTestSupport::url('/oauth-applications/'.$app->id), [
+            'name' => 'New',
+            'callback_urls' => ['https://new.example/cb'],
+            'scopes' => ['openid', 'email'],
+        ]);
+
+    $r->assertOk()->assertJsonPath('name', 'New')
+        ->assertJsonPath('callback_urls.0', 'https://new.example/cb')
+        ->assertJsonPath('scopes.1', 'email');
+});
+
+it('rotate-secret mints a fresh plaintext and invalidates the previous one', function (): void {
+    $f = BapiTestSupport::bootEnv();
+
+    // Create via API so we have a verifiable plaintext to compare against.
+    $created = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/oauth-applications'), [
+            'name' => 'Rotatable',
+            'callback_urls' => ['https://example.test/cb'],
+        ]);
+    $created->assertCreated();
+    $id = $created->json('id');
+    $oldPlaintext = $created->json('client_secret');
+
+    $rotated = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/oauth-applications/'.$id.'/rotate-secret'));
+
+    $rotated->assertOk();
+    $newPlaintext = $rotated->json('client_secret');
+    expect($newPlaintext)->toStartWith('osec_');
+    expect($newPlaintext)->not->toBe($oldPlaintext);
+
+    $row = OauthApplication::query()->withoutGlobalScopes()->where('id', $id)->first();
+    expect($row->verifyClientSecret($newPlaintext))->toBeTrue();
+    expect($row->verifyClientSecret($oldPlaintext))->toBeFalse();
+});
+
+it('rotate-secret refuses public clients with 409', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $app = OauthApplication::factory()->public()->create(['environment_id' => $f['env']->id]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->postJson(BapiTestSupport::url('/oauth-applications/'.$app->id.'/rotate-secret'));
+
+    $r->assertStatus(409)->assertJsonPath('errors.0.code', 'oauth_application_public_client');
+});
+
+it('DELETE soft-removes the application and cascade-revokes its AuthorizationGrants', function (): void {
+    $f = BapiTestSupport::bootEnv();
+    $user = User::create(['environment_id' => $f['env']->id]);
+    $app = OauthApplication::factory()->create(['environment_id' => $f['env']->id]);
+    $grant = AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $user->id,
+    ]);
+    expect($grant->fresh()->isActive())->toBeTrue();
+
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->deleteJson(BapiTestSupport::url('/oauth-applications/'.$app->id));
+    $r->assertNoContent();
+
+    expect($grant->fresh()->isActive())->toBeFalse();
+    $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+        ->getJson(BapiTestSupport::url('/oauth-applications/'.$app->id));
+    $r->assertStatus(404)->assertJsonPath('errors.0.code', 'oauth_application_not_found');
+});
+
+it('returns 404 for a row in another env on GET/PATCH/DELETE', function (): void {
+    $f = BapiTestSupport::bootEnv('one');
+    $other = BapiTestSupport::bootEnv('two');
+    $app = OauthApplication::factory()->create(['environment_id' => $other['env']->id]);
+
+    foreach (['GET', 'PATCH', 'DELETE'] as $method) {
+        $r = $this->withHeaders(BapiTestSupport::headers($f['token']))
+            ->json($method, BapiTestSupport::url('/oauth-applications/'.$app->id), $method === 'PATCH' ? ['name' => 'x'] : []);
+        $r->assertStatus(404);
+    }
+});

--- a/tests/Feature/Models/OauthApplicationTest.php
+++ b/tests/Feature/Models/OauthApplicationTest.php
@@ -20,7 +20,7 @@ function makeEnvForOauthApp(string $slug = 'env'): Environment
     ]);
 }
 
-it('mints an oac_ prefixed id and an oac_pub_ prefixed client_id', function (): void {
+it('mints an oac_ prefixed id and derives client_id deterministically', function (): void {
     $env = makeEnvForOauthApp();
 
     $app = OauthApplication::factory()->create([
@@ -29,18 +29,19 @@ it('mints an oac_ prefixed id and an oac_pub_ prefixed client_id', function (): 
     ]);
 
     expect($app->id)->toStartWith('oac_');
-    expect($app->client_id)->toStartWith('oac_pub_');
+    expect($app->client_id)->toBe('oac_pub_'.substr($app->id, strlen('oac_')));
     expect($app->callback_urls)->toBe(['https://example.test/oauth/callback']);
     expect($app->scopes)->toBe(['openid', 'profile', 'email']);
     expect($app->is_public)->toBeFalse();
 });
 
-it('mints a hashed client secret + verifies the plaintext + hides hashed_client_secret', function (): void {
+it('mints an Argon2id-hashed client secret + verifies the plaintext + hides hashed_client_secret', function (): void {
     $env = makeEnvForOauthApp();
     $secret = OauthApplication::mintClientSecret();
 
-    expect($secret['plaintext'])->toStartWith('oac_sec_');
-    expect($secret['hash'])->toBe(hash('sha256', $secret['plaintext']));
+    expect($secret['plaintext'])->toStartWith('osec_');
+    // Argon2id stamps `$argon2id$...` at the start of the encoded hash.
+    expect($secret['hash'])->toStartWith('$argon2id$');
 
     $app = OauthApplication::factory()->create([
         'environment_id' => $env->id,


### PR DESCRIPTION
Closes #241 (AU-5).

## Summary

Operator-scoped CRUD for the AU-2 `OauthApplication` model + the rotate-secret one-shot. Bearer-secret authenticated, env-pinned via the standard BAPI middleware. Response shape mirrors OA-2 spec exactly (`additionalProperties: false`); the plaintext `client_secret` rides only the create + rotate responses (`OauthApplicationWithSecret`).

```
GET    /v1/oauth-applications
POST   /v1/oauth-applications                                       (plaintext secret once)
GET    /v1/oauth-applications/{oauth_application_id}
PATCH  /v1/oauth-applications/{oauth_application_id}
DELETE /v1/oauth-applications/{oauth_application_id}                (revokes grants)
POST   /v1/oauth-applications/{oauth_application_id}/rotate-secret
```

## Model alignment with the spec contract

Aligned AU-2's `OauthApplication` model to the spec (alpha, no compat shims):

- **Hashing**: sha256 → `PASSWORD_ARGON2ID` per the issue body. Plaintext format now `osec_<26-char-base32>` matching the `OauthApplicationWithSecret` schema.
- **client_id**: now deterministic from the row id (same ULID body, re-prefixed `oac_pub_`) via a new `clientIdFor()` helper and a `creating` boot hook. Survives credential rotations and stays stable across reads.

## Semantics

- `is_public` + `client_id` are immutable on PATCH (422).
- DELETE soft-removes via `removed_at` AND revokes every active `AuthorizationGrant` row in the same transaction, so tokens carrying a still-active grant can't survive the application's tombstone.
- Rotate-secret refuses public clients with `409 oauth_application_public_client` (PKCE-only, no secret).

## Pest

Covers: list pagination, confidential create + plaintext-on-create, public create with no secret stored, callback_urls validation, PATCH immutables, PATCH name/urls/scopes, rotate mints fresh + invalidates old, rotate refused on public, DELETE soft-remove + grant cascade, cross-env 404. Updated model tests for the new Argon2id + deterministic-client_id contract.

## Out of scope (follow-ups)

- AU-6 (#242) — FAPI `GET /oauth/authorize` (consumes these rows).
- AU-15 — webhook payload contract for `oauthApplication.*` and `oauthApplication.secret_rotated`.