### PR TITLE
Add Dashboard Configure → JWT Templates + OAuth Applications (#247)

### DIFF
--- a/app/Http/Controllers/Dashboard/DashboardController.php
+++ b/app/Http/Controllers/Dashboard/DashboardController.php
@@ -12,6 +12,7 @@ use App\Jobs\Sms\SendSmsTemplate;
 use App\Localization\CanonicalSchema;
 use App\Models\AllowlistIdentifier;
 use App\Models\ApiKey;
+use App\Models\AuthorizationGrant;
 use App\Models\BlocklistIdentifier;
 use App\Models\EmailTemplate;
 use App\Models\EnterpriseAccount;
@@ -19,6 +20,8 @@ use App\Models\EnterpriseConnection;
 use App\Models\Environment;
 use App\Models\ExternalAccount;
 use App\Models\Invitation;
+use App\Models\JwtTemplate;
+use App\Models\OauthApplication;
 use App\Models\OauthProvider;
 use App\Models\Organization;
 use App\Models\OrganizationDomain;
@@ -288,6 +291,24 @@ final class DashboardController
             ->orderBy('name')
             ->get();
 
+        $jwtTemplateRows = JwtTemplate::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->whereNull('removed_at')
+            ->orderBy('name')
+            ->get();
+
+        $oauthAppRows = OauthApplication::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->whereNull('removed_at')
+            ->orderBy('name')
+            ->get();
+        $grantCounts = AuthorizationGrant::query()->withoutGlobalScopes()
+            ->whereIn('oauth_application_id', $oauthAppRows->pluck('id'))
+            ->whereNull('revoked_at')
+            ->selectRaw('oauth_application_id, count(*) as c')
+            ->groupBy('oauth_application_id')
+            ->pluck('c', 'oauth_application_id');
+
         return Inertia::render('Dashboard/Configure', [
             'section' => $section,
             'user_settings' => $userSettings,
@@ -318,6 +339,27 @@ final class DashboardController
             'oauth_providers' => $oauthRows->map(fn (OauthProvider $p) => $this->oauthRowShape($p))->all(),
             'oauth_preset_keys' => $this->oauthPresets->keys(),
             'enterprise_connections' => $enterpriseRows->map(fn (EnterpriseConnection $c) => $this->enterpriseConnectionRowShape($c))->all(),
+            'jwt_templates' => $jwtTemplateRows->map(fn (JwtTemplate $t) => [
+                'id' => $t->id,
+                'name' => $t->name,
+                'claims' => is_array($t->claims) ? $t->claims : [],
+                'lifetime' => $t->lifetime,
+                'allowed_clock_skew' => $t->allowed_clock_skew,
+                'signing_algorithm' => $t->signing_algorithm,
+                'has_custom_signing_key' => $t->custom_signing_key !== null && $t->custom_signing_key !== '',
+                'last_used_at' => $t->last_used_at?->getTimestampMs(),
+                'created_at' => $t->created_at?->getTimestampMs(),
+            ])->all(),
+            'oauth_applications' => $oauthAppRows->map(fn (OauthApplication $a) => [
+                'id' => $a->id,
+                'name' => $a->name,
+                'client_id' => $a->client_id,
+                'callback_urls' => is_array($a->callback_urls) ? array_values($a->callback_urls) : [],
+                'scopes' => is_array($a->scopes) ? array_values($a->scopes) : [],
+                'is_public' => (bool) $a->is_public,
+                'grants_count' => (int) ($grantCounts[$a->id] ?? 0),
+                'created_at' => $a->created_at?->getTimestampMs(),
+            ])->all(),
             'localization' => $this->localizationShape($env),
             'localization_canonical' => [
                 'shipped_locales' => CanonicalSchema::SHIPPED_LOCALES,
@@ -1355,5 +1397,204 @@ final class DashboardController
 
         return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/enterprise-sso")
             ->with('enterprise_connection_deleted', true);
+    }
+
+    // --- JWT Templates (AU-11). ---------------------------------------------
+
+    public function storeJwtTemplate(Request $request, string $project_slug, string $env_slug): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_-]{0,63}$/'],
+            'claims' => ['required', 'array'],
+            'lifetime' => ['sometimes', 'integer', 'between:1,86400'],
+            'allowed_clock_skew' => ['sometimes', 'integer', 'between:0,300'],
+            'signing_algorithm' => ['sometimes', 'string', 'in:RS256,ES256,HS256'],
+            'custom_signing_key' => ['sometimes', 'nullable', 'string'],
+        ]);
+
+        JwtTemplate::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'name' => $data['name'],
+            'claims' => $data['claims'],
+            'lifetime' => $data['lifetime'] ?? 60,
+            'allowed_clock_skew' => $data['allowed_clock_skew'] ?? 5,
+            'signing_algorithm' => $data['signing_algorithm'] ?? JwtTemplate::ALG_RS256,
+            'custom_signing_key' => $data['custom_signing_key'] ?? null,
+        ]);
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/jwt-templates")
+            ->with('jwt_template_saved', true);
+    }
+
+    public function updateJwtTemplate(Request $request, string $project_slug, string $env_slug, string $jwt_template_id): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+        $row = JwtTemplate::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $jwt_template_id)
+            ->whereNull('removed_at')
+            ->first();
+        if ($row === null) {
+            return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/jwt-templates");
+        }
+
+        $data = $request->validate([
+            'claims' => ['sometimes', 'array'],
+            'lifetime' => ['sometimes', 'integer', 'between:1,86400'],
+            'allowed_clock_skew' => ['sometimes', 'integer', 'between:0,300'],
+            'custom_signing_key' => ['sometimes', 'nullable', 'string'],
+        ]);
+
+        $row->fill(array_intersect_key($data, array_flip(['claims', 'lifetime', 'allowed_clock_skew'])));
+        if (array_key_exists('custom_signing_key', $data)) {
+            $row->custom_signing_key = $data['custom_signing_key'];
+        }
+        $row->save();
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/jwt-templates")
+            ->with('jwt_template_saved', true);
+    }
+
+    public function destroyJwtTemplate(string $project_slug, string $env_slug, string $jwt_template_id): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+        $row = JwtTemplate::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $jwt_template_id)
+            ->whereNull('removed_at')
+            ->first();
+        if ($row !== null) {
+            $row->delete();
+        }
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/jwt-templates")
+            ->with('jwt_template_deleted', true);
+    }
+
+    // --- OAuth Applications (AU-11). ---------------------------------------
+
+    public function storeOauthApplication(Request $request, string $project_slug, string $env_slug): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+
+        $data = $request->validate([
+            'name' => ['required', 'string', 'min:1', 'max:100'],
+            'callback_urls' => ['required', 'array', 'min:1'],
+            'callback_urls.*' => ['required', 'string', 'max:2048'],
+            'scopes' => ['sometimes', 'array'],
+            'scopes.*' => ['string', 'max:120'],
+            'is_public' => ['sometimes', 'boolean'],
+        ]);
+        $isPublic = (bool) ($data['is_public'] ?? false);
+        $secret = $isPublic ? null : OauthApplication::mintClientSecret();
+
+        $row = OauthApplication::query()->withoutGlobalScopes()->create([
+            'environment_id' => $env->id,
+            'name' => $data['name'],
+            'hashed_client_secret' => $secret['hash'] ?? null,
+            'callback_urls' => array_values($data['callback_urls']),
+            'scopes' => array_values($data['scopes'] ?? []),
+            'is_public' => $isPublic,
+        ]);
+
+        $redirect = redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/oauth-applications")
+            ->with('oauth_application_saved', true)
+            ->with('oauth_application_id', $row->id);
+        if ($secret !== null) {
+            $redirect = $redirect->with('oauth_application_secret', $secret['plaintext']);
+        }
+
+        return $redirect;
+    }
+
+    public function updateOauthApplication(Request $request, string $project_slug, string $env_slug, string $oauth_application_id): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+        $row = OauthApplication::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $oauth_application_id)
+            ->whereNull('removed_at')
+            ->first();
+        if ($row === null) {
+            return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/oauth-applications");
+        }
+
+        $data = $request->validate([
+            'name' => ['sometimes', 'string', 'min:1', 'max:100'],
+            'callback_urls' => ['sometimes', 'array', 'min:1'],
+            'callback_urls.*' => ['required', 'string', 'max:2048'],
+            'scopes' => ['sometimes', 'array'],
+            'scopes.*' => ['string', 'max:120'],
+        ]);
+
+        $row->fill(array_intersect_key($data, array_flip(['name', 'callback_urls', 'scopes'])));
+        $row->save();
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/oauth-applications")
+            ->with('oauth_application_saved', true);
+    }
+
+    public function destroyOauthApplication(string $project_slug, string $env_slug, string $oauth_application_id): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+        $row = OauthApplication::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $oauth_application_id)
+            ->whereNull('removed_at')
+            ->first();
+        if ($row !== null) {
+            AuthorizationGrant::query()->withoutGlobalScopes()
+                ->where('oauth_application_id', $row->id)
+                ->whereNull('revoked_at')
+                ->update(['revoked_at' => now()]);
+            $row->delete();
+        }
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/oauth-applications")
+            ->with('oauth_application_deleted', true);
+    }
+
+    public function rotateOauthApplicationSecret(string $project_slug, string $env_slug, string $oauth_application_id): RedirectResponse
+    {
+        $env = $this->env($project_slug, $env_slug);
+        if ($env === null) {
+            return redirect(Url::dashboardPathPrefix().'/create-project');
+        }
+        $row = OauthApplication::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $oauth_application_id)
+            ->whereNull('removed_at')
+            ->first();
+        if ($row === null || $row->is_public) {
+            return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/oauth-applications");
+        }
+
+        $secret = OauthApplication::mintClientSecret();
+        $row->forceFill(['hashed_client_secret' => $secret['hash']])->save();
+
+        return redirect(Url::dashboardPathPrefix()."/{$project_slug}/{$env_slug}/configure/oauth-applications")
+            ->with('oauth_application_saved', true)
+            ->with('oauth_application_id', $row->id)
+            ->with('oauth_application_secret', $secret['plaintext']);
     }
 }

