### PR TITLE
Add FAPI GET /oauth/authorize (#242)

### DIFF
--- a/app/Http/Controllers/Fapi/OauthAuthorizeController.php
+++ b/app/Http/Controllers/Fapi/OauthAuthorizeController.php
@@ -1,0 +1,305 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Models\AuthorizationGrant;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\OauthApplication;
+use App\Models\Session;
+use App\Services\Client\ClientResolver;
+use App\Support\Base64Url;
+use App\Support\Url;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * v0.7 OAuth provider mode entry point — RFC 6749 §4.1 + OIDC §3.1.2.
+ *
+ *   GET /oauth/authorize?client_id=&redirect_uri=&response_type=code
+ *                       &scope=&state=&nonce=&code_challenge=
+ *                       &code_challenge_method=S256&prompt=
+ *
+ * Outcome routing (all 302s ride Cache-Control: no-store):
+ *
+ *   - No active session  →  /sign-in?continue_url=<this URL>
+ *   - First-time consent →  /oauth/consent/{request_id}     (AU-9)
+ *   - Silent reuse       →  <redirect_uri>?code=…&state=…
+ *
+ * `client_id` and `redirect_uri` errors return JSON 400 — redirecting to
+ * an unvetted URL with `error=` would leak the validation outcome to a
+ * caller-controlled domain. Every later validation error (scope, PKCE,
+ * etc.) rides the redirect back to `redirect_uri` per RFC 6749 §4.1.2.1.
+ */
+final class OauthAuthorizeController
+{
+    public const REQUEST_CONTEXT_TTL_SECONDS = 10 * 60;
+
+    public const AUTHORIZATION_CODE_TTL_SECONDS = 5 * 60;
+
+    public function __construct(private readonly ClientResolver $clientResolver) {}
+
+    public function __invoke(Request $request): JsonResponse|RedirectResponse|Response
+    {
+        $env = app(Environment::class);
+
+        // --- Step 1+2: validate client_id + redirect_uri (JSON 400 on miss).
+
+        $clientIdParam = (string) $request->query('client_id', '');
+        $redirectUri = (string) $request->query('redirect_uri', '');
+        if ($clientIdParam === '' || $redirectUri === '') {
+            return $this->jsonError(400, 'oauth_invalid_request',
+                'client_id and redirect_uri are required.');
+        }
+
+        $app = OauthApplication::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('client_id', $clientIdParam)
+            ->whereNull('removed_at')
+            ->first();
+        if ($app === null) {
+            return $this->jsonError(400, 'oauth_invalid_client',
+                'Unknown client_id.');
+        }
+        $callbackUrls = is_array($app->callback_urls) ? $app->callback_urls : [];
+        if (! in_array($redirectUri, $callbackUrls, true)) {
+            return $this->jsonError(400, 'oauth_invalid_redirect_uri',
+                'redirect_uri is not on the application\'s callback_urls allowlist.');
+        }
+
+        // --- Step 3+: validation errors below ride the redirect with
+        // `error=…&state=…` (RFC 6749 §4.1.2.1).
+
+        $state = (string) $request->query('state', '');
+        if ($state === '') {
+            return $this->errorRedirect($redirectUri, 'invalid_request', 'state is required', '');
+        }
+
+        $responseType = (string) $request->query('response_type', '');
+        if ($responseType !== 'code') {
+            return $this->errorRedirect($redirectUri, 'unsupported_response_type',
+                'Only response_type=code is supported.', $state);
+        }
+
+        $rawScope = trim((string) $request->query('scope', ''));
+        if ($rawScope === '') {
+            return $this->errorRedirect($redirectUri, 'invalid_scope', 'scope is required.', $state);
+        }
+        $requestedScopes = array_values(array_filter(
+            preg_split('/\s+/', $rawScope) ?: [],
+            static fn ($s) => is_string($s) && $s !== '',
+        ));
+        $appScopes = is_array($app->scopes) ? $app->scopes : [];
+        $extras = array_values(array_diff($requestedScopes, $appScopes));
+        if (! empty($extras)) {
+            return $this->errorRedirect($redirectUri, 'invalid_scope',
+                'Requested scopes are not registered on the application: '.implode(' ', $extras),
+                $state);
+        }
+
+        // OIDC: nonce required when `openid` is in the scope set.
+        $nonce = (string) $request->query('nonce', '');
+        if (in_array('openid', $requestedScopes, true) && $nonce === '') {
+            return $this->errorRedirect($redirectUri, 'invalid_request',
+                'nonce is required when the openid scope is requested.', $state);
+        }
+
+        // PKCE: required for public clients; method must be S256.
+        $codeChallenge = (string) $request->query('code_challenge', '');
+        $codeChallengeMethod = (string) $request->query('code_challenge_method', '');
+        if ($app->is_public) {
+            if ($codeChallenge === '' || $codeChallengeMethod === '') {
+                return $this->errorRedirect($redirectUri, 'invalid_request',
+                    'code_challenge + code_challenge_method=S256 are required for public clients.',
+                    $state);
+            }
+        }
+        if ($codeChallenge !== '' && $codeChallengeMethod !== 'S256') {
+            return $this->errorRedirect($redirectUri, 'invalid_request',
+                'Only code_challenge_method=S256 is supported.', $state);
+        }
+
+        $prompt = (string) $request->query('prompt', '');
+
+        // --- Resolve the calling user from the __client cookie + live session.
+        $client = $this->clientResolver->fromCookie(
+            (string) ($request->cookie('__client') ?? ''),
+            $env,
+        );
+        $session = $client !== null ? $this->liveSessionFor($client) : null;
+
+        if ($session === null) {
+            if ($prompt === 'none') {
+                return $this->errorRedirect($redirectUri, 'login_required',
+                    'No active session and prompt=none was supplied.', $state);
+            }
+
+            $signInUrl = Url::accountPortal($env, '/sign-in').'?continue_url='.urlencode($request->fullUrl());
+
+            return $this->result($request, $signInUrl);
+        }
+
+        // --- Silent reuse?
+        $scopesHash = AuthorizationGrant::hashScopes($requestedScopes);
+        $grant = AuthorizationGrant::query()->withoutGlobalScopes()
+            ->where('user_id', $session->user_id)
+            ->where('oauth_application_id', $app->id)
+            ->where('scopes_hash', $scopesHash)
+            ->whereNull('revoked_at')
+            ->first();
+
+        if ($grant !== null && $prompt !== 'consent' && $prompt !== 'select_account') {
+            $code = $this->mintAuthorizationCode(
+                env: $env,
+                app: $app,
+                userId: $session->user_id,
+                scopes: $requestedScopes,
+                redirectUri: $redirectUri,
+                codeChallenge: $codeChallenge !== '' ? $codeChallenge : null,
+                codeChallengeMethod: $codeChallengeMethod !== '' ? $codeChallengeMethod : null,
+                nonce: $nonce !== '' ? $nonce : null,
+                state: $state,
+            );
+            $target = $this->appendQuery($redirectUri, [
+                'code' => $code,
+                'state' => $state,
+            ]);
+
+            return $this->result($request, $target);
+        }
+
+        // --- Park the request for the consent page (AU-9).
+        $requestId = $this->parkRequestContext($env, $app, [
+            'client_id' => $app->client_id,
+            'redirect_uri' => $redirectUri,
+            'scope' => implode(' ', $requestedScopes),
+            'state' => $state,
+            'nonce' => $nonce,
+            'code_challenge' => $codeChallenge,
+            'code_challenge_method' => $codeChallengeMethod,
+            'prompt' => $prompt,
+        ]);
+
+        $consentUrl = Url::accountPortal($env, '/oauth/consent/'.$requestId);
+
+        return $this->result($request, $consentUrl);
+    }
+
+    private function liveSessionFor(Client $client): ?Session
+    {
+        return Session::query()
+            ->where('client_id', $client->id)
+            ->whereIn('status', Session::LIVE_STATUSES)
+            ->orderByDesc('last_active_at')
+            ->first();
+    }
+
+    /**
+     * @param  list<string>  $scopes
+     */
+    private function mintAuthorizationCode(
+        Environment $env,
+        OauthApplication $app,
+        string $userId,
+        array $scopes,
+        string $redirectUri,
+        ?string $codeChallenge,
+        ?string $codeChallengeMethod,
+        ?string $nonce,
+        string $state,
+    ): string {
+        $code = 'oacd_'.Base64Url::encode(random_bytes(32));
+        DB::table('oauth_authorization_codes')->insert([
+            'code' => $code,
+            'environment_id' => $env->id,
+            'oauth_application_id' => $app->id,
+            'user_id' => $userId,
+            'scopes' => json_encode($scopes, JSON_THROW_ON_ERROR),
+            'redirect_uri' => $redirectUri,
+            'code_challenge' => $codeChallenge,
+            'code_challenge_method' => $codeChallengeMethod,
+            'nonce' => $nonce,
+            'state' => $state,
+            'expires_at' => now()->addSeconds(self::AUTHORIZATION_CODE_TTL_SECONDS),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // Opportunistic GC keeps the table small.
+        DB::table('oauth_authorization_codes')->where('expires_at', '<', now()->subMinutes(10))->delete();
+
+        return $code;
+    }
+
+    /**
+     * @param  array<string, string>  $params
+     */
+    private function parkRequestContext(Environment $env, OauthApplication $app, array $params): string
+    {
+        $requestId = 'oareq_'.Base64Url::encode(random_bytes(24));
+        DB::table('oauth_request_contexts')->insert([
+            'request_id' => $requestId,
+            'environment_id' => $env->id,
+            'oauth_application_id' => $app->id,
+            'params' => json_encode($params, JSON_THROW_ON_ERROR),
+            'expires_at' => now()->addSeconds(self::REQUEST_CONTEXT_TTL_SECONDS),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('oauth_request_contexts')->where('expires_at', '<', now()->subMinutes(10))->delete();
+
+        return $requestId;
+    }
+
+    /**
+     * @param  array<string, string>  $params
+     */
+    private function appendQuery(string $url, array $params): string
+    {
+        $sep = str_contains($url, '?') ? '&' : '?';
+        $qs = http_build_query($params);
+
+        return $url.$sep.$qs;
+    }
+
+    private function errorRedirect(string $redirectUri, string $error, string $description, string $state): RedirectResponse
+    {
+        $params = ['error' => $error, 'error_description' => $description];
+        if ($state !== '') {
+            $params['state'] = $state;
+        }
+
+        return redirect()->away($this->appendQuery($redirectUri, $params), 302)
+            ->withHeaders(['Cache-Control' => 'no-store']);
+    }
+
+    private function jsonError(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [['code' => $code, 'message' => $message, 'long_message' => $message]],
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    /**
+     * Either 200 JSON (`Accept: application/json`) or 302 (browser GET).
+     */
+    private function result(Request $request, string $redirectUrl): JsonResponse|RedirectResponse
+    {
+        $accept = strtolower((string) $request->header('Accept', ''));
+        if (str_contains($accept, 'application/json') && ! str_contains($accept, 'text/html')) {
+            return response()->json([
+                'object' => 'oauth_authorize_result',
+                'redirect_url' => $redirectUrl,
+            ])->header('Cache-Control', 'no-store');
+        }
+
+        return redirect()->away($redirectUrl, 302)
+            ->withHeaders(['Cache-Control' => 'no-store']);
+    }
+}

--- a/database/migrations/2026_05_14_000001_create_oauth_authorization_codes_and_requests.php
+++ b/database/migrations/2026_05_14_000001_create_oauth_authorization_codes_and_requests.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * v0.7 OAuth provider mode — short-lived authorization codes + parked
+ * authorize-request contexts.
+ *
+ * `oauth_authorization_codes` rows are minted by GET /oauth/authorize when
+ * the user already has a covering AuthorizationGrant (silent reuse) or by
+ * POST /oauth/consent when the user accepts (AU-9). They live for 5 minutes
+ * and are exchanged by POST /oauth/token (AU-7).
+ *
+ * `oauth_request_contexts` rows park the original /oauth/authorize query
+ * parameters during the user-facing consent flow so the Account Portal can
+ * reconstruct them without a long opaque URL. 10-minute TTL per spec OA-3.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('oauth_authorization_codes', function (Blueprint $table): void {
+            $table->string('code', 96)->primary();
+            $table->string('environment_id', 64);
+            $table->string('oauth_application_id', 64);
+            $table->string('user_id', 64);
+            $table->jsonb('scopes')->default(json_encode([]));
+            $table->string('redirect_uri', 2048);
+            $table->text('code_challenge')->nullable();
+            $table->string('code_challenge_method', 16)->nullable();
+            $table->text('nonce')->nullable();
+            $table->string('state', 2048)->nullable();
+            $table->timestamp('expires_at');
+            $table->timestamp('consumed_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('oauth_application_id')->references('id')->on('oauth_applications')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->index(['expires_at']);
+            $table->index(['oauth_application_id']);
+        });
+
+        Schema::create('oauth_request_contexts', function (Blueprint $table): void {
+            $table->string('request_id', 96)->primary();
+            $table->string('environment_id', 64);
+            $table->string('oauth_application_id', 64);
+            $table->jsonb('params');
+            $table->timestamp('expires_at');
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('oauth_application_id')->references('id')->on('oauth_applications')->cascadeOnDelete();
+            $table->index(['expires_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_request_contexts');
+        Schema::dropIfExists('oauth_authorization_codes');
+    }
+};

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\Fapi\MeOrganizationController;
 use App\Http\Controllers\Fapi\MePasskeysController;
 use App\Http\Controllers\Fapi\MePhoneNumberController;
 use App\Http\Controllers\Fapi\MeTotpController;
+use App\Http\Controllers\Fapi\OauthAuthorizeController;
 use App\Http\Controllers\Fapi\OauthCallbackController;
 use App\Http\Controllers\Fapi\OrganizationController as FapiOrganizationController;
 use App\Http\Controllers\Fapi\OrganizationEnterpriseConnectionController;
@@ -60,6 +61,12 @@ use Illuminate\Support\Facades\Route;
 Route::withoutMiddleware([EnforceFapiOrigin::class])->group(function (): void {
     Route::get('/.well-known/jwks.json', JwksController::class)->name('fapi.jwks');
     Route::get('/.well-known/openid-configuration', OpenIdConfigurationController::class)->name('fapi.openid_configuration');
+
+    // OAuth provider mode (AU-6). Browser-initiated top-level navigation; no
+    // Origin header / Client cookie required up front. Cache-Control: no-store
+    // is set on every response per RFC 6749 §5.1.
+    Route::get('/oauth/authorize', OauthAuthorizeController::class)
+        ->name('fapi.oauth.authorize');
 });
 
 // SCIM 2.0 server (RFC 7644). Bearer-authenticated; the SCIM client is the

--- a/tests/Feature/Http/Fapi/OauthAuthorizeTest.php
+++ b/tests/Feature/Http/Fapi/OauthAuthorizeTest.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Fapi\OauthAuthorizeController;
+use App\Models\AuthorizationGrant;
+use App\Models\OauthApplication;
+use Illuminate\Support\Facades\DB;
+use Tests\Feature\Http\Sessions\SessionsTestSupport;
+
+function authorizeUrl(array $params): string
+{
+    return 'https://acme.authn.local/oauth/authorize?'.http_build_query($params);
+}
+
+function authorizeBaseParams(OauthApplication $app, string $redirect = 'https://app.example.com/oauth/callback'): array
+{
+    return [
+        'client_id' => $app->client_id,
+        'redirect_uri' => $redirect,
+        'response_type' => 'code',
+        'scope' => 'openid profile email',
+        'state' => 'state-'.bin2hex(random_bytes(4)),
+        'nonce' => 'nonce-'.bin2hex(random_bytes(4)),
+    ];
+}
+
+it('returns 400 oauth_invalid_client for an unknown client_id', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get(authorizeUrl([
+            'client_id' => 'oac_pub_'.str_repeat('Z', 26),
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+            'response_type' => 'code',
+            'scope' => 'openid',
+            'state' => 'state',
+        ]));
+
+    $r->assertStatus(400)->assertJsonPath('errors.0.code', 'oauth_invalid_client');
+});
+
+it('returns 400 oauth_invalid_redirect_uri when redirect_uri is not on the allowlist', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://allowed.example/cb'],
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get(authorizeUrl([
+            'client_id' => $app->client_id,
+            'redirect_uri' => 'https://attacker.example/cb',
+            'response_type' => 'code',
+            'scope' => 'openid',
+            'state' => 'state',
+        ]));
+
+    $r->assertStatus(400)->assertJsonPath('errors.0.code', 'oauth_invalid_redirect_uri');
+});
+
+it('redirects to redirect_uri with error=invalid_scope when scope is not a subset', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+        'scopes' => ['openid', 'profile'],
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get(authorizeUrl(array_merge(authorizeBaseParams($app), ['scope' => 'openid acme.read_billing'])));
+
+    $r->assertStatus(302);
+    $loc = (string) $r->headers->get('Location');
+    expect($loc)->toStartWith('https://app.example.com/oauth/callback?');
+    expect($loc)->toContain('error=invalid_scope');
+    expect($loc)->toContain('state=');
+});
+
+it('redirects to redirect_uri with error=invalid_request when state is missing', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get(authorizeUrl([
+            'client_id' => $app->client_id,
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+            'response_type' => 'code',
+            'scope' => 'openid',
+        ]));
+
+    $r->assertStatus(302);
+    expect((string) $r->headers->get('Location'))->toContain('error=invalid_request');
+});
+
+it('redirects to redirect_uri with error=invalid_request when openid scope lacks nonce', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+
+    $params = authorizeBaseParams($app);
+    unset($params['nonce']);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get(authorizeUrl($params));
+
+    $r->assertStatus(302);
+    expect((string) $r->headers->get('Location'))->toContain('error=invalid_request');
+});
+
+it('redirects to redirect_uri with error=invalid_request when public client omits PKCE', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $app = OauthApplication::factory()->public()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get(authorizeUrl(authorizeBaseParams($app)));
+
+    $r->assertStatus(302);
+    $loc = (string) $r->headers->get('Location');
+    expect($loc)->toContain('error=invalid_request');
+    expect($loc)->toContain('code_challenge');
+});
+
+it('redirects unauthenticated browser to /sign-in?continue_url=...', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get(authorizeUrl(authorizeBaseParams($app)));
+
+    $r->assertStatus(302);
+    $loc = (string) $r->headers->get('Location');
+    expect($loc)->toContain('/sign-in');
+    expect($loc)->toContain('continue_url=');
+    expect($r->headers->get('Cache-Control'))->toContain('no-store');
+});
+
+it('returns error=login_required when prompt=none and no session', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get(authorizeUrl(array_merge(authorizeBaseParams($app), ['prompt' => 'none'])));
+
+    $r->assertStatus(302);
+    expect((string) $r->headers->get('Location'))->toContain('error=login_required');
+});
+
+it('parks the request + redirects to /oauth/consent/{request_id} when user has no covering grant', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get(authorizeUrl(authorizeBaseParams($app)));
+
+    $r->assertStatus(302);
+    $loc = (string) $r->headers->get('Location');
+    expect($loc)->toContain('/oauth/consent/');
+    $requestId = substr($loc, (int) strrpos($loc, '/') + 1);
+    $row = DB::table('oauth_request_contexts')->where('request_id', $requestId)->first();
+    expect($row)->not->toBeNull();
+    expect($row->oauth_application_id)->toBe($app->id);
+});
+
+it('silent-reuses an existing AuthorizationGrant: mints code + 302 back to redirect_uri', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+        'scopes' => ['openid', 'profile', 'email'],
+    ]);
+    AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $bs['user']->id,
+        'scopes' => ['openid', 'profile', 'email'],
+    ]);
+
+    $params = authorizeBaseParams($app);
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get(authorizeUrl($params));
+
+    $r->assertStatus(302);
+    $loc = (string) $r->headers->get('Location');
+    expect($loc)->toStartWith('https://app.example.com/oauth/callback?');
+    expect($loc)->toContain('code=oacd_');
+    expect($loc)->toContain('state='.$params['state']);
+
+    // Code was persisted with the matching app + user + scope set.
+    parse_str((string) parse_url($loc, PHP_URL_QUERY), $q);
+    $row = DB::table('oauth_authorization_codes')->where('code', $q['code'])->first();
+    expect($row)->not->toBeNull();
+    expect($row->oauth_application_id)->toBe($app->id);
+    expect($row->user_id)->toBe($bs['user']->id);
+});
+
+it('prompt=consent forces the consent screen even when a covering grant exists', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+    AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $bs['user']->id,
+    ]);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get(authorizeUrl(array_merge(authorizeBaseParams($app), ['prompt' => 'consent'])));
+
+    $r->assertStatus(302);
+    expect((string) $r->headers->get('Location'))->toContain('/oauth/consent/');
+});
+
+it('returns the redirect target as JSON when Accept: application/json', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+
+    $r = $this->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Accept' => 'application/json',
+    ])->withoutOpenApiAssertions()->get(authorizeUrl(authorizeBaseParams($app)));
+
+    $r->assertOk()
+        ->assertJsonPath('object', 'oauth_authorize_result');
+    expect($r->json('redirect_url'))->toContain('/sign-in');
+});
+
+it('persists the parked request context with a 10-minute TTL', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get(authorizeUrl(authorizeBaseParams($app)));
+
+    $loc = (string) $r->headers->get('Location');
+    $requestId = substr($loc, (int) strrpos($loc, '/') + 1);
+    $row = DB::table('oauth_request_contexts')->where('request_id', $requestId)->first();
+    $ttlSeconds = strtotime((string) $row->expires_at) - strtotime((string) $row->created_at);
+    expect($ttlSeconds)->toBeGreaterThanOrEqual(OauthAuthorizeController::REQUEST_CONTEXT_TTL_SECONDS - 1);
+    expect($ttlSeconds)->toBeLessThanOrEqual(OauthAuthorizeController::REQUEST_CONTEXT_TTL_SECONDS + 1);
+});


