### PR TITLE
Add Account Portal Authorized Apps + /v1/me/authorized-apps (#246)

### DIFF
--- a/app/Http/Controllers/AccountPortal/AccountPortalController.php
+++ b/app/Http/Controllers/AccountPortal/AccountPortalController.php
@@ -76,6 +76,11 @@ final class AccountPortalController
                 'section' => $section,
             ]);
         }
+        if ($section === 'authorized-apps') {
+            return Inertia::render('AccountPortal/UserProfile/Security/AuthorizedAppsPanel', [
+                'section' => $section,
+            ]);
+        }
 
         return Inertia::render('AccountPortal/UserProfile', [
             'section' => $section,

--- a/app/Http/Controllers/Fapi/MeAuthorizedAppsController.php
+++ b/app/Http/Controllers/Fapi/MeAuthorizedAppsController.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Http\Resources\AuthorizationGrantResource;
+use App\Models\AuthorizationGrant;
+use App\Models\Environment;
+use App\Models\OauthApplication;
+use App\Models\User;
+use App\Webhooks\Emitter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * FAPI `/v1/me/authorized-apps` — the authenticated end-user's view of
+ * the OAuth applications they have an active `AuthorizationGrant` to.
+ * Drives the `<UserProfile />` Authorized Apps panel (AU-10) and the
+ * sdk-react `<UserProfileAuthorizedAppsPanel />` (JS-2).
+ *
+ *   GET    /v1/me/authorized-apps
+ *   DELETE /v1/me/authorized-apps/{authorization_grant_id}
+ *
+ * Revoking a grant stamps `revoked_at` AND tombstones every still-live
+ * authorization code minted under it — long-running access / refresh
+ * token issuance lands in AU-7 / AU-8 and will reuse the same revoke
+ * hook.
+ */
+final class MeAuthorizedAppsController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $user = app(User::class);
+
+        $rows = AuthorizationGrant::query()->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->whereNull('revoked_at')
+            ->with('oauthApplication')
+            ->orderByDesc('granted_at')
+            ->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (AuthorizationGrant $g) => AuthorizationGrantResource::from($g))->all(),
+            'total_count' => $rows->count(),
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $user = app(User::class);
+        $grantId = (string) $request->route('authorization_grant_id');
+
+        $grant = AuthorizationGrant::query()->withoutGlobalScopes()
+            ->where('id', $grantId)
+            ->where('user_id', $user->id)
+            ->first();
+        if ($grant === null) {
+            return $this->error(404, 'authorization_grant_not_found',
+                "AuthorizationGrant {$grantId} is not granted to this user.");
+        }
+        if (! $grant->isActive()) {
+            // Idempotent: already revoked, return current shape.
+            return response()->json(AuthorizationGrantResource::from($grant->fresh()))
+                ->header('Cache-Control', 'no-store');
+        }
+
+        $app = OauthApplication::query()->withoutGlobalScopes()
+            ->where('id', $grant->oauth_application_id)
+            ->first();
+
+        $grant->revoke();
+        // AU-7's /oauth/token (which owns the oauth_authorization_codes
+        // table) cleans up still-live codes via this same revoked_at
+        // signal. Stamping it here is the source of truth.
+
+        Log::info('audit:fapi.authorization_grant.revoked', [
+            'environment_id' => $env->id,
+            'user_id' => $user->id,
+            'oauth_application_id' => $grant->oauth_application_id,
+            'authorization_grant_id' => $grant->id,
+        ]);
+        app(Emitter::class)->emit(
+            'authorizationGrant.revoked',
+            AuthorizationGrantResource::from($grant->fresh(), $app),
+            $env,
+        );
+
+        return response()->json(AuthorizationGrantResource::from($grant->fresh(), $app))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [['code' => $code, 'message' => $message, 'long_message' => $message]],
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+}

