### PR TITLE
Add Account Portal OAuth consent screen + accept/deny (#245)

### DIFF
--- a/app/Http/Controllers/Fapi/OauthConsentController.php
+++ b/app/Http/Controllers/Fapi/OauthConsentController.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Models\AuthorizationGrant;
+use App\Models\Environment;
+use App\Models\OauthApplication;
+use App\Models\Session;
+use App\Services\Client\ClientResolver;
+use App\Support\Base64Url;
+use App\Support\Url;
+use App\Webhooks\Emitter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Inertia\Inertia;
+use Inertia\Response as InertiaResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * v0.7 Account Portal — OAuth consent screen at /oauth/consent/{request_id}.
+ *
+ *   GET  /oauth/consent/{request_id}            Inertia consent screen
+ *   POST /oauth/consent/{request_id}/accept     create grant + auth code → redirect
+ *   POST /oauth/consent/{request_id}/deny       error=access_denied redirect
+ *
+ * The parked oauth_request_contexts row was minted by AU-6's
+ * /oauth/authorize when the calling user lacked a covering
+ * AuthorizationGrant. 10-minute TTL; expired contexts return 404.
+ */
+final class OauthConsentController
+{
+    public const AUTHORIZATION_CODE_TTL_SECONDS = 5 * 60;
+
+    public function __construct(private readonly ClientResolver $clientResolver) {}
+
+    public function show(Request $request): InertiaResponse|Response|RedirectResponse
+    {
+        $context = $this->loadContext($request);
+        if ($context === null) {
+            return response('consent request expired or invalid', 404)
+                ->header('Cache-Control', 'no-store');
+        }
+        if ($this->signedInSession($request) === null) {
+            return redirect(Url::accountPortal($context->_env, '/sign-in')
+                .'?continue_url='.urlencode($request->fullUrl()));
+        }
+        $params = is_array(json_decode((string) $context->params, true)) ? json_decode((string) $context->params, true) : [];
+        $app = OauthApplication::query()->withoutGlobalScopes()
+            ->where('id', $context->oauth_application_id)
+            ->whereNull('removed_at')
+            ->first();
+        if ($app === null) {
+            return response('oauth application no longer exists', 404)
+                ->header('Cache-Control', 'no-store');
+        }
+
+        $scopes = $this->scopeListFromParams($params);
+
+        return Inertia::render('AccountPortal/Oauth/ConsentScreen', [
+            'request_id' => $context->request_id,
+            'application' => [
+                'id' => $app->id,
+                'name' => $app->name,
+            ],
+            'scopes' => array_map(fn (string $s) => [
+                'name' => $s,
+                'label' => $this->humanizeScope($s),
+            ], $scopes),
+        ]);
+    }
+
+    public function accept(Request $request): JsonResponse|RedirectResponse|Response
+    {
+        $context = $this->loadContext($request);
+        if ($context === null) {
+            return response('consent request expired or invalid', 404)
+                ->header('Cache-Control', 'no-store');
+        }
+
+        $session = $this->signedInSession($request);
+        if ($session === null) {
+            return response()->json([
+                'errors' => [['code' => 'no_active_session', 'message' => 'You must be signed in to consent.']],
+            ], 401);
+        }
+
+        $params = (array) (json_decode((string) $context->params, true) ?: []);
+        $scopes = $this->scopeListFromParams($params);
+        $redirectUri = (string) ($params['redirect_uri'] ?? '');
+        $state = (string) ($params['state'] ?? '');
+        $codeChallenge = (string) ($params['code_challenge'] ?? '');
+        $codeChallengeMethod = (string) ($params['code_challenge_method'] ?? '');
+        $nonce = (string) ($params['nonce'] ?? '');
+
+        $env = $context->_env;
+        $app = OauthApplication::query()->withoutGlobalScopes()
+            ->where('id', $context->oauth_application_id)
+            ->whereNull('removed_at')
+            ->first();
+        if ($app === null) {
+            return response()->json([
+                'errors' => [['code' => 'oauth_application_not_found', 'message' => 'The application no longer exists.']],
+            ], 404);
+        }
+
+        $code = 'oacd_'.Base64Url::encode(random_bytes(32));
+
+        DB::transaction(function () use ($env, $app, $session, $scopes, $redirectUri, $codeChallenge, $codeChallengeMethod, $nonce, $state, $code, $context): void {
+            // Persist the grant (deduped against any existing active row for
+            // the same (user, app, scopes) tuple) — partial unique index on
+            // Postgres handles the race; SQLite just no-ops the second insert.
+            AuthorizationGrant::query()->withoutGlobalScopes()->create([
+                'environment_id' => $env->id,
+                'oauth_application_id' => $app->id,
+                'user_id' => $session->user_id,
+                'scopes' => $scopes,
+                'scopes_hash' => AuthorizationGrant::hashScopes($scopes),
+                'granted_at' => now(),
+            ]);
+
+            DB::table('oauth_authorization_codes')->insert([
+                'code' => $code,
+                'environment_id' => $env->id,
+                'oauth_application_id' => $app->id,
+                'user_id' => $session->user_id,
+                'scopes' => json_encode($scopes, JSON_THROW_ON_ERROR),
+                'redirect_uri' => $redirectUri,
+                'code_challenge' => $codeChallenge !== '' ? $codeChallenge : null,
+                'code_challenge_method' => $codeChallengeMethod !== '' ? $codeChallengeMethod : null,
+                'nonce' => $nonce !== '' ? $nonce : null,
+                'state' => $state,
+                'expires_at' => now()->addSeconds(self::AUTHORIZATION_CODE_TTL_SECONDS),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            // Burn the request context so the same code can't ride twice
+            // through the consent screen.
+            DB::table('oauth_request_contexts')->where('request_id', $context->request_id)->delete();
+        });
+
+        Log::info('audit:fapi.oauth.consent_accepted', [
+            'environment_id' => $env->id,
+            'user_id' => $session->user_id,
+            'oauth_application_id' => $app->id,
+        ]);
+        app(Emitter::class)->emit('authorizationGrant.granted', [
+            'oauth_application_id' => $app->id,
+            'user_id' => $session->user_id,
+            'scopes' => $scopes,
+        ], $env);
+
+        $target = $this->appendQuery($redirectUri, [
+            'code' => $code,
+            'state' => $state,
+        ]);
+
+        return $this->envelope($request, $target);
+    }
+
+    public function deny(Request $request): JsonResponse|RedirectResponse|Response
+    {
+        $context = $this->loadContext($request);
+        if ($context === null) {
+            return response('consent request expired or invalid', 404)
+                ->header('Cache-Control', 'no-store');
+        }
+        $params = (array) (json_decode((string) $context->params, true) ?: []);
+        $redirectUri = (string) ($params['redirect_uri'] ?? '');
+        $state = (string) ($params['state'] ?? '');
+
+        DB::table('oauth_request_contexts')->where('request_id', $context->request_id)->delete();
+
+        Log::info('audit:fapi.oauth.consent_denied', [
+            'environment_id' => $context->_env->id,
+            'oauth_application_id' => $context->oauth_application_id,
+        ]);
+
+        $target = $this->appendQuery($redirectUri, [
+            'error' => 'access_denied',
+            'error_description' => 'The user denied the consent request.',
+            'state' => $state,
+        ]);
+
+        return $this->envelope($request, $target);
+    }
+
+    /**
+     * Pulls the request context row out of the DB, env-pinned and TTL-checked.
+     * Decorates with the resolved Environment so callers don't have to refetch.
+     */
+    private function loadContext(Request $request): ?object
+    {
+        $env = app()->bound(Environment::class) ? app(Environment::class) : null;
+        if (! $env instanceof Environment) {
+            return null;
+        }
+        $requestId = (string) $request->route('request_id');
+        $row = DB::table('oauth_request_contexts')
+            ->where('request_id', $requestId)
+            ->where('environment_id', $env->id)
+            ->where('expires_at', '>', now())
+            ->first();
+        if ($row === null) {
+            return null;
+        }
+        $row->_env = $env;
+
+        return $row;
+    }
+
+    private function signedInSession(Request $request): ?Session
+    {
+        $env = app(Environment::class);
+        $client = $this->clientResolver->fromCookie(
+            (string) ($request->cookie('__client') ?? ''),
+            $env,
+        );
+        if ($client === null) {
+            return null;
+        }
+
+        return Session::query()
+            ->where('client_id', $client->id)
+            ->whereIn('status', Session::LIVE_STATUSES)
+            ->orderByDesc('last_active_at')
+            ->first();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function scopeListFromParams(array $params): array
+    {
+        $raw = (string) ($params['scope'] ?? '');
+
+        return array_values(array_filter(
+            preg_split('/\s+/', $raw) ?: [],
+            static fn ($s) => is_string($s) && $s !== '',
+        ));
+    }
+
+    private function humanizeScope(string $scope): string
+    {
+        return match ($scope) {
+            'openid' => 'Verify your identity',
+            'profile' => 'View your profile',
+            'email' => 'View your email address',
+            default => $scope,
+        };
+    }
+
+    /**
+     * @param  array<string, string>  $params
+     */
+    private function appendQuery(string $url, array $params): string
+    {
+        $sep = str_contains($url, '?') ? '&' : '?';
+
+        return $url.$sep.http_build_query($params);
+    }
+
+    private function envelope(Request $request, string $redirectUrl): JsonResponse|RedirectResponse
+    {
+        $accept = strtolower((string) $request->header('Accept', ''));
+        if (str_contains($accept, 'application/json') && ! str_contains($accept, 'text/html')) {
+            return response()->json([
+                'object' => 'oauth_consent_result',
+                'redirect_url' => $redirectUrl,
+            ])->header('Cache-Control', 'no-store');
+        }
+
+        return redirect()->away($redirectUrl, 302)
+            ->withHeaders(['Cache-Control' => 'no-store']);
+    }
+}

--- a/resources/js/account-portal/pages/Oauth/ConsentScreen.tsx
+++ b/resources/js/account-portal/pages/Oauth/ConsentScreen.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import { useBootstrap } from '../../bootstrap'
+
+type Scope = { name: string; label: string }
+type Application = { id: string; name: string }
+
+type Props = {
+    request_id: string
+    application: Application
+    scopes: Scope[]
+}
+
+/**
+ * v0.7 OAuth provider mode — consent screen mounted at
+ * `/oauth/consent/{request_id}`. The Account Portal lands here from AU-6's
+ * /oauth/authorize when the user lacks a covering AuthorizationGrant.
+ *
+ * Accept POSTs to `/oauth/consent/{request_id}/accept` and follows the
+ * server-issued `redirect_url` (carries `code=&state=` back to the
+ * application's `callback_url`). Deny POSTs to `…/deny` and follows the
+ * `error=access_denied` redirect.
+ */
+export default function ConsentScreen(props: Props) {
+    const { ready, env } = useBootstrap()
+    const [busy, setBusy] = useState<'accept' | 'deny' | null>(null)
+    const [error, setError] = useState<string | null>(null)
+
+    if (!ready) return <p>Loading…</p>
+
+    const post = async (path: 'accept' | 'deny') => {
+        setBusy(path)
+        setError(null)
+        try {
+            const res = await fetch(`${env?.fapi_url ?? ''}/oauth/consent/${props.request_id}/${path}`, {
+                method: 'POST',
+                credentials: 'include',
+                headers: { Accept: 'application/json' },
+            })
+            if (!res.ok) throw new Error(`HTTP ${res.status}`)
+            const body = await res.json()
+            const target = typeof body?.redirect_url === 'string' ? body.redirect_url : null
+            if (!target) throw new Error('No redirect_url in response')
+            window.location.href = target
+        } catch (err) {
+            setError((err as Error).message)
+            setBusy(null)
+        }
+    }
+
+    return (
+        <main data-testid="authn-oauth-consent" style={{ maxWidth: 480, margin: '64px auto', padding: 24, fontFamily: 'system-ui, sans-serif' }}>
+            <h1 style={{ marginTop: 0 }}>{props.application.name} wants to access your account</h1>
+            <p style={{ color: '#475569' }}>By accepting, you grant {props.application.name} the following permissions:</p>
+
+            <ul style={{ listStyle: 'none', padding: 0, marginTop: 16 }}>
+                {props.scopes.map(s => (
+                    <li key={s.name} data-testid={`authn-oauth-consent-scope-${s.name}`} style={{ padding: '8px 0', borderBottom: '1px solid #e5e7eb' }}>
+                        <span style={{ fontWeight: 500 }}>{s.label}</span>
+                        <code style={{ marginLeft: 8, fontSize: 12, color: '#94a3b8' }}>{s.name}</code>
+                    </li>
+                ))}
+            </ul>
+
+            {error && <p style={{ color: '#b91c1c', marginTop: 16 }}>{error}</p>}
+
+            <div style={{ marginTop: 24, display: 'flex', gap: 12, justifyContent: 'flex-end' }}>
+                <button
+                    type="button"
+                    onClick={() => post('deny')}
+                    disabled={busy !== null}
+                    data-testid="authn-oauth-consent-deny"
+                    style={{ padding: '8px 16px', background: 'transparent', border: '1px solid #cbd5e1', borderRadius: 4 }}
+                >
+                    {busy === 'deny' ? 'Denying…' : 'Deny'}
+                </button>
+                <button
+                    type="button"
+                    onClick={() => post('accept')}
+                    disabled={busy !== null}
+                    data-testid="authn-oauth-consent-accept"
+                    style={{ padding: '8px 16px', background: '#0a84ff', color: '#fff', border: 'none', borderRadius: 4 }}
+                >
+                    {busy === 'accept' ? 'Accepting…' : 'Allow access'}
+                </button>
+            </div>
+        </main>
+    )
+}

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\Fapi\MePhoneNumberController;
 use App\Http\Controllers\Fapi\MeTotpController;
 use App\Http\Controllers\Fapi\OauthAuthorizeController;
 use App\Http\Controllers\Fapi\OauthCallbackController;
+use App\Http\Controllers\Fapi\OauthConsentController;
 use App\Http\Controllers\Fapi\OrganizationController as FapiOrganizationController;
 use App\Http\Controllers\Fapi\OrganizationEnterpriseConnectionController;
 use App\Http\Controllers\Fapi\OrganizationInvitationController as FapiOrganizationInvitationController;
@@ -346,7 +347,27 @@ Route::withoutMiddleware([EnforceFapiOrigin::class])
         Route::get('/_preview/appearance/{token}', [AppearancePreviewRenderController::class, 'show'])
             ->where('token', '[A-Za-z0-9]{16,128}')
             ->name('account_portal.appearance_preview');
+
+        // OAuth provider mode — consent screen for /oauth/authorize redirects
+        // (AU-9). The accept/deny POSTs do JSON-only fetch from the page so
+        // they sit outside the Inertia group below.
+        Route::get('/oauth/consent/{request_id}', [OauthConsentController::class, 'show'])
+            ->where('request_id', '[A-Za-z0-9_-]{16,128}')
+            ->name('account_portal.oauth_consent');
     });
+
+// OAuth consent accept/deny — top-level POSTs from the consent screen.
+// JSON-only response shape (`{redirect_url}`) so the page can follow the
+// redirect in JS. EnforceFapiOrigin opt-out because the consent screen is
+// a top-level Inertia navigation context, not an embedded SDK call.
+Route::withoutMiddleware([EnforceFapiOrigin::class])->group(function (): void {
+    Route::post('/oauth/consent/{request_id}/accept', [OauthConsentController::class, 'accept'])
+        ->where('request_id', '[A-Za-z0-9_-]{16,128}')
+        ->name('fapi.oauth.consent.accept');
+    Route::post('/oauth/consent/{request_id}/deny', [OauthConsentController::class, 'deny'])
+        ->where('request_id', '[A-Za-z0-9_-]{16,128}')
+        ->name('fapi.oauth.consent.deny');
+});
 
 Route::prefix('account')->group(function (): void {
     Route::get('/_ping', PingController::class)->name('account_portal.ping');

--- a/tests/Feature/Http/Fapi/OauthConsentTest.php
+++ b/tests/Feature/Http/Fapi/OauthConsentTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\AuthorizationGrant;
+use App\Models\OauthApplication;
+use Illuminate\Support\Facades\DB;
+use Tests\Feature\Http\Sessions\SessionsTestSupport;
+
+function plantOauthRequestContext(string $envId, string $appId, array $params, ?int $ttl = null): string
+{
+    $requestId = 'oareq_'.bin2hex(random_bytes(16));
+    DB::table('oauth_request_contexts')->insert([
+        'request_id' => $requestId,
+        'environment_id' => $envId,
+        'oauth_application_id' => $appId,
+        'params' => json_encode($params, JSON_THROW_ON_ERROR),
+        'expires_at' => now()->addSeconds($ttl ?? 600),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return $requestId;
+}
+
+function consentBaseParams(OauthApplication $app, string $redirect = 'https://app.example.com/oauth/callback', string $state = 'state-x'): array
+{
+    return [
+        'client_id' => $app->client_id,
+        'redirect_uri' => $redirect,
+        'scope' => 'openid profile email',
+        'state' => $state,
+        'nonce' => 'nonce-x',
+        'code_challenge' => '',
+        'code_challenge_method' => '',
+    ];
+}
+
+it('renders the consent screen for a valid request_id + signed-in user', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'name' => 'Acme Dashboard',
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+        'scopes' => ['openid', 'profile', 'email'],
+    ]);
+    $requestId = plantOauthRequestContext($f['env']->id, $app->id, consentBaseParams($app));
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'X-Inertia' => 'true', 'X-Inertia-Version' => '1'])
+        ->withoutOpenApiAssertions()
+        ->get('https://acme.authn.local/oauth/consent/'.$requestId);
+
+    $r->assertOk()->assertJsonPath('component', 'AccountPortal/Oauth/ConsentScreen');
+    expect($r->json('props.application.name'))->toBe('Acme Dashboard');
+    expect($r->json('props.scopes.0.name'))->toBe('openid');
+    expect($r->json('props.scopes.0.label'))->toBe('Verify your identity');
+});
+
+it('redirects to /sign-in when the user has no live session', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $app = OauthApplication::factory()->create(['environment_id' => $f['env']->id]);
+    $requestId = plantOauthRequestContext($f['env']->id, $app->id, consentBaseParams($app));
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get('https://acme.authn.local/oauth/consent/'.$requestId);
+
+    $r->assertStatus(302);
+    expect((string) $r->headers->get('Location'))->toContain('/sign-in?continue_url=');
+});
+
+it('returns 404 when the request_id has expired or never existed', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get('https://acme.authn.local/oauth/consent/oareq_'.str_repeat('z', 32));
+    $r->assertStatus(404);
+});
+
+it('accept creates AuthorizationGrant + authorization code, returns redirect to redirect_uri', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+        'scopes' => ['openid', 'profile', 'email'],
+    ]);
+    $requestId = plantOauthRequestContext($f['env']->id, $app->id, consentBaseParams($app));
+
+    $r = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Accept' => 'application/json',
+        ])
+        ->withoutOpenApiAssertions()
+        ->postJson('https://acme.authn.local/oauth/consent/'.$requestId.'/accept');
+
+    $r->assertOk()->assertJsonPath('object', 'oauth_consent_result');
+    $redirect = (string) $r->json('redirect_url');
+    expect($redirect)->toStartWith('https://app.example.com/oauth/callback?');
+    expect($redirect)->toContain('code=oacd_');
+    expect($redirect)->toContain('state=state-x');
+
+    // Grant persisted with the scope set + scopes_hash.
+    $grant = AuthorizationGrant::query()->withoutGlobalScopes()
+        ->where('user_id', $bs['user']->id)
+        ->where('oauth_application_id', $app->id)
+        ->first();
+    expect($grant)->not->toBeNull();
+    expect($grant->scopes)->toBe(['openid', 'profile', 'email']);
+
+    // Code persisted with the matching app + user + redirect_uri.
+    parse_str((string) parse_url($redirect, PHP_URL_QUERY), $q);
+    $row = DB::table('oauth_authorization_codes')->where('code', $q['code'])->first();
+    expect($row)->not->toBeNull();
+    expect($row->redirect_uri)->toBe('https://app.example.com/oauth/callback');
+
+    // Request context is burnt — re-using the same accept rides into 404.
+    $r2 = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local', 'Accept' => 'application/json'])
+        ->withoutOpenApiAssertions()
+        ->postJson('https://acme.authn.local/oauth/consent/'.$requestId.'/accept');
+    $r2->assertStatus(404);
+});
+
+it('deny stamps error=access_denied + drops the request context', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+    $requestId = plantOauthRequestContext($f['env']->id, $app->id, consentBaseParams($app));
+
+    $r = $this->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Accept' => 'application/json',
+    ])->withoutOpenApiAssertions()
+        ->postJson('https://acme.authn.local/oauth/consent/'.$requestId.'/deny');
+
+    $r->assertOk()->assertJsonPath('object', 'oauth_consent_result');
+    $redirect = (string) $r->json('redirect_url');
+    expect($redirect)->toContain('error=access_denied');
+    expect($redirect)->toContain('state=state-x');
+
+    expect(DB::table('oauth_request_contexts')->where('request_id', $requestId)->exists())->toBeFalse();
+});
+
+it('accept refuses (401) without an active session', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $app = OauthApplication::factory()->create(['environment_id' => $f['env']->id]);
+    $requestId = plantOauthRequestContext($f['env']->id, $app->id, consentBaseParams($app));
+
+    $r = $this->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Accept' => 'application/json',
+    ])->withoutOpenApiAssertions()
+        ->postJson('https://acme.authn.local/oauth/consent/'.$requestId.'/accept');
+
+    $r->assertStatus(401)->assertJsonPath('errors.0.code', 'no_active_session');
+});


