### PR TITLE
Add FAPI POST /oauth/token + /oauth/token_info (#243)

### DIFF
--- a/app/Http/Controllers/Fapi/OauthTokenController.php
+++ b/app/Http/Controllers/Fapi/OauthTokenController.php
@@ -1,0 +1,471 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Models\AuthorizationGrant;
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\OauthApplication;
+use App\Models\SigningKey;
+use App\Models\User;
+use App\Support\Base64Url;
+use App\Support\Url;
+use App\Webhooks\Emitter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Token\Parser;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+
+/**
+ * v0.7 OAuth provider mode token endpoint — RFC 6749 §4.1.3 (auth-code
+ * grant) + §6 (refresh-token grant) + OIDC §3.1.3.7 (id_token), plus
+ * RFC 7662 token introspection.
+ *
+ *   POST /oauth/token        application/x-www-form-urlencoded
+ *   POST /oauth/token_info   application/x-www-form-urlencoded
+ *
+ * Both `id_token` and `access_token` are RS256 JWTs signed with the
+ * env's active SigningKey (the same key surfaced at
+ * `/.well-known/jwks.json` so verifiers don't need to bind anything
+ * new). The refresh-token grant rotates the row — the previous
+ * `oauth_refresh_tokens` row is revoked in the same transaction.
+ */
+final class OauthTokenController
+{
+    public const ACCESS_TOKEN_TTL_SECONDS = 3600;
+
+    public const REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 3600;
+
+    /**
+     * `POST /oauth/token` dispatcher.
+     */
+    public function token(Request $request): JsonResponse
+    {
+        $grantType = (string) $request->input('grant_type', '');
+
+        return match ($grantType) {
+            'authorization_code' => $this->exchangeAuthorizationCode($request),
+            'refresh_token' => $this->exchangeRefreshToken($request),
+            default => $this->oauthError(400, 'unsupported_grant_type',
+                'Supported grant_types: authorization_code, refresh_token.'),
+        };
+    }
+
+    public function tokenInfo(Request $request): JsonResponse
+    {
+        $token = (string) $request->input('token', '');
+        if ($token === '') {
+            return response()->json(['active' => false])->header('Cache-Control', 'no-store');
+        }
+
+        // Access tokens are JWTs we issued — parse + verify against the env JWKS.
+        $env = app(Environment::class);
+        $parsed = $this->parseAccessToken($env, $token);
+        if ($parsed === null) {
+            return response()->json(['active' => false])->header('Cache-Control', 'no-store');
+        }
+
+        return response()->json([
+            'active' => true,
+            'sub' => $parsed['sub'],
+            'scope' => $parsed['scope'],
+            'exp' => $parsed['exp'],
+            'iat' => $parsed['iat'],
+            'client_id' => $parsed['client_id'],
+            'token_type' => 'Bearer',
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    private function exchangeAuthorizationCode(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $code = (string) $request->input('code', '');
+        $redirectUri = (string) $request->input('redirect_uri', '');
+
+        $codeRow = DB::table('oauth_authorization_codes')
+            ->where('code', $code)
+            ->where('environment_id', $env->id)
+            ->whereNull('consumed_at')
+            ->where('expires_at', '>', now())
+            ->first();
+        if ($codeRow === null) {
+            return $this->oauthError(400, 'invalid_grant', 'authorization_code is unknown, expired, or already consumed.');
+        }
+
+        $app = OauthApplication::query()->withoutGlobalScopes()
+            ->where('id', $codeRow->oauth_application_id)
+            ->whereNull('removed_at')
+            ->first();
+        if ($app === null) {
+            return $this->oauthError(400, 'invalid_grant', 'The associated OauthApplication has been deleted.');
+        }
+
+        if ($redirectUri === '' || $redirectUri !== $codeRow->redirect_uri) {
+            return $this->oauthError(400, 'invalid_grant', 'redirect_uri does not match the original /oauth/authorize request.');
+        }
+
+        // Client authentication.
+        $clientAuth = $this->authenticateClient($request, $app, $codeRow);
+        if ($clientAuth !== null) {
+            return $clientAuth;
+        }
+
+        // Single-use: consume the code.
+        DB::table('oauth_authorization_codes')->where('code', $code)
+            ->update(['consumed_at' => now(), 'updated_at' => now()]);
+
+        // Confirm a still-active AuthorizationGrant covers this scope set —
+        // gives AU-10's revoke hook teeth (no token issued from a code minted
+        // before the user revoked the grant).
+        $scopes = is_array(json_decode((string) $codeRow->scopes, true)) ? json_decode((string) $codeRow->scopes, true) : [];
+        $grant = AuthorizationGrant::query()->withoutGlobalScopes()
+            ->where('user_id', $codeRow->user_id)
+            ->where('oauth_application_id', $app->id)
+            ->where('scopes_hash', AuthorizationGrant::hashScopes($scopes))
+            ->whereNull('revoked_at')
+            ->first();
+        if ($grant === null) {
+            return $this->oauthError(400, 'invalid_grant', 'The covering AuthorizationGrant has been revoked.');
+        }
+
+        return $this->mintTokens(
+            env: $env,
+            app: $app,
+            userId: (string) $codeRow->user_id,
+            scopes: $scopes,
+            nonce: $codeRow->nonce !== null ? (string) $codeRow->nonce : null,
+            wantsIdToken: in_array('openid', $scopes, true),
+        );
+    }
+
+    private function exchangeRefreshToken(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $plaintext = (string) $request->input('refresh_token', '');
+        if ($plaintext === '') {
+            return $this->oauthError(400, 'invalid_grant', 'refresh_token is required.');
+        }
+        $hash = hash('sha256', $plaintext);
+        $row = DB::table('oauth_refresh_tokens')
+            ->where('hashed_token', $hash)
+            ->where('environment_id', $env->id)
+            ->whereNull('revoked_at')
+            ->where('expires_at', '>', now())
+            ->first();
+        if ($row === null) {
+            return $this->oauthError(400, 'invalid_grant', 'refresh_token is unknown, expired, or revoked.');
+        }
+        $app = OauthApplication::query()->withoutGlobalScopes()
+            ->where('id', $row->oauth_application_id)
+            ->whereNull('removed_at')
+            ->first();
+        if ($app === null) {
+            return $this->oauthError(400, 'invalid_grant', 'The associated OauthApplication has been deleted.');
+        }
+        $clientAuth = $this->authenticateClient($request, $app, null);
+        if ($clientAuth !== null) {
+            return $clientAuth;
+        }
+
+        $grant = AuthorizationGrant::query()->withoutGlobalScopes()
+            ->where('user_id', $row->user_id)
+            ->where('oauth_application_id', $app->id)
+            ->whereNull('revoked_at')
+            ->first();
+        if ($grant === null) {
+            return $this->oauthError(400, 'invalid_grant', 'The covering AuthorizationGrant has been revoked.');
+        }
+
+        // Rotate: revoke the consumed row, mint a fresh one.
+        DB::table('oauth_refresh_tokens')->where('id', $row->id)->update(['revoked_at' => now(), 'updated_at' => now()]);
+        $scopes = is_array(json_decode((string) $row->scopes, true)) ? json_decode((string) $row->scopes, true) : [];
+
+        return $this->mintTokens(
+            env: $env,
+            app: $app,
+            userId: (string) $row->user_id,
+            scopes: $scopes,
+            nonce: null,
+            wantsIdToken: in_array('openid', $scopes, true),
+            rotatedFromId: (string) $row->id,
+        );
+    }
+
+    /**
+     * @param  list<string>  $scopes
+     */
+    private function mintTokens(
+        Environment $env,
+        OauthApplication $app,
+        string $userId,
+        array $scopes,
+        ?string $nonce,
+        bool $wantsIdToken,
+        ?string $rotatedFromId = null,
+    ): JsonResponse {
+        $signingKey = $env->signingKeys()
+            ->where('status', SigningKey::STATUS_ACTIVE)
+            ->latest('activated_at')
+            ->first();
+        if ($signingKey === null) {
+            return $this->oauthError(500, 'server_error', 'No active signing key for this environment.');
+        }
+
+        $now = now();
+        $accessExpires = $now->copy()->addSeconds(self::ACCESS_TOKEN_TTL_SECONDS);
+        $refreshExpires = $now->copy()->addSeconds(self::REFRESH_TOKEN_TTL_SECONDS);
+        $config = Configuration::forAsymmetricSigner(
+            new Sha256,
+            InMemory::plainText($signingKey->privatePem()),
+            InMemory::plainText('public-not-needed-for-signing'),
+        );
+
+        // Access token — JWT, audience pinned to the client_id so verifiers
+        // can disambiguate this from a session token.
+        $accessBuilder = $config->builder()
+            ->withHeader('kid', $signingKey->id)
+            ->issuedBy(Url::fapi($env, ''))
+            ->relatedTo($userId)
+            ->permittedFor($app->client_id)
+            ->identifiedBy('oat_'.Base64Url::encode(random_bytes(16)))
+            ->issuedAt($now->toDateTimeImmutable())
+            ->canOnlyBeUsedAfter($now->toDateTimeImmutable())
+            ->expiresAt($accessExpires->toDateTimeImmutable())
+            ->withClaim('scope', implode(' ', $scopes))
+            ->withClaim('client_id', $app->client_id)
+            ->withClaim('token_use', 'access');
+        $accessToken = $accessBuilder->getToken($config->signer(), $config->signingKey())->toString();
+
+        $idToken = null;
+        if ($wantsIdToken) {
+            $user = User::query()->withoutGlobalScopes()->find($userId);
+            $email = $user !== null
+                ? EmailAddress::query()->where('user_id', $user->id)->where('is_primary', true)->value('email_address')
+                : null;
+
+            $idBuilder = $config->builder()
+                ->withHeader('kid', $signingKey->id)
+                ->issuedBy(Url::fapi($env, ''))
+                ->relatedTo($userId)
+                ->permittedFor($app->client_id)
+                ->identifiedBy('oit_'.Base64Url::encode(random_bytes(16)))
+                ->issuedAt($now->toDateTimeImmutable())
+                ->canOnlyBeUsedAfter($now->toDateTimeImmutable())
+                ->expiresAt($accessExpires->toDateTimeImmutable())
+                ->withClaim('token_use', 'id');
+            if ($nonce !== null && $nonce !== '') {
+                $idBuilder = $idBuilder->withClaim('nonce', $nonce);
+            }
+            if (in_array('profile', $scopes, true) && $user !== null) {
+                $idBuilder = $idBuilder
+                    ->withClaim('given_name', (string) ($user->first_name ?? ''))
+                    ->withClaim('family_name', (string) ($user->last_name ?? ''));
+            }
+            if (in_array('email', $scopes, true) && $email !== null) {
+                $idBuilder = $idBuilder
+                    ->withClaim('email', $email)
+                    ->withClaim('email_verified', true);
+            }
+            $idToken = $idBuilder->getToken($config->signer(), $config->signingKey())->toString();
+        }
+
+        // Refresh token — opaque random, sha256-hashed at rest.
+        $refreshPlaintext = 'ort_'.Base64Url::encode(random_bytes(32));
+        $refreshId = 'ort_'.Base64Url::encode(random_bytes(16));
+        DB::table('oauth_refresh_tokens')->insert([
+            'id' => $refreshId,
+            'environment_id' => $env->id,
+            'oauth_application_id' => $app->id,
+            'user_id' => $userId,
+            'hashed_token' => hash('sha256', $refreshPlaintext),
+            'scopes' => json_encode($scopes, JSON_THROW_ON_ERROR),
+            'nonce' => $nonce,
+            'expires_at' => $refreshExpires,
+            'rotated_from_id' => $rotatedFromId,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        Log::info('audit:fapi.oauth.token_issued', [
+            'environment_id' => $env->id,
+            'oauth_application_id' => $app->id,
+            'user_id' => $userId,
+            'rotated_from_id' => $rotatedFromId,
+        ]);
+        app(Emitter::class)->emit('oauthToken.issued', [
+            'oauth_application_id' => $app->id,
+            'user_id' => $userId,
+            'scopes' => $scopes,
+        ], $env);
+
+        $payload = [
+            'access_token' => $accessToken,
+            'token_type' => 'Bearer',
+            'expires_in' => self::ACCESS_TOKEN_TTL_SECONDS,
+            'refresh_token' => $refreshPlaintext,
+            'scope' => implode(' ', $scopes),
+        ];
+        if ($idToken !== null) {
+            $payload['id_token'] = $idToken;
+        }
+
+        return response()->json($payload)->header('Cache-Control', 'no-store');
+    }
+
+    /**
+     * Authenticate the calling client. Returns null on success or a
+     * `JsonResponse` with the right `invalid_client` envelope on failure.
+     * Confidential clients can authenticate via Basic auth (`Authorization`)
+     * OR form-encoded `client_id` + `client_secret`. Public clients
+     * supply PKCE `code_verifier` (auth-code path) or `client_id` only
+     * (refresh-token path) — we still match the `client_id` to the app.
+     */
+    private function authenticateClient(Request $request, OauthApplication $app, ?object $codeRow): ?JsonResponse
+    {
+        // Basic auth path (RFC 6749 §2.3.1).
+        $authHeader = (string) $request->header('Authorization', '');
+        $providedClientId = null;
+        $providedSecret = null;
+        if (str_starts_with(strtolower($authHeader), 'basic ')) {
+            $decoded = base64_decode(substr($authHeader, 6), true);
+            if (is_string($decoded) && str_contains($decoded, ':')) {
+                [$providedClientId, $providedSecret] = explode(':', $decoded, 2);
+                $providedClientId = urldecode($providedClientId);
+                $providedSecret = urldecode($providedSecret);
+            }
+        }
+        $providedClientId ??= (string) $request->input('client_id', '');
+        $providedSecret ??= (string) $request->input('client_secret', '');
+
+        if ($providedClientId === '' || $providedClientId !== $app->client_id) {
+            return $this->oauthError(401, 'invalid_client', 'client_id does not match the supplied credentials.');
+        }
+
+        if ($app->is_public) {
+            // Public clients on the auth-code path must verify their PKCE
+            // commitment. On the refresh-token path PKCE is no longer in
+            // play; client_id parity is the only check.
+            if ($codeRow !== null) {
+                $challenge = $codeRow->code_challenge ?? null;
+                $verifier = (string) $request->input('code_verifier', '');
+                if ($challenge === null || $challenge === '') {
+                    return $this->oauthError(400, 'invalid_grant',
+                        'Public client missing code_challenge on the authorization request.');
+                }
+                if ($verifier === '') {
+                    return $this->oauthError(400, 'invalid_grant', 'code_verifier is required for public clients.');
+                }
+                $expected = rtrim(strtr(base64_encode(hash('sha256', $verifier, true)), '+/', '-_'), '=');
+                if (! hash_equals($challenge, $expected)) {
+                    return $this->oauthError(400, 'invalid_grant', 'code_verifier does not match the original code_challenge.');
+                }
+            }
+
+            return null;
+        }
+
+        // Confidential client — secret must verify against the row's hash.
+        if ($providedSecret === '' || ! $app->verifyClientSecret($providedSecret)) {
+            return $this->oauthError(401, 'invalid_client', 'client_secret did not verify.');
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{sub: string, scope: string, exp: int, iat: int, client_id: string}|null
+     */
+    private function parseAccessToken(Environment $env, string $token): ?array
+    {
+        try {
+            $parser = new Parser(new JoseEncoder);
+            $parsed = $parser->parse($token);
+        } catch (\Throwable) {
+            return null;
+        }
+        $claims = $parsed->claims();
+        $exp = $claims->get('exp');
+        if (! $exp instanceof \DateTimeInterface || $exp->getTimestamp() < now()->getTimestamp()) {
+            return null;
+        }
+        if ($claims->get('token_use') !== 'access') {
+            return null;
+        }
+        // The token must verify against the env's active JWKS — we trust
+        // any active SigningKey for the env. (Rotation is handled by the
+        // kid header; we just iterate active keys.)
+        $kid = (string) $parsed->headers()->get('kid', '');
+        $signingKey = SigningKey::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $kid)
+            ->whereIn('status', [SigningKey::STATUS_ACTIVE, SigningKey::STATUS_RETIRING])
+            ->first();
+        if ($signingKey === null) {
+            return null;
+        }
+        // Derive the public key PEM from the persisted private PEM so
+        // verification doesn't need a separate column. RS256 keypair —
+        // openssl extracts the public half deterministically.
+        $publicPem = $this->publicPemFor($signingKey);
+        if ($publicPem === null) {
+            return null;
+        }
+        $config = Configuration::forAsymmetricSigner(
+            new Sha256,
+            InMemory::plainText($signingKey->privatePem()),
+            InMemory::plainText($publicPem),
+        );
+        try {
+            $valid = $config->validator()->validate(
+                $parsed,
+                new SignedWith($config->signer(), $config->verificationKey()),
+            );
+        } catch (\Throwable) {
+            return null;
+        }
+        if (! $valid) {
+            return null;
+        }
+        $iat = $claims->get('iat');
+        $iatStamp = $iat instanceof \DateTimeInterface ? $iat->getTimestamp() : 0;
+
+        return [
+            'sub' => (string) ($claims->get('sub') ?? ''),
+            'scope' => (string) ($claims->get('scope') ?? ''),
+            'exp' => $exp->getTimestamp(),
+            'iat' => $iatStamp,
+            'client_id' => (string) ($claims->get('client_id') ?? ''),
+        ];
+    }
+
+    private function publicPemFor(SigningKey $signingKey): ?string
+    {
+        $res = openssl_pkey_get_private($signingKey->privatePem());
+        if ($res === false) {
+            return null;
+        }
+        $details = openssl_pkey_get_details($res);
+        if (! is_array($details) || ! isset($details['key']) || ! is_string($details['key'])) {
+            return null;
+        }
+
+        return $details['key'];
+    }
+
+    private function oauthError(int $status, string $code, string $message): JsonResponse
+    {
+        // RFC 6749 §5.2 error envelope.
+        return response()->json([
+            'error' => $code,
+            'error_description' => $message,
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+}

--- a/database/migrations/2026_05_14_000002_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2026_05_14_000002_create_oauth_refresh_tokens_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * v0.7 OAuth provider mode — refresh tokens. Rotated on every
+ * `/oauth/token grant_type=refresh_token` exchange; the previous row
+ * gets its `revoked_at` stamped in the same transaction.
+ *
+ * Storage: opaque random secret hashed via sha256 (Argon2id is overkill
+ * for short-lived rotating credentials; the rotation discipline is the
+ * real defense). 30-day lifetime per spec OA-4.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('oauth_refresh_tokens', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('environment_id', 64);
+            $table->string('oauth_application_id', 64);
+            $table->string('user_id', 64);
+            $table->string('hashed_token', 64); // sha256 hex
+            $table->jsonb('scopes')->default(json_encode([]));
+            $table->text('nonce')->nullable();
+            $table->timestamp('expires_at');
+            $table->timestamp('revoked_at')->nullable();
+            $table->string('rotated_from_id', 64)->nullable();
+            $table->timestamps();
+
+            $table->foreign('environment_id')->references('id')->on('environments')->cascadeOnDelete();
+            $table->foreign('oauth_application_id')->references('id')->on('oauth_applications')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->unique(['hashed_token']);
+            $table->index(['oauth_application_id', 'user_id']);
+            $table->index(['expires_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_refresh_tokens');
+    }
+};

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\Fapi\MeTotpController;
 use App\Http\Controllers\Fapi\OauthAuthorizeController;
 use App\Http\Controllers\Fapi\OauthCallbackController;
 use App\Http\Controllers\Fapi\OauthConsentController;
+use App\Http\Controllers\Fapi\OauthTokenController;
 use App\Http\Controllers\Fapi\OrganizationController as FapiOrganizationController;
 use App\Http\Controllers\Fapi\OrganizationEnterpriseConnectionController;
 use App\Http\Controllers\Fapi\OrganizationInvitationController as FapiOrganizationInvitationController;
@@ -69,6 +70,11 @@ Route::withoutMiddleware([EnforceFapiOrigin::class])->group(function (): void {
     // is set on every response per RFC 6749 §5.1.
     Route::get('/oauth/authorize', OauthAuthorizeController::class)
         ->name('fapi.oauth.authorize');
+
+    // AU-7: token + introspection. Server-to-server (no Origin); confidential
+    // clients authenticate via Basic auth / post creds, public via PKCE.
+    Route::post('/oauth/token', [OauthTokenController::class, 'token'])->name('fapi.oauth.token');
+    Route::post('/oauth/token_info', [OauthTokenController::class, 'tokenInfo'])->name('fapi.oauth.token_info');
 });
 
 // SCIM 2.0 server (RFC 7644). Bearer-authenticated; the SCIM client is the

--- a/tests/Feature/Http/Fapi/OauthTokenTest.php
+++ b/tests/Feature/Http/Fapi/OauthTokenTest.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Fapi\OauthTokenController;
+use App\Models\AuthorizationGrant;
+use App\Models\OauthApplication;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Token\Parser;
+use Tests\Feature\Http\Sessions\SessionsTestSupport;
+
+function plantOauthCode(
+    string $envId,
+    string $appId,
+    string $userId,
+    array $scopes = ['openid', 'profile', 'email'],
+    string $redirect = 'https://app.example.com/oauth/callback',
+    ?string $codeChallenge = null,
+    ?string $codeChallengeMethod = null,
+    ?string $nonce = 'nonce-x',
+    string $state = 'state-x',
+    ?int $ttl = null,
+): string {
+    $code = 'oacd_'.bin2hex(random_bytes(16));
+    DB::table('oauth_authorization_codes')->insert([
+        'code' => $code,
+        'environment_id' => $envId,
+        'oauth_application_id' => $appId,
+        'user_id' => $userId,
+        'scopes' => json_encode($scopes, JSON_THROW_ON_ERROR),
+        'redirect_uri' => $redirect,
+        'code_challenge' => $codeChallenge,
+        'code_challenge_method' => $codeChallengeMethod,
+        'nonce' => $nonce,
+        'state' => $state,
+        'expires_at' => now()->addSeconds($ttl ?? OauthTokenController::ACCESS_TOKEN_TTL_SECONDS),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return $code;
+}
+
+function withCoveringGrant(string $envId, string $appId, string $userId, array $scopes): void
+{
+    AuthorizationGrant::factory()->create([
+        'environment_id' => $envId,
+        'oauth_application_id' => $appId,
+        'user_id' => $userId,
+        'scopes' => $scopes,
+        'scopes_hash' => AuthorizationGrant::hashScopes($scopes),
+    ]);
+}
+
+it('exchanges authorization_code for confidential client + Basic auth and returns access + id + refresh tokens', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+        'scopes' => ['openid', 'profile', 'email'],
+    ]);
+    // Refresh the persisted hashed_client_secret via mintClientSecret so we
+    // have the plaintext to send back on /oauth/token.
+    $minted = OauthApplication::mintClientSecret();
+    $app->forceFill(['hashed_client_secret' => $minted['hash']])->save();
+    $plaintextSecret = $minted['plaintext'];
+
+    withCoveringGrant($f['env']->id, $app->id, $bs['user']->id, ['openid', 'profile', 'email']);
+    $code = plantOauthCode($f['env']->id, $app->id, $bs['user']->id);
+
+    $basic = base64_encode($app->client_id.':'.$plaintextSecret);
+    $r = $this->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Authorization' => 'Basic '.$basic,
+    ])->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+        ]);
+
+    $r->assertOk()
+        ->assertJsonPath('token_type', 'Bearer')
+        ->assertJsonPath('expires_in', OauthTokenController::ACCESS_TOKEN_TTL_SECONDS);
+    expect($r->json('access_token'))->toBeString();
+    expect($r->json('id_token'))->toBeString();
+    expect($r->json('refresh_token'))->toStartWith('ort_');
+
+    // id_token carries nonce + email + profile claims.
+    $parsed = (new Parser(new JoseEncoder))->parse($r->json('id_token'));
+    expect($parsed->claims()->get('nonce'))->toBe('nonce-x');
+    expect($parsed->claims()->get('aud'))->toContain($app->client_id);
+    expect($parsed->claims()->get('email'))->toBe('alice@example.com');
+    expect($parsed->claims()->get('email_verified'))->toBeTrue();
+    expect($parsed->claims()->get('given_name'))->toBe('Alice');
+    expect($parsed->claims()->get('token_use'))->toBe('id');
+
+    // access_token has token_use=access, scope claim, audience pinned.
+    $access = (new Parser(new JoseEncoder))->parse($r->json('access_token'));
+    expect($access->claims()->get('token_use'))->toBe('access');
+    expect($access->claims()->get('scope'))->toBe('openid profile email');
+    expect($access->claims()->get('client_id'))->toBe($app->client_id);
+
+    // Authorization code is single-use — second attempt fails.
+    $r2 = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+        ]);
+    $r2->assertStatus(400)->assertJsonPath('error', 'invalid_grant');
+});
+
+it('exchanges authorization_code for public client + PKCE', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $user = User::create(['environment_id' => $f['env']->id, 'first_name' => 'Bob']);
+    $app = OauthApplication::factory()->public()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://spa.example/callback'],
+        'scopes' => ['openid'],
+    ]);
+    withCoveringGrant($f['env']->id, $app->id, $user->id, ['openid']);
+
+    $verifier = bin2hex(random_bytes(32));
+    $challenge = rtrim(strtr(base64_encode(hash('sha256', $verifier, true)), '+/', '-_'), '=');
+    $code = plantOauthCode(
+        $f['env']->id, $app->id, $user->id,
+        scopes: ['openid'],
+        redirect: 'https://spa.example/callback',
+        codeChallenge: $challenge,
+        codeChallengeMethod: 'S256',
+    );
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => 'https://spa.example/callback',
+            'client_id' => $app->client_id,
+            'code_verifier' => $verifier,
+        ]);
+
+    $r->assertOk();
+    expect($r->json('access_token'))->toBeString();
+});
+
+it('rejects PKCE verifier mismatch with invalid_grant', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $user = User::create(['environment_id' => $f['env']->id]);
+    $app = OauthApplication::factory()->public()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://spa.example/callback'],
+        'scopes' => ['openid'],
+    ]);
+    withCoveringGrant($f['env']->id, $app->id, $user->id, ['openid']);
+    $challenge = rtrim(strtr(base64_encode(hash('sha256', 'correct-verifier', true)), '+/', '-_'), '=');
+    $code = plantOauthCode(
+        $f['env']->id, $app->id, $user->id,
+        scopes: ['openid'],
+        redirect: 'https://spa.example/callback',
+        codeChallenge: $challenge,
+        codeChallengeMethod: 'S256',
+    );
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => 'https://spa.example/callback',
+            'client_id' => $app->client_id,
+            'code_verifier' => 'wrong-verifier',
+        ]);
+
+    $r->assertStatus(400)->assertJsonPath('error', 'invalid_grant');
+});
+
+it('refuses an expired authorization code with invalid_grant', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $user = User::create(['environment_id' => $f['env']->id]);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+    $secret = OauthApplication::mintClientSecret();
+    $app->forceFill(['hashed_client_secret' => $secret['hash']])->save();
+    withCoveringGrant($f['env']->id, $app->id, $user->id, ['openid']);
+
+    $code = plantOauthCode(
+        $f['env']->id, $app->id, $user->id,
+        scopes: ['openid'],
+        ttl: -10,
+    );
+    // Manually move expires_at into the past — `ttl: -10` puts it 10s ago.
+    DB::table('oauth_authorization_codes')->where('code', $code)->update(['expires_at' => now()->subMinutes(1)]);
+
+    $basic = base64_encode($app->client_id.':'.$secret['plaintext']);
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+        ]);
+    $r->assertStatus(400)->assertJsonPath('error', 'invalid_grant');
+});
+
+it('rotates a refresh_token on grant_type=refresh_token: old revoked, new minted', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+        'scopes' => ['openid', 'profile', 'email'],
+    ]);
+    $secret = OauthApplication::mintClientSecret();
+    $app->forceFill(['hashed_client_secret' => $secret['hash']])->save();
+    withCoveringGrant($f['env']->id, $app->id, $bs['user']->id, ['openid', 'profile', 'email']);
+    $code = plantOauthCode($f['env']->id, $app->id, $bs['user']->id);
+
+    $basic = base64_encode($app->client_id.':'.$secret['plaintext']);
+    $first = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+        ]);
+    $first->assertOk();
+    $refresh1 = $first->json('refresh_token');
+
+    $second = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'refresh_token',
+            'refresh_token' => $refresh1,
+        ]);
+    $second->assertOk();
+    $refresh2 = $second->json('refresh_token');
+    expect($refresh2)->toStartWith('ort_');
+    expect($refresh2)->not->toBe($refresh1);
+
+    // First refresh token is now revoked — re-use rejected.
+    $reuse = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'refresh_token',
+            'refresh_token' => $refresh1,
+        ]);
+    $reuse->assertStatus(400)->assertJsonPath('error', 'invalid_grant');
+});
+
+it('rejects authorization_code when the covering grant has been revoked', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $user = User::create(['environment_id' => $f['env']->id]);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+    $secret = OauthApplication::mintClientSecret();
+    $app->forceFill(['hashed_client_secret' => $secret['hash']])->save();
+    $grant = AuthorizationGrant::factory()->revoked()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $user->id,
+        'scopes' => ['openid'],
+        'scopes_hash' => AuthorizationGrant::hashScopes(['openid']),
+    ]);
+    $code = plantOauthCode($f['env']->id, $app->id, $user->id, scopes: ['openid']);
+
+    $basic = base64_encode($app->client_id.':'.$secret['plaintext']);
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+        ]);
+    $r->assertStatus(400)->assertJsonPath('error', 'invalid_grant');
+});
+
+it('refuses wrong client_secret with invalid_client', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $user = User::create(['environment_id' => $f['env']->id]);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+    ]);
+    $secret = OauthApplication::mintClientSecret();
+    $app->forceFill(['hashed_client_secret' => $secret['hash']])->save();
+    withCoveringGrant($f['env']->id, $app->id, $user->id, ['openid']);
+    $code = plantOauthCode($f['env']->id, $app->id, $user->id, scopes: ['openid']);
+
+    $basic = base64_encode($app->client_id.':wrong-secret');
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+        ]);
+    $r->assertStatus(401)->assertJsonPath('error', 'invalid_client');
+});
+
+it('token_info introspects an active access_token + reports inactive for garbage', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+        'scopes' => ['openid', 'profile', 'email'],
+    ]);
+    $secret = OauthApplication::mintClientSecret();
+    $app->forceFill(['hashed_client_secret' => $secret['hash']])->save();
+    withCoveringGrant($f['env']->id, $app->id, $bs['user']->id, ['openid', 'profile', 'email']);
+    $code = plantOauthCode($f['env']->id, $app->id, $bs['user']->id);
+
+    $basic = base64_encode($app->client_id.':'.$secret['plaintext']);
+    $token = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+        ])->json('access_token');
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token_info', ['token' => $token]);
+    $r->assertOk()
+        ->assertJsonPath('active', true)
+        ->assertJsonPath('client_id', $app->client_id)
+        ->assertJsonPath('sub', $bs['user']->id)
+        ->assertJsonPath('scope', 'openid profile email');
+
+    $r2 = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token_info', ['token' => 'garbage']);
+    $r2->assertOk()->assertJsonPath('active', false);
+});
+
+it('rejects unsupported grant_type with 400', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', ['grant_type' => 'password']);
+
+    $r->assertStatus(400)->assertJsonPath('error', 'unsupported_grant_type');
+});