### PR DESCRIPTION
Closes #242 (AU-6).

## Summary

OAuth 2.0 / OIDC entry point — RFC 6749 §4.1 + OIDC §3.1.2. Sits at the FAPI host root (no /v1 prefix) and is the first hop in the authorization-code grant for v0.7's OAuth provider mode.

```
GET /oauth/authorize?client_id=&redirect_uri=&response_type=code
                    &scope=&state=&nonce=&code_challenge=
                    &code_challenge_method=S256&prompt=
```

Outcome routing (all 302s + `Cache-Control: no-store`):

- **No active session** → `/sign-in?continue_url=<this URL>` (or `error=login_required` when `prompt=none`).
- **First-time consent** → `/oauth/consent/{request_id}` (handled by Account Portal in AU-9).
- **Silent reuse** → `<redirect_uri>?code=…&state=…`.

## Validation discipline (RFC 6749 §4.1.2.1)

- `client_id` + `redirect_uri` failures return JSON 400 — redirecting an `error=…` query to an unvetted URL would leak the validation outcome to a caller-controlled domain.
- Every later validation error (scope subset, PKCE on public clients, missing nonce on openid, missing state) rides the redirect back to `redirect_uri` with `error=…&error_description=…&state=…`.

## Persistence

Two new tables back the OAuth ceremony:

- `oauth_authorization_codes` (5-min TTL) — minted on silent reuse and (eventually) on AU-9 consent acceptance. Carries the scope set, PKCE challenge, nonce, `redirect_uri`, and `state` ready for AU-7's `/oauth/token` exchange. Opportunistic GC on insert.
- `oauth_request_contexts` (10-min TTL) — parks the original `/oauth/authorize` query params during the user-facing consent flow so the Account Portal can reconstruct them without a long opaque URL.

`Accept: application/json` (no `text/html`) returns a 200 `{object: 'oauth_authorize_result', redirect_url}` instead of a 302 — useful for SSR proxies / curl-driven debugging. The browser path stays 302.

## Pest

Covers: `invalid_client` + `invalid_redirect_uri` 400s; `invalid_scope` / missing-state / `openid`-without-nonce / public-without-PKCE redirect-back errors; unauthenticated → `/sign-in`; `prompt=none` → `login_required`; parked consent redirect + DB row; silent reuse → code + state on `redirect_uri`; `prompt=consent` forces consent even with a covering grant; JSON `Accept` returns 200 envelope; request_context 10-minute TTL persisted.

## Out of scope (follow-ups)

- AU-7 (#243) — POST `/oauth/token` + token_info (consumes the authorization codes minted here).
- AU-9 (#245) — Account Portal consent screen at `/oauth/consent/{request_id}` (reads the parked request context).