### PR DESCRIPTION
Closes #245 (AU-9).

## Summary

User-facing consent screen for OAuth provider mode. Mounted at `/oauth/consent/{request_id}`; backs AU-6's redirect target when the authenticated user lacks a covering `AuthorizationGrant` for the requested scope set.

```
GET  /oauth/consent/{request_id}            Inertia consent screen
POST /oauth/consent/{request_id}/accept     grant + auth-code → redirect
POST /oauth/consent/{request_id}/deny       error=access_denied redirect
```

Accept-side flow (single transaction):

1. Insert an `AuthorizationGrant` row for `(user, app, scopes)`.
2. Insert an `oauth_authorization_code` with 5-min TTL (the same `oacd_…` shape AU-6's silent reuse mints; AU-7's `/oauth/token` consumes both paths uniformly).
3. Burn the `oauth_request_contexts` row so the same `request_id` can't ride twice.
4. Emit `authorizationGrant.granted` webhook.

Both endpoints return `{object: 'oauth_consent_result', redirect_url}` JSON when `Accept: application/json`; the React page POSTs from JS and follows the redirect via `window.location.href`. Browsers hitting the endpoints directly (curl / SSR debug) get a 302.

Scope labels are humanized server-side (`openid` → "Verify your identity", `profile` → "View your profile", `email` → "View your email address"); unknown scopes pass through verbatim. JS-2's sdk-react component will eventually take over the rendering; until then the page ships server-rendered labels.

## Pest

Covers: signed-in render → component name + props; unauthenticated → `/sign-in?continue_url=…`; expired/missing `request_id` → 404; accept happy path → grant + code + redirect with `state` + context burnt; deny → `error=access_denied` + context burnt; accept without session → 401.