### PR DESCRIPTION
Closes #243 (AU-7).

## Summary

```
POST /oauth/token        application/x-www-form-urlencoded
POST /oauth/token_info   RFC 7662 introspection
```

`/oauth/token` accepts both `grant_type=authorization_code` and `grant_type=refresh_token`:

- **authorization_code**: consumes the AU-6 / AU-9-minted `oacd_…` code (single-use; stamps `consumed_at`), verifies the client (Basic auth or form creds for confidential; PKCE `code_verifier` for public), confirms the covering `AuthorizationGrant` is still active, mints access_token + optional id_token + refresh_token.
- **refresh_token**: looks up the previous `oauth_refresh_tokens` row by sha256 hash, rotates it in the same tx (`revoked_at` stamped, fresh row inserted with `rotated_from_id`), re-mints the access + id tokens.

## Token shapes

Both `access_token` and `id_token` are RS256 JWTs signed with the env's active `SigningKey` — same key surfaced at `/.well-known/jwks.json`, so verifiers don't need any new key material. `id_token` follows OIDC §3.1.3.7: nonce passthrough, `sub = user.id`, `aud = client_id`, plus profile claims (`given_name` / `family_name`) and `email` + `email_verified` gated on the matching scope.

Refresh tokens are opaque `ort_…` strings sha256-hashed at rest. Rotation discipline + the 30-day TTL provide the security envelope.

`token_info` parses the access token, validates the `kid` against the env's `SigningKey` table, and returns `{active, sub, scope, exp, iat, client_id, token_type}` per RFC 7662 §2.2. Unknown / expired / non-access tokens return `{active: false}` only.

## Pest

9 tests, all passing: confidential `authorization_code` happy path → access + id + refresh + claim shape; public PKCE happy path; PKCE verifier mismatch → `invalid_grant`; expired code → `invalid_grant`; refresh_token rotation revokes old + re-use fails; revoked grant → `invalid_grant`; wrong `client_secret` → `invalid_client`; `token_info` active + inactive; unsupported `grant_type` → 400.