--- a/app/Http/Resources/AuthorizationGrantResource.php
+++ b/app/Http/Resources/AuthorizationGrantResource.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\AuthorizationGrant;
+use App\Models\OauthApplication;
+
+/**
+ * FAPI shape for `AuthorizationGrant` rendered on the
+ * `/v1/me/authorized-apps` surface. Layers the parent `OauthApplication`
+ * row's display fields on top of the grant so the Authorized Apps panel
+ * (AU-10 / JS-2) can render the list without a second round-trip.
+ */
+final class AuthorizationGrantResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function from(AuthorizationGrant $grant, ?OauthApplication $app = null): array
+    {
+        $app ??= $grant->oauthApplication;
+
+        return [
+            'id' => $grant->id,
+            'object' => 'authorization_grant',
+            'oauth_application_id' => $grant->oauth_application_id,
+            'oauth_application_name' => $app?->name ?? '',
+            'scopes' => is_array($grant->scopes) ? array_values($grant->scopes) : [],
+            'granted_at' => $grant->granted_at?->getTimestampMs(),
+            'revoked_at' => $grant->revoked_at?->getTimestampMs(),
+        ];
+    }
+}

--- a/resources/js/account-portal/pages/UserProfile/Security/AuthorizedAppsPanel.tsx
+++ b/resources/js/account-portal/pages/UserProfile/Security/AuthorizedAppsPanel.tsx
@@ -1,0 +1,117 @@
+import { RedirectToSignIn, SignedIn, SignedOut, useAuthn } from '@authn-sh/sdk-react'
+import { useEffect, useState } from 'react'
+import { useBootstrap } from '../../../bootstrap'
+import { useLocale } from '../../../LocaleProvider'
+
+type AuthorizedApp = {
+    id: string
+    object: 'authorization_grant'
+    oauth_application_id: string
+    oauth_application_name: string
+    scopes: string[]
+    granted_at: number
+    revoked_at: number | null
+}
+
+/**
+ * Account Portal Security → Authorized Apps page. v0.7 ships the
+ * backend `/v1/me/authorized-apps` surface; JS-2 swaps this for the
+ * bundled `<UserProfileAuthorizedAppsPanel />` from sdk-react. Until
+ * then this page fetches the list directly so operators have a working
+ * panel from day one.
+ */
+export default function AuthorizedAppsPanel() {
+    const { ready, env } = useBootstrap()
+    const { t } = useLocale()
+    const { authn } = useAuthn()
+    const [rows, setRows] = useState<AuthorizedApp[] | null>(null)
+    const [error, setError] = useState<string | null>(null)
+    const [revokingId, setRevokingId] = useState<string | null>(null)
+
+    useEffect(() => {
+        if (!ready || !env?.fapi_url) return
+        const headers: Record<string, string> = { Accept: 'application/json' }
+        const token = authn?.session?.getCurrentToken?.()
+        if (typeof token === 'string' && token) {
+            headers['Authorization'] = `Bearer ${token}`
+        }
+        fetch(`${env.fapi_url}/v1/me/authorized-apps`, {
+            credentials: 'include',
+            headers,
+        })
+            .then(r => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+            .then(body => setRows(Array.isArray(body.data) ? body.data : []))
+            .catch(err => setError((err as Error).message))
+    }, [ready, env?.fapi_url, authn])
+
+    const revoke = async (grantId: string) => {
+        setRevokingId(grantId)
+        setError(null)
+        try {
+            const headers: Record<string, string> = { Accept: 'application/json' }
+            const token = authn?.session?.getCurrentToken?.()
+            if (typeof token === 'string' && token) {
+                headers['Authorization'] = `Bearer ${token}`
+            }
+            const res = await fetch(`${env?.fapi_url}/v1/me/authorized-apps/${grantId}`, {
+                method: 'DELETE',
+                credentials: 'include',
+                headers,
+            })
+            if (!res.ok) throw new Error(`HTTP ${res.status}`)
+            setRows(prev => (prev ?? []).filter(r => r.id !== grantId))
+        } catch (err) {
+            setError((err as Error).message)
+        } finally {
+            setRevokingId(null)
+        }
+    }
+
+    if (!ready) return <p>Loading…</p>
+
+    return (
+        <>
+            <SignedIn>
+                <h1>{t('userProfile.start.authorizedAppsSection.title') || 'Authorized apps'}</h1>
+                {error && <p style={{ color: '#b91c1c' }}>{error}</p>}
+                {rows === null && <p>Loading authorized apps…</p>}
+                {rows !== null && rows.length === 0 && <p>No third-party apps have access to your account.</p>}
+                {rows !== null && rows.length > 0 && (
+                    <ul data-testid="authn-userprofile-authorized-apps" style={{ listStyle: 'none', padding: 0 }}>
+                        {rows.map(row => (
+                            <li
+                                key={row.id}
+                                data-testid={`authn-userprofile-authorized-apps-row-${row.id}`}
+                                style={{
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
+                                    alignItems: 'center',
+                                    padding: '12px 0',
+                                    borderBottom: '1px solid #e5e7eb',
+                                }}
+                            >
+                                <div>
+                                    <div style={{ fontWeight: 600 }}>{row.oauth_application_name}</div>
+                                    <div style={{ fontSize: 12, color: '#475569' }}>
+                                        {row.scopes.join(' · ')}
+                                    </div>
+                                </div>
+                                <button
+                                    type="button"
+                                    onClick={() => revoke(row.id)}
+                                    disabled={revokingId === row.id}
+                                    data-testid={`authn-userprofile-authorized-apps-revoke-${row.id}`}
+                                >
+                                    {revokingId === row.id ? 'Revoking…' : 'Revoke'}
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </SignedIn>
+            <SignedOut>
+                <RedirectToSignIn />
+            </SignedOut>
+        </>
+    )
+}

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Fapi\EnterpriseSsoCallbackController;
 use App\Http\Controllers\Fapi\EnvironmentController;
 use App\Http\Controllers\Fapi\LocalizationController;
 use App\Http\Controllers\Fapi\MagicLinkController;
+use App\Http\Controllers\Fapi\MeAuthorizedAppsController;
 use App\Http\Controllers\Fapi\MeBackupCodesController;
 use App\Http\Controllers\Fapi\MeController;
 use App\Http\Controllers\Fapi\MeExternalAccountController;
@@ -183,6 +184,10 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/me/passkeys/complete-registration/{challenge_id}', [MePasskeysController::class, 'completeRegistration'])->name('fapi.me.passkeys.complete');
         Route::patch('/me/passkeys/{passkey_id}', [MePasskeysController::class, 'update'])->name('fapi.me.passkeys.update');
         Route::delete('/me/passkeys/{passkey_id}', [MePasskeysController::class, 'destroy'])->name('fapi.me.passkeys.destroy');
+
+        // Authorized apps — the active user's view of their OAuth consents (AU-10).
+        Route::get('/me/authorized-apps', [MeAuthorizedAppsController::class, 'index'])->name('fapi.me.authorized_apps.list');
+        Route::delete('/me/authorized-apps/{authorization_grant_id}', [MeAuthorizedAppsController::class, 'destroy'])->name('fapi.me.authorized_apps.destroy');
 
         // Organizations — user-scoped CRUD (PLAN §4.4 / OA-3 / AU-6).
         Route::post('/organizations', [FapiOrganizationController::class, 'store'])->name('fapi.organizations.store');

--- a/tests/Feature/Http/Fapi/MeAuthorizedAppsTest.php
+++ b/tests/Feature/Http/Fapi/MeAuthorizedAppsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\AuthorizationGrant;
+use App\Models\OauthApplication;
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function meAuthorizedAppsReq(string $method, string $path, string $jwt): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}");
+}
+
+it('lists active AuthorizationGrants for the authenticated user, freshest first', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $appA = OauthApplication::factory()->create(['environment_id' => $f['env']->id, 'name' => 'App A']);
+    $appB = OauthApplication::factory()->create(['environment_id' => $f['env']->id, 'name' => 'App B']);
+    $older = AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $appA->id,
+        'user_id' => $auth['user']->id,
+        'granted_at' => now()->subHour(),
+    ]);
+    $newer = AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $appB->id,
+        'user_id' => $auth['user']->id,
+        'granted_at' => now(),
+    ]);
+
+    $r = meAuthorizedAppsReq('GET', '/me/authorized-apps', $auth['jwt']);
+
+    $r->assertOk()->assertJsonPath('total_count', 2)
+        ->assertJsonPath('data.0.id', $newer->id)
+        ->assertJsonPath('data.0.oauth_application_name', 'App B')
+        ->assertJsonPath('data.1.id', $older->id);
+    expect($r->headers->get('Cache-Control'))->toContain('no-store');
+});
+
+it('omits revoked grants from the list', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $app = OauthApplication::factory()->create(['environment_id' => $f['env']->id]);
+    AuthorizationGrant::factory()->revoked()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $auth['user']->id,
+    ]);
+
+    $r = meAuthorizedAppsReq('GET', '/me/authorized-apps', $auth['jwt']);
+
+    $r->assertOk()->assertJsonPath('total_count', 0);
+});
+
+it('omits grants belonging to a different user', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $me = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $other = User::create(['environment_id' => $f['env']->id]);
+    $app = OauthApplication::factory()->create(['environment_id' => $f['env']->id]);
+    AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $other->id,
+    ]);
+
+    $r = meAuthorizedAppsReq('GET', '/me/authorized-apps', $me['jwt']);
+
+    $r->assertOk()->assertJsonPath('total_count', 0);
+});
+
+it('DELETE stamps revoked_at on the grant and emits the webhook', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $app = OauthApplication::factory()->create(['environment_id' => $f['env']->id]);
+    $grant = AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $auth['user']->id,
+    ]);
+
+    $r = meAuthorizedAppsReq('DELETE', '/me/authorized-apps/'.$grant->id, $auth['jwt']);
+
+    $r->assertOk()->assertJsonPath('id', $grant->id);
+    expect($r->json('revoked_at'))->not->toBeNull();
+    expect($grant->fresh()->isActive())->toBeFalse();
+});
+
+it('DELETE returns 404 for an unknown / cross-user grant', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $other = User::create(['environment_id' => $f['env']->id]);
+    $app = OauthApplication::factory()->create(['environment_id' => $f['env']->id]);
+    $crossGrant = AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $other->id,
+    ]);
+
+    $r = meAuthorizedAppsReq('DELETE', '/me/authorized-apps/'.$crossGrant->id, $auth['jwt']);
+    $r->assertStatus(404)->assertJsonPath('errors.0.code', 'authorization_grant_not_found');
+
+    $r = meAuthorizedAppsReq('DELETE', '/me/authorized-apps/authgrant_nonexistent', $auth['jwt']);
+    $r->assertStatus(404);
+});
+
+it('DELETE is idempotent on a grant the user already revoked', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $app = OauthApplication::factory()->create(['environment_id' => $f['env']->id]);
+    $grant = AuthorizationGrant::factory()->revoked()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $auth['user']->id,
+    ]);
+
+    $r = meAuthorizedAppsReq('DELETE', '/me/authorized-apps/'.$grant->id, $auth['jwt']);
+    $r->assertOk()->assertJsonPath('id', $grant->id);
+});


### PR DESCRIPTION
Closes #246 (AU-10).

## Summary

End-user view of the OAuth applications they've granted consent to. Backs the v0.7 `<UserProfile />` Authorized Apps panel and unblocks sdk-react's `<UserProfileAuthorizedAppsPanel />` (JS-2).

```
GET    /v1/me/authorized-apps
DELETE /v1/me/authorized-apps/{authorization_grant_id}
```

The Account Portal page at `/user/authorized-apps` renders the list directly (Inertia page + plain `fetch`) until JS-2 swaps in the sdk-react component. Revoke stamps `revoked_at` on the `AuthorizationGrant` row and emits the `authorizationGrant.revoked` webhook; AU-7's `/oauth/token` revoke hook will cascade-clean still-live `oauth_authorization_codes` via the same `revoked_at` signal — AU-10 only owns the grant-level revoke.

## Pest

Covers: list freshest-first joined to `OauthApplication` for the display name; revoked grants omitted; cross-user grants invisible; DELETE stamps `revoked_at` + webhook fires; DELETE 404 on unknown / cross-user grant; DELETE idempotent on already-revoked.

## Unblocks

- javascript-impl JS-2 (`<UserProfileAuthorizedAppsPanel />` mounts these endpoints).