--- a/resources/js/dashboard/pages/Configure.tsx
+++ b/resources/js/dashboard/pages/Configure.tsx
@@ -85,6 +85,31 @@ type Props = {
     localization: LocalizationShape
     localization_canonical: LocalizationCanonical
     enterprise_connections: EnterpriseConnection[]
+    jwt_templates?: JwtTemplateRow[]
+    oauth_applications?: OauthApplicationRow[]
+}
+
+type JwtTemplateRow = {
+    id: string
+    name: string
+    claims: Record<string, unknown>
+    lifetime: number
+    allowed_clock_skew: number
+    signing_algorithm: 'RS256' | 'ES256' | 'HS256'
+    has_custom_signing_key: boolean
+    last_used_at: number | null
+    created_at: number | null
+}
+
+type OauthApplicationRow = {
+    id: string
+    name: string
+    client_id: string
+    callback_urls: string[]
+    scopes: string[]
+    is_public: boolean
+    grants_count: number
+    created_at: number | null
 }
 
 const SECTIONS = [
@@ -95,6 +120,8 @@ const SECTIONS = [
     { slug: 'enterprise-sso', label: 'Enterprise SSO' },
     { slug: 'appearance', label: 'Appearance' },
     { slug: 'localization', label: 'Localization' },
+    { slug: 'jwt-templates', label: 'JWT Templates' },
+    { slug: 'oauth-applications', label: 'OAuth Applications' },
 ] as const
 
 type EnterpriseConnection = {
@@ -156,7 +183,13 @@ export default function Configure(props: Props) {
             {props.section === 'enterprise-sso' && (
                 <EnterpriseSsoSection connections={props.enterprise_connections} />
             )}
-            {!['attributes', 'multi-factor', 'sms', 'social-providers', 'enterprise-sso', 'appearance', 'localization'].includes(props.section) && (
+            {props.section === 'jwt-templates' && (
+                <JwtTemplatesSection templates={props.jwt_templates ?? []} />
+            )}
+            {props.section === 'oauth-applications' && (
+                <OauthApplicationsSection applications={props.oauth_applications ?? []} />
+            )}
+            {!['attributes', 'multi-factor', 'sms', 'social-providers', 'enterprise-sso', 'appearance', 'localization', 'jwt-templates', 'oauth-applications'].includes(props.section) && (
                 <pre style={{ background: '#f1f5f9', padding: 12, borderRadius: 6 }}>
                     {JSON.stringify(props.user_settings, null, 2)}
                 </pre>
@@ -1795,6 +1828,476 @@ function DeleteConnectionButton({ id, action, disabled }: { id: string; action: 
             disabled={disabled || form.processing}
             title={disabled ? 'Has linked accounts — unlink users first.' : undefined}
             style={{ padding: '4px 10px', background: disabled ? '#e5e7eb' : '#fee2e2', color: disabled ? '#94a3b8' : '#b91c1c', border: 'none', borderRadius: 4, cursor: disabled ? 'not-allowed' : 'pointer' }}
+        >
+            Delete
+        </button>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// JWT Templates (AU-11).
+// ---------------------------------------------------------------------------
+
+function JwtTemplatesSection({ templates }: { templates: JwtTemplateRow[] }) {
+    const url = useDashboardUrl()
+    const { active_project, active_environment } = useDashboard()
+    const { props: pageProps } = usePage<{ flash?: { jwt_template_saved?: boolean; jwt_template_deleted?: boolean } }>()
+    const [adding, setAdding] = React.useState(false)
+    const [editing, setEditing] = React.useState<string | null>(null)
+
+    if (!active_project || !active_environment) {
+        return <p>No active environment.</p>
+    }
+    const base = `/${active_project.slug}/${active_environment.slug}/configure`
+
+    return (
+        <section>
+            <h2>JWT Templates</h2>
+            <p style={{ color: '#475569', marginBottom: 16 }}>
+                Named JWT shapes for <code>Session.getToken({'{template}'})</code>. Each template renders
+                Liquid-style <code>{'{{user.id}}'}</code> placeholders against the active user / session / org.
+            </p>
+            {pageProps.flash?.jwt_template_saved && (
+                <p style={{ color: '#15803d', marginBottom: 12 }}>Template saved.</p>
+            )}
+            {pageProps.flash?.jwt_template_deleted && (
+                <p style={{ color: '#15803d', marginBottom: 12 }}>Template deleted.</p>
+            )}
+
+            {templates.length === 0 ? (
+                <p style={{ color: '#64748b' }}>No JWT templates yet.</p>
+            ) : (
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, marginBottom: 16 }}>
+                    <thead>
+                        <tr style={{ borderBottom: '1px solid #e5e7eb' }}>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Name</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Algorithm</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Lifetime</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Last used</th>
+                            <th style={{ textAlign: 'right', padding: 6 }}></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {templates.map(t => (
+                            <tr key={t.id} style={{ borderBottom: '1px solid #f1f5f9' }}>
+                                <td style={{ padding: 6 }}><code>{t.name}</code></td>
+                                <td style={{ padding: 6 }}>{t.signing_algorithm}{t.has_custom_signing_key && ' (custom key)'}</td>
+                                <td style={{ padding: 6 }}>{t.lifetime}s</td>
+                                <td style={{ padding: 6, color: '#475569' }}>{t.last_used_at ? new Date(t.last_used_at).toISOString() : '—'}</td>
+                                <td style={{ padding: 6, textAlign: 'right' }}>
+                                    <button type="button" onClick={() => setEditing(editing === t.id ? null : t.id)} style={{ marginRight: 6 }}>
+                                        {editing === t.id ? 'Close' : 'Edit'}
+                                    </button>
+                                    <DeleteJwtTemplateButton id={t.id} action={url(`${base}/jwt-templates/${t.id}`)} />
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+
+            {editing && (
+                <JwtTemplateForm
+                    template={templates.find(t => t.id === editing) ?? null}
+                    saveUrl={url(`${base}/jwt-templates/${editing}`)}
+                    onDone={() => setEditing(null)}
+                />
+            )}
+
+            {adding ? (
+                <JwtTemplateForm
+                    template={null}
+                    saveUrl={url(`${base}/jwt-templates`)}
+                    onDone={() => setAdding(false)}
+                />
+            ) : (
+                <button type="button" onClick={() => setAdding(true)} style={{ marginTop: 8 }}>
+                    Add JWT template
+                </button>
+            )}
+        </section>
+    )
+}
+
+function JwtTemplateForm({ template, saveUrl, onDone }: { template: JwtTemplateRow | null; saveUrl: string; onDone: () => void }) {
+    const isEdit = template !== null
+    const form = useForm({
+        name: template?.name ?? '',
+        claims: JSON.stringify(template?.claims ?? { sub: '{{user.id}}' }, null, 2),
+        lifetime: template?.lifetime ?? 60,
+        allowed_clock_skew: template?.allowed_clock_skew ?? 5,
+        signing_algorithm: template?.signing_algorithm ?? 'RS256',
+        custom_signing_key: '',
+    })
+    const [parseError, setParseError] = React.useState<string | null>(null)
+
+    const onSubmit = (e: React.FormEvent) => {
+        e.preventDefault()
+        let parsedClaims: Record<string, unknown>
+        try {
+            const v = JSON.parse(form.data.claims || '{}')
+            if (typeof v !== 'object' || v === null || Array.isArray(v)) {
+                throw new Error('claims must be a JSON object.')
+            }
+            parsedClaims = v
+        } catch (err) {
+            setParseError((err as Error).message)
+            return
+        }
+        setParseError(null)
+        const payload = form.transform(() => ({
+            name: form.data.name,
+            claims: parsedClaims,
+            lifetime: Number(form.data.lifetime) || 60,
+            allowed_clock_skew: Number(form.data.allowed_clock_skew) || 5,
+            signing_algorithm: form.data.signing_algorithm,
+            custom_signing_key: form.data.custom_signing_key === '' ? null : form.data.custom_signing_key,
+        }))
+        if (isEdit) {
+            payload.patch(saveUrl, { preserveScroll: true, onSuccess: onDone })
+        } else {
+            payload.post(saveUrl, { preserveScroll: true, onSuccess: onDone })
+        }
+    }
+
+    return (
+        <form onSubmit={onSubmit} style={{ marginTop: 8, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+            <h3 style={{ marginTop: 0 }}>{isEdit ? 'Edit JWT template' : 'New JWT template'}</h3>
+            <label style={{ display: 'block', marginBottom: 8 }}>
+                <span style={{ display: 'block', color: '#475569' }}>Name (slug)</span>
+                <input
+                    type="text"
+                    value={form.data.name}
+                    onChange={e => form.setData('name', e.target.value)}
+                    placeholder="supabase"
+                    disabled={isEdit}
+                    style={{ width: '100%', padding: 6 }}
+                />
+                {form.errors.name && <p style={{ color: '#b91c1c' }}>{form.errors.name}</p>}
+            </label>
+
+            <label style={{ display: 'block', marginBottom: 8 }}>
+                <span style={{ display: 'block', color: '#475569' }}>Claims (JSON with {`{{user.id}}`}-style placeholders)</span>
+                <textarea
+                    value={form.data.claims}
+                    onChange={e => form.setData('claims', e.target.value)}
+                    rows={10}
+                    style={{ width: '100%', fontFamily: 'monospace', padding: 6 }}
+                />
+                {parseError && <p style={{ color: '#b91c1c' }}>{parseError}</p>}
+                {form.errors.claims && <p style={{ color: '#b91c1c' }}>{form.errors.claims}</p>}
+            </label>
+
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12, marginBottom: 8 }}>
+                <label>
+                    <span style={{ display: 'block', color: '#475569' }}>Lifetime (s)</span>
+                    <input type="number" min={1} max={86400} value={form.data.lifetime} onChange={e => form.setData('lifetime', Number(e.target.value))} style={{ width: '100%', padding: 6 }} />
+                </label>
+                <label>
+                    <span style={{ display: 'block', color: '#475569' }}>Allowed clock skew (s)</span>
+                    <input type="number" min={0} max={300} value={form.data.allowed_clock_skew} onChange={e => form.setData('allowed_clock_skew', Number(e.target.value))} style={{ width: '100%', padding: 6 }} />
+                </label>
+                <label>
+                    <span style={{ display: 'block', color: '#475569' }}>Algorithm</span>
+                    <select
+                        value={form.data.signing_algorithm}
+                        onChange={e => form.setData('signing_algorithm', e.target.value as JwtTemplateRow['signing_algorithm'])}
+                        disabled={isEdit}
+                        style={{ width: '100%', padding: 6 }}
+                    >
+                        <option value="RS256">RS256</option>
+                        <option value="ES256">ES256</option>
+                        <option value="HS256">HS256</option>
+                    </select>
+                </label>
+            </div>
+
+            <label style={{ display: 'block', marginBottom: 8 }}>
+                <span style={{ display: 'block', color: '#475569' }}>
+                    Custom signing key (PEM / base64 secret — leave blank to use the env signing key)
+                </span>
+                <textarea
+                    value={form.data.custom_signing_key}
+                    onChange={e => form.setData('custom_signing_key', e.target.value)}
+                    rows={4}
+                    placeholder="-----BEGIN PRIVATE KEY-----..."
+                    style={{ width: '100%', fontFamily: 'monospace', padding: 6 }}
+                />
+            </label>
+
+            <div style={{ display: 'flex', gap: 8 }}>
+                <button type="submit" disabled={form.processing}>
+                    {form.processing ? 'Saving…' : isEdit ? 'Save changes' : 'Create template'}
+                </button>
+                <button type="button" onClick={onDone}>Cancel</button>
+            </div>
+        </form>
+    )
+}
+
+function DeleteJwtTemplateButton({ id: _id, action }: { id: string; action: string }) {
+    const form = useForm({})
+    const onDelete = () => {
+        if (!window.confirm('Delete this JWT template? Refused if it was used to mint a token within the grace window (40h).')) return
+        form.delete(action, { preserveScroll: true })
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={onDelete}
+            disabled={form.processing}
+            style={{ padding: '4px 10px', background: '#fee2e2', color: '#b91c1c', border: 'none', borderRadius: 4 }}
+        >
+            Delete
+        </button>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// OAuth Applications (AU-11).
+// ---------------------------------------------------------------------------
+
+function OauthApplicationsSection({ applications }: { applications: OauthApplicationRow[] }) {
+    const url = useDashboardUrl()
+    const { active_project, active_environment } = useDashboard()
+    const { props: pageProps } = usePage<{ flash?: {
+        oauth_application_saved?: boolean
+        oauth_application_deleted?: boolean
+        oauth_application_secret?: string
+        oauth_application_id?: string
+    } }>()
+    const [adding, setAdding] = React.useState(false)
+    const [editing, setEditing] = React.useState<string | null>(null)
+
+    if (!active_project || !active_environment) {
+        return <p>No active environment.</p>
+    }
+    const base = `/${active_project.slug}/${active_environment.slug}/configure`
+    const flashedSecret = pageProps.flash?.oauth_application_secret ?? null
+
+    return (
+        <section>
+            <h2>OAuth Applications</h2>
+            <p style={{ color: '#475569', marginBottom: 16 }}>
+                Third-party applications authenticating against this environment as the IdP.
+                Confidential clients hold a server-side secret; public clients use PKCE.
+            </p>
+            {pageProps.flash?.oauth_application_saved && (
+                <p style={{ color: '#15803d', marginBottom: 12 }}>Application saved.</p>
+            )}
+            {pageProps.flash?.oauth_application_deleted && (
+                <p style={{ color: '#15803d', marginBottom: 12 }}>Application deleted — every active AuthorizationGrant was revoked.</p>
+            )}
+            {flashedSecret && (
+                <div style={{ marginBottom: 12, padding: 12, background: '#fef3c7', borderRadius: 6, fontSize: 13 }}>
+                    <strong>Plaintext client secret — capture now, it never appears again:</strong>
+                    <pre style={{ marginTop: 6, padding: 8, background: '#fff', border: '1px solid #e5e7eb' }}>{flashedSecret}</pre>
+                </div>
+            )}
+
+            {applications.length === 0 ? (
+                <p style={{ color: '#64748b' }}>No OAuth applications yet.</p>
+            ) : (
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, marginBottom: 16 }}>
+                    <thead>
+                        <tr style={{ borderBottom: '1px solid #e5e7eb' }}>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Name</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Client ID</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Type</th>
+                            <th style={{ textAlign: 'left', padding: 6 }}>Active grants</th>
+                            <th style={{ textAlign: 'right', padding: 6 }}></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {applications.map(a => (
+                            <tr key={a.id} style={{ borderBottom: '1px solid #f1f5f9' }}>
+                                <td style={{ padding: 6 }}>{a.name}</td>
+                                <td style={{ padding: 6 }}><code style={{ fontSize: 11 }}>{a.client_id}</code></td>
+                                <td style={{ padding: 6 }}>{a.is_public ? 'Public (PKCE)' : 'Confidential'}</td>
+                                <td style={{ padding: 6 }}>{a.grants_count}</td>
+                                <td style={{ padding: 6, textAlign: 'right' }}>
+                                    <button type="button" onClick={() => setEditing(editing === a.id ? null : a.id)} style={{ marginRight: 6 }}>
+                                        {editing === a.id ? 'Close' : 'Edit'}
+                                    </button>
+                                    {!a.is_public && (
+                                        <RotateSecretButton action={url(`${base}/oauth-applications/${a.id}/rotate-secret`)} />
+                                    )}
+                                    <DeleteOauthApplicationButton action={url(`${base}/oauth-applications/${a.id}`)} />
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+
+            {editing && (
+                <OauthApplicationForm
+                    application={applications.find(a => a.id === editing) ?? null}
+                    saveUrl={url(`${base}/oauth-applications/${editing}`)}
+                    onDone={() => setEditing(null)}
+                />
+            )}
+
+            {adding ? (
+                <OauthApplicationForm
+                    application={null}
+                    saveUrl={url(`${base}/oauth-applications`)}
+                    onDone={() => setAdding(false)}
+                />
+            ) : (
+                <button type="button" onClick={() => setAdding(true)} style={{ marginTop: 8 }}>
+                    Add OAuth application
+                </button>
+            )}
+        </section>
+    )
+}
+
+const KNOWN_SCOPES = ['openid', 'profile', 'email'] as const
+
+function OauthApplicationForm({ application, saveUrl, onDone }: { application: OauthApplicationRow | null; saveUrl: string; onDone: () => void }) {
+    const isEdit = application !== null
+    const form = useForm({
+        name: application?.name ?? '',
+        callback_urls_text: (application?.callback_urls ?? []).join('\n'),
+        scopes: application?.scopes ?? ['openid', 'profile', 'email'],
+        is_public: application?.is_public ?? false,
+    })
+    const [customScope, setCustomScope] = React.useState('')
+
+    const toggleScope = (scope: string) => {
+        const set = new Set(form.data.scopes)
+        if (set.has(scope)) set.delete(scope)
+        else set.add(scope)
+        form.setData('scopes', Array.from(set))
+    }
+
+    const onSubmit = (e: React.FormEvent) => {
+        e.preventDefault()
+        const urls = form.data.callback_urls_text.split('\n').map(s => s.trim()).filter(Boolean)
+        const payload = form.transform(() => ({
+            name: form.data.name,
+            callback_urls: urls,
+            scopes: form.data.scopes,
+            ...(isEdit ? {} : { is_public: form.data.is_public }),
+        }))
+        if (isEdit) {
+            payload.patch(saveUrl, { preserveScroll: true, onSuccess: onDone })
+        } else {
+            payload.post(saveUrl, { preserveScroll: true, onSuccess: onDone })
+        }
+    }
+
+    return (
+        <form onSubmit={onSubmit} style={{ marginTop: 8, padding: 12, border: '1px solid #e5e7eb', borderRadius: 6 }}>
+            <h3 style={{ marginTop: 0 }}>{isEdit ? 'Edit OAuth application' : 'New OAuth application'}</h3>
+
+            <label style={{ display: 'block', marginBottom: 8 }}>
+                <span style={{ display: 'block', color: '#475569' }}>Name</span>
+                <input type="text" value={form.data.name} onChange={e => form.setData('name', e.target.value)} style={{ width: '100%', padding: 6 }} />
+                {form.errors.name && <p style={{ color: '#b91c1c' }}>{form.errors.name}</p>}
+            </label>
+
+            <label style={{ display: 'block', marginBottom: 8 }}>
+                <span style={{ display: 'block', color: '#475569' }}>Callback URLs (one per line — must match exactly on /oauth/authorize)</span>
+                <textarea
+                    value={form.data.callback_urls_text}
+                    onChange={e => form.setData('callback_urls_text', e.target.value)}
+                    rows={4}
+                    placeholder="https://app.acme.example/oauth/callback"
+                    style={{ width: '100%', fontFamily: 'monospace', padding: 6 }}
+                />
+            </label>
+
+            <fieldset style={{ marginBottom: 8, padding: 8, border: '1px solid #e5e7eb', borderRadius: 4 }}>
+                <legend style={{ color: '#475569', padding: '0 6px' }}>Scopes</legend>
+                <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+                    {KNOWN_SCOPES.map(s => (
+                        <label key={s} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                            <input type="checkbox" checked={form.data.scopes.includes(s)} onChange={() => toggleScope(s)} />
+                            <code>{s}</code>
+                        </label>
+                    ))}
+                </div>
+                {form.data.scopes.filter(s => !KNOWN_SCOPES.includes(s as typeof KNOWN_SCOPES[number])).map(s => (
+                    <div key={s} style={{ display: 'inline-flex', alignItems: 'center', gap: 4, marginRight: 8, marginTop: 6 }}>
+                        <code>{s}</code>
+                        <button type="button" onClick={() => toggleScope(s)} style={{ background: 'transparent', border: 'none', color: '#b91c1c', cursor: 'pointer' }}>×</button>
+                    </div>
+                ))}
+                <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+                    <input
+                        type="text"
+                        value={customScope}
+                        onChange={e => setCustomScope(e.target.value)}
+                        placeholder="acme.read_billing"
+                        style={{ flex: 1, padding: 6 }}
+                    />
+                    <button
+                        type="button"
+                        onClick={() => {
+                            if (!customScope.trim()) return
+                            if (!form.data.scopes.includes(customScope.trim())) {
+                                form.setData('scopes', [...form.data.scopes, customScope.trim()])
+                            }
+                            setCustomScope('')
+                        }}
+                    >
+                        Add scope
+                    </button>
+                </div>
+            </fieldset>
+
+            {!isEdit && (
+                <label style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+                    <input type="checkbox" checked={form.data.is_public} onChange={e => form.setData('is_public', e.target.checked)} />
+                    Public client (PKCE-only; no client_secret minted)
+                </label>
+            )}
+
+            <div style={{ display: 'flex', gap: 8 }}>
+                <button type="submit" disabled={form.processing}>
+                    {form.processing ? 'Saving…' : isEdit ? 'Save changes' : 'Create application'}
+                </button>
+                <button type="button" onClick={onDone}>Cancel</button>
+            </div>
+        </form>
+    )
+}
+
+function RotateSecretButton({ action }: { action: string }) {
+    const form = useForm({})
+    const onClick = () => {
+        if (!window.confirm('Mint a fresh client secret? The previous secret is invalidated immediately — coordinate with the consumer.')) return
+        form.post(action, { preserveScroll: true })
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            disabled={form.processing}
+            style={{ marginRight: 6, padding: '4px 10px', background: '#fef3c7', border: 'none', borderRadius: 4 }}
+        >
+            Rotate secret
+        </button>
+    )
+}
+
+function DeleteOauthApplicationButton({ action }: { action: string }) {
+    const form = useForm({})
+    const onDelete = () => {
+        if (!window.confirm('Delete this OAuth application? Every active AuthorizationGrant will be revoked.')) return
+        form.delete(action, { preserveScroll: true })
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={onDelete}
+            disabled={form.processing}
+            style={{ padding: '4px 10px', background: '#fee2e2', color: '#b91c1c', border: 'none', borderRadius: 4 }}
         >
             Delete
         </button>

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -54,6 +54,17 @@ Route::prefix('{project_slug}/{env_slug}')->group(function (): void {
     Route::post('/configure/oauth-providers/{oauth_provider_id}/test', [DashboardController::class, 'testOauthProvider'])->name('dashboard.configure.oauth_providers.test');
     Route::post('/configure/enterprise-connections', [DashboardController::class, 'storeEnterpriseConnection'])->name('dashboard.configure.enterprise_connections.store');
     Route::delete('/configure/enterprise-connections/{enterprise_connection_id}', [DashboardController::class, 'destroyEnterpriseConnection'])->name('dashboard.configure.enterprise_connections.destroy');
+
+    // v0.7 JWT templates + OAuth applications (AU-11).
+    Route::post('/configure/jwt-templates', [DashboardController::class, 'storeJwtTemplate'])->name('dashboard.configure.jwt_templates.store');
+    Route::patch('/configure/jwt-templates/{jwt_template_id}', [DashboardController::class, 'updateJwtTemplate'])->name('dashboard.configure.jwt_templates.update');
+    Route::delete('/configure/jwt-templates/{jwt_template_id}', [DashboardController::class, 'destroyJwtTemplate'])->name('dashboard.configure.jwt_templates.destroy');
+
+    Route::post('/configure/oauth-applications', [DashboardController::class, 'storeOauthApplication'])->name('dashboard.configure.oauth_applications.store');
+    Route::patch('/configure/oauth-applications/{oauth_application_id}', [DashboardController::class, 'updateOauthApplication'])->name('dashboard.configure.oauth_applications.update');
+    Route::delete('/configure/oauth-applications/{oauth_application_id}', [DashboardController::class, 'destroyOauthApplication'])->name('dashboard.configure.oauth_applications.destroy');
+    Route::post('/configure/oauth-applications/{oauth_application_id}/rotate-secret', [DashboardController::class, 'rotateOauthApplicationSecret'])->name('dashboard.configure.oauth_applications.rotate_secret');
+
     Route::get('/email-templates', [DashboardController::class, 'emailTemplates'])->name('dashboard.email_templates');
 
     Route::get('/api-keys', [DashboardController::class, 'apiKeys'])->name('dashboard.api_keys');

--- a/tests/Feature/Http/Dashboard/ConfigureV07EditorsTest.php
+++ b/tests/Feature/Http/Dashboard/ConfigureV07EditorsTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\AuthorizationGrant;
+use App\Models\Environment;
+use App\Models\JwtTemplate;
+use App\Models\OauthApplication;
+use App\Models\Project;
+use App\Models\User;
+use Tests\Feature\Http\Dashboard\DashboardTestSupport;
+
+function bootEditorsEnv(): array
+{
+    $f = DashboardTestSupport::bootAdminEnv();
+    $bs = DashboardTestSupport::operatorWithMembership($f['env']);
+    $project = Project::create(['name' => 'Acme', 'slug' => 'acme', 'owner_organization_id' => $bs['workspace']->id]);
+    $env = Environment::create([
+        'project_id' => $project->id,
+        'kind' => Environment::KIND_PRODUCTION,
+        'slug' => 'production',
+        'routing_label' => 'acme',
+        'allowed_origins' => [],
+    ]);
+
+    return ['env' => $env, 'project' => $project, 'jwt' => $bs['jwt'], 'workspace' => $bs['workspace']];
+}
+
+it('renders JWT Templates + OAuth Applications subsections on Configure', function (): void {
+    $f = bootEditorsEnv();
+    JwtTemplate::factory()->create(['environment_id' => $f['env']->id, 'name' => 'supabase']);
+    OauthApplication::factory()->create(['environment_id' => $f['env']->id, 'name' => 'Acme Dashboard']);
+
+    $r = $this->withHeaders(DashboardTestSupport::headers($f['jwt']))
+        ->get('http://dashboard.authn.local/acme/production/configure/jwt-templates');
+    $r->assertOk()->assertJsonPath('component', 'Dashboard/Configure');
+    expect($r->json('props.jwt_templates.0.name'))->toBe('supabase');
+    expect($r->json('props.oauth_applications.0.name'))->toBe('Acme Dashboard');
+});
+
+it('stores a JWT template via the dashboard endpoint', function (): void {
+    $f = bootEditorsEnv();
+
+    $r = $this->withHeaders(DashboardTestSupport::headers($f['jwt']))
+        ->postJson('http://dashboard.authn.local/acme/production/configure/jwt-templates', [
+            'name' => 'supabase',
+            'claims' => ['sub' => '{{user.id}}', 'role' => 'authenticated'],
+            'lifetime' => 300,
+        ]);
+    $r->assertRedirect();
+
+    $row = JwtTemplate::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('name', 'supabase')
+        ->first();
+    expect($row)->not->toBeNull();
+    expect($row->lifetime)->toBe(300);
+    expect($row->claims['role'])->toBe('authenticated');
+});
+
+it('rejects JWT template names that violate the slug pattern', function (): void {
+    $f = bootEditorsEnv();
+
+    $r = $this->withHeaders(DashboardTestSupport::headers($f['jwt']))
+        ->postJson('http://dashboard.authn.local/acme/production/configure/jwt-templates', [
+            'name' => 'BadName',
+            'claims' => ['sub' => '{{user.id}}'],
+        ]);
+    $r->assertStatus(422);
+});
+
+it('patches a JWT template (claims + lifetime + clock skew + custom_signing_key revert)', function (): void {
+    $f = bootEditorsEnv();
+    $row = JwtTemplate::factory()->withCustomSigningKey('--initial--')->create([
+        'environment_id' => $f['env']->id,
+        'name' => 'tmpl',
+        'lifetime' => 60,
+    ]);
+
+    $r = $this->withHeaders(DashboardTestSupport::headers($f['jwt']))
+        ->patchJson('http://dashboard.authn.local/acme/production/configure/jwt-templates/'.$row->id, [
+            'claims' => ['sub' => '{{user.external_id}}'],
+            'lifetime' => 900,
+            'custom_signing_key' => null,
+        ]);
+    $r->assertRedirect();
+
+    $row->refresh();
+    expect($row->lifetime)->toBe(900);
+    expect($row->claims['sub'])->toBe('{{user.external_id}}');
+    expect($row->custom_signing_key)->toBeNull();
+});
+
+it('soft-deletes a JWT template via the dashboard endpoint', function (): void {
+    $f = bootEditorsEnv();
+    $row = JwtTemplate::factory()->create(['environment_id' => $f['env']->id, 'name' => 'temp']);
+
+    $r = $this->withHeaders(DashboardTestSupport::headers($f['jwt']))
+        ->deleteJson('http://dashboard.authn.local/acme/production/configure/jwt-templates/'.$row->id);
+    $r->assertRedirect();
+
+    $alive = JwtTemplate::query()->withoutGlobalScopes()
+        ->where('id', $row->id)
+        ->whereNull('removed_at')
+        ->exists();
+    expect($alive)->toBeFalse();
+});
+
+it('creates a confidential OAuth application and flashes the plaintext secret once', function (): void {
+    $f = bootEditorsEnv();
+
+    $r = $this->withHeaders(DashboardTestSupport::headers($f['jwt']))
+        ->postJson('http://dashboard.authn.local/acme/production/configure/oauth-applications', [
+            'name' => 'Acme Dashboard',
+            'callback_urls' => ['https://app.acme.example/oauth/callback'],
+            'scopes' => ['openid', 'profile', 'email'],
+        ]);
+    $r->assertRedirect()->assertSessionHas('oauth_application_secret');
+    $secret = session('oauth_application_secret');
+    expect($secret)->toStartWith('osec_');
+
+    $row = OauthApplication::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('name', 'Acme Dashboard')
+        ->first();
+    expect($row)->not->toBeNull();
+    expect($row->verifyClientSecret($secret))->toBeTrue();
+});
+
+it('creates a public OAuth application without a client_secret', function (): void {
+    $f = bootEditorsEnv();
+
+    $r = $this->withHeaders(DashboardTestSupport::headers($f['jwt']))
+        ->postJson('http://dashboard.authn.local/acme/production/configure/oauth-applications', [
+            'name' => 'Acme Mobile',
+            'callback_urls' => ['com.acme.app://oauth/callback'],
+            'is_public' => true,
+        ]);
+    $r->assertRedirect();
+
+    $row = OauthApplication::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('name', 'Acme Mobile')
+        ->first();
+    expect($row->is_public)->toBeTrue();
+    expect($row->hashed_client_secret)->toBeNull();
+});
+
+it('rotates a confidential client secret and flashes the new plaintext once', function (): void {
+    $f = bootEditorsEnv();
+    $row = OauthApplication::factory()->create(['environment_id' => $f['env']->id]);
+
+    $r = $this->withHeaders(DashboardTestSupport::headers($f['jwt']))
+        ->postJson('http://dashboard.authn.local/acme/production/configure/oauth-applications/'.$row->id.'/rotate-secret');
+    $r->assertRedirect()->assertSessionHas('oauth_application_secret');
+    $newSecret = session('oauth_application_secret');
+    expect($newSecret)->toStartWith('osec_');
+    expect($row->fresh()->verifyClientSecret($newSecret))->toBeTrue();
+});
+
+it('refuses to rotate a public client secret (no-op)', function (): void {
+    $f = bootEditorsEnv();
+    $row = OauthApplication::factory()->public()->create(['environment_id' => $f['env']->id]);
+
+    $r = $this->withHeaders(DashboardTestSupport::headers($f['jwt']))
+        ->postJson('http://dashboard.authn.local/acme/production/configure/oauth-applications/'.$row->id.'/rotate-secret');
+    $r->assertRedirect();
+    expect($row->fresh()->hashed_client_secret)->toBeNull();
+});
+
+it('soft-deletes an OAuth application and cascade-revokes its AuthorizationGrants', function (): void {
+    $f = bootEditorsEnv();
+    $user = User::create(['environment_id' => $f['env']->id]);
+    $row = OauthApplication::factory()->create(['environment_id' => $f['env']->id]);
+    $grant = AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $row->id,
+        'user_id' => $user->id,
+    ]);
+    expect($grant->fresh()->isActive())->toBeTrue();
+
+    $r = $this->withHeaders(DashboardTestSupport::headers($f['jwt']))
+        ->deleteJson('http://dashboard.authn.local/acme/production/configure/oauth-applications/'.$row->id);
+    $r->assertRedirect();
+
+    expect($grant->fresh()->isActive())->toBeFalse();
+    $alive = OauthApplication::query()->withoutGlobalScopes()
+        ->where('id', $row->id)->whereNull('removed_at')->exists();
+    expect($alive)->toBeFalse();
+});


### PR DESCRIPTION
Closes #247 (AU-11).

## Summary

Two new operator-facing subsections under Dashboard → Configure:

- **JWT Templates** — list table + add/edit/delete inline form + soft-delete via `removed_at`. Form takes `name` (slug pattern, immutable on edit), `claims` JSON (textarea + parse/validate), `lifetime` / `allowed_clock_skew`, `signing_algorithm` (immutable on edit), and an optional `custom_signing_key` (PEM / base64; clearing reverts to the env signing key).
- **OAuth Applications** — list table + add/edit/delete + rotate-secret button. Confidential clients get a single-shot plaintext secret on create + rotate flashed via the session bag; subsequent reads never re-leak it. Public clients (PKCE) skip the secret entirely. Soft-delete cascade-revokes every active `AuthorizationGrant` on the same row.

Backed by new dashboard routes that proxy the env-scoped models directly (same pattern as `updateAppearance` / `updateMultiFactor`). Validation mirrors the OA-1 / OA-2 BAPI schemas — slug pattern on `JwtTemplate.name`, 1–100 char name, 1+ `callback_urls`, optional custom scopes via free-text add.

## Scope cut: Monaco deferred

Monaco JSON editor for the claims field is deferred to v0.8 (#257 — same scope cut team-lead accepted for AU-13). The textarea-based editor with JSON parse + diff stays inside the 220 KB shared-vendor bundle budget — Configure chunk lands at **62.77 KB / 12.38 KB gzipped**.

## Pest

Covers: subsection rendering with seeded rows; JwtTemplate store + slug-pattern rejection + PATCH (claims/lifetime/custom_signing_key revert) + soft-delete; OauthApplication confidential create + plaintext flash; public create with no secret; rotate-secret confidential happy path; public rotate-secret no-op; DELETE soft-removes + cascade-revokes grants. 10 Pest tests, all passing; full Dashboard suite still green (49 tests).