### PR TITLE
Add FAPI GET /oauth/userinfo + extend OIDC discovery (#244)

### DIFF
--- a/app/Http/Controllers/Fapi/OauthUserinfoController.php
+++ b/app/Http/Controllers/Fapi/OauthUserinfoController.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Models\EmailAddress;
+use App\Models\Environment;
+use App\Models\SigningKey;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Token\Parser;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+
+/**
+ * v0.7 OAuth provider mode — OIDC userinfo endpoint.
+ *
+ *   GET /oauth/userinfo
+ *
+ * Bearer-authenticated by an `access_token` minted by AU-7's
+ * `/oauth/token`. Returns User claims filtered by the granted `scope`
+ * baked into the access token. `openid` is always required (rejects
+ * with 401 if absent — RFC 7662 §3.1).
+ *
+ * Scope → claim mapping:
+ *   openid          → sub
+ *   profile         → name, given_name, family_name, preferred_username, picture
+ *   email           → email, email_verified
+ *   other / custom  → reserved for v0.8 (per-env mapping).
+ */
+final class OauthUserinfoController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $env = app(Environment::class);
+
+        $token = $this->bearerToken($request);
+        if ($token === null) {
+            return $this->unauthorized('missing_token', 'Bearer access_token required.');
+        }
+
+        $claims = $this->parseAccessToken($env, $token);
+        if ($claims === null) {
+            return $this->unauthorized('invalid_token', 'Bearer access_token is invalid or expired.');
+        }
+
+        $scopes = $this->scopeList($claims['scope']);
+        if (! in_array('openid', $scopes, true)) {
+            // OIDC userinfo requires `openid` — without it the access token
+            // is for a different audience (custom API scope).
+            return $this->unauthorized('insufficient_scope', 'openid scope is required to call /oauth/userinfo.');
+        }
+
+        $user = User::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $claims['sub'])
+            ->first();
+        if ($user === null) {
+            return $this->unauthorized('invalid_token', 'The user referenced by sub no longer exists.');
+        }
+
+        $payload = ['sub' => $user->id];
+
+        if (in_array('profile', $scopes, true)) {
+            $given = (string) ($user->first_name ?? '');
+            $family = (string) ($user->last_name ?? '');
+            $payload['given_name'] = $given;
+            $payload['family_name'] = $family;
+            $payload['name'] = trim($given.' '.$family);
+            $payload['preferred_username'] = (string) ($user->username ?? '');
+            if (! empty($user->image_url)) {
+                $payload['picture'] = (string) $user->image_url;
+            }
+        }
+
+        if (in_array('email', $scopes, true)) {
+            $email = EmailAddress::query()
+                ->where('user_id', $user->id)
+                ->where('is_primary', true)
+                ->first();
+            if ($email !== null) {
+                $payload['email'] = (string) $email->email_address;
+                $payload['email_verified'] = $email->verified_at !== null;
+            }
+        }
+
+        return response()->json($payload)->header('Cache-Control', 'no-store');
+    }
+
+    private function bearerToken(Request $request): ?string
+    {
+        $header = (string) $request->header('Authorization', '');
+        if (! str_starts_with(strtolower($header), 'bearer ')) {
+            return null;
+        }
+        $value = trim(substr($header, 7));
+
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * @return array{sub: string, scope: string, exp: int, iat: int, client_id: string}|null
+     */
+    private function parseAccessToken(Environment $env, string $token): ?array
+    {
+        try {
+            $parsed = (new Parser(new JoseEncoder))->parse($token);
+        } catch (\Throwable) {
+            return null;
+        }
+        $exp = $parsed->claims()->get('exp');
+        if (! $exp instanceof \DateTimeInterface || $exp->getTimestamp() < now()->getTimestamp()) {
+            return null;
+        }
+        if ($parsed->claims()->get('token_use') !== 'access') {
+            return null;
+        }
+        $kid = (string) $parsed->headers()->get('kid', '');
+        $signingKey = SigningKey::query()->withoutGlobalScopes()
+            ->where('environment_id', $env->id)
+            ->where('id', $kid)
+            ->whereIn('status', [SigningKey::STATUS_ACTIVE, SigningKey::STATUS_RETIRING])
+            ->first();
+        if ($signingKey === null) {
+            return null;
+        }
+        $publicPem = $this->publicPemFor($signingKey);
+        if ($publicPem === null) {
+            return null;
+        }
+        $config = Configuration::forAsymmetricSigner(
+            new Sha256,
+            InMemory::plainText($signingKey->privatePem()),
+            InMemory::plainText($publicPem),
+        );
+        try {
+            $valid = $config->validator()->validate(
+                $parsed,
+                new SignedWith($config->signer(), $config->verificationKey()),
+            );
+        } catch (\Throwable) {
+            return null;
+        }
+        if (! $valid) {
+            return null;
+        }
+        $iat = $parsed->claims()->get('iat');
+
+        return [
+            'sub' => (string) ($parsed->claims()->get('sub') ?? ''),
+            'scope' => (string) ($parsed->claims()->get('scope') ?? ''),
+            'exp' => $exp->getTimestamp(),
+            'iat' => $iat instanceof \DateTimeInterface ? $iat->getTimestamp() : 0,
+            'client_id' => (string) ($parsed->claims()->get('client_id') ?? ''),
+        ];
+    }
+
+    private function publicPemFor(SigningKey $signingKey): ?string
+    {
+        $res = openssl_pkey_get_private($signingKey->privatePem());
+        if ($res === false) {
+            return null;
+        }
+        $details = openssl_pkey_get_details($res);
+        if (! is_array($details) || ! isset($details['key']) || ! is_string($details['key'])) {
+            return null;
+        }
+
+        return $details['key'];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function scopeList(string $raw): array
+    {
+        return array_values(array_filter(
+            preg_split('/\s+/', trim($raw)) ?: [],
+            static fn ($s) => is_string($s) && $s !== '',
+        ));
+    }
+
+    private function unauthorized(string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'error' => $code,
+            'error_description' => $message,
+        ], 401)->header('Cache-Control', 'no-store');
+    }
+}

--- a/app/Http/Controllers/WellKnown/OpenIdConfigurationController.php
+++ b/app/Http/Controllers/WellKnown/OpenIdConfigurationController.php
@@ -10,13 +10,11 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 /**
- * `GET /.well-known/openid-configuration` — minimal v0.1 OIDC discovery.
+ * `GET /.well-known/openid-configuration` — OIDC discovery document.
  *
- * Just enough for downstream JWT verifiers (Supabase, Hasura, custom
- * middleware) to discover the issuer + JWKS URL + signing algorithms.
- * The full IdP role (authorization_endpoint, token_endpoint, userinfo)
- * lands in v0.7 when authn.sh starts acting as an OAuth provider in
- * its own right.
+ * v0.7 lit up the full IdP role: the authorize / token / userinfo
+ * endpoints are now part of the discovery payload, alongside the JWKS
+ * URL and signing algorithms that downstream JWT verifiers consume.
  */
 final class OpenIdConfigurationController
 {
@@ -28,11 +26,27 @@ final class OpenIdConfigurationController
         return response()->json([
             'issuer' => $issuer,
             'jwks_uri' => Url::fapi($env, '/.well-known/jwks.json'),
-            'response_types_supported' => ['id_token'],
+            'authorization_endpoint' => Url::fapi($env, '/oauth/authorize'),
+            'token_endpoint' => Url::fapi($env, '/oauth/token'),
+            'userinfo_endpoint' => Url::fapi($env, '/oauth/userinfo'),
+            'introspection_endpoint' => Url::fapi($env, '/oauth/token_info'),
+            'response_types_supported' => ['code', 'id_token'],
+            'response_modes_supported' => ['query'],
+            'grant_types_supported' => ['authorization_code', 'refresh_token'],
             'subject_types_supported' => ['public'],
             'id_token_signing_alg_values_supported' => ['RS256'],
-            'claims_supported' => ['iss', 'sub', 'sid', 'aud', 'exp', 'iat', 'nbf', 'jti', 'azp', 'v', 'fva', 'sts'],
-            'token_endpoint_auth_methods_supported' => [],
-        ])->header('Cache-Control', 'public, max-age=300, must-revalidate');
+            'scopes_supported' => ['openid', 'profile', 'email'],
+            'token_endpoint_auth_methods_supported' => [
+                'client_secret_basic',
+                'client_secret_post',
+                'none', // public PKCE clients.
+            ],
+            'code_challenge_methods_supported' => ['S256'],
+            'claims_supported' => [
+                'iss', 'sub', 'aud', 'exp', 'iat', 'nbf', 'jti', 'azp', 'nonce',
+                'name', 'given_name', 'family_name', 'preferred_username', 'picture',
+                'email', 'email_verified',
+            ],
+        ])->header('Cache-Control', 'public, max-age=3600, must-revalidate');
     }
 }

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\Fapi\OauthAuthorizeController;
 use App\Http\Controllers\Fapi\OauthCallbackController;
 use App\Http\Controllers\Fapi\OauthConsentController;
 use App\Http\Controllers\Fapi\OauthTokenController;
+use App\Http\Controllers\Fapi\OauthUserinfoController;
 use App\Http\Controllers\Fapi\OrganizationController as FapiOrganizationController;
 use App\Http\Controllers\Fapi\OrganizationEnterpriseConnectionController;
 use App\Http\Controllers\Fapi\OrganizationInvitationController as FapiOrganizationInvitationController;
@@ -75,6 +76,9 @@ Route::withoutMiddleware([EnforceFapiOrigin::class])->group(function (): void {
     // clients authenticate via Basic auth / post creds, public via PKCE.
     Route::post('/oauth/token', [OauthTokenController::class, 'token'])->name('fapi.oauth.token');
     Route::post('/oauth/token_info', [OauthTokenController::class, 'tokenInfo'])->name('fapi.oauth.token_info');
+
+    // AU-8: OIDC userinfo. Bearer-authenticated by the AU-7 access_token.
+    Route::get('/oauth/userinfo', OauthUserinfoController::class)->name('fapi.oauth.userinfo');
 });
 
 // SCIM 2.0 server (RFC 7644). Bearer-authenticated; the SCIM client is the

--- a/tests/Feature/Http/Fapi/OauthUserinfoTest.php
+++ b/tests/Feature/Http/Fapi/OauthUserinfoTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Fapi\OauthTokenController;
+use App\Models\AuthorizationGrant;
+use App\Models\OauthApplication;
+use Illuminate\Support\Facades\DB;
+use Tests\Feature\Http\Sessions\SessionsTestSupport;
+
+function userinfoAccessToken(array $scopes, ?array $bsOverride = null): array
+{
+    $f = SessionsTestSupport::bootEnv();
+    $bs = $bsOverride ?? SessionsTestSupport::makeUserWithSession($f['env']);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+        'scopes' => $scopes,
+    ]);
+    $secret = OauthApplication::mintClientSecret();
+    $app->forceFill(['hashed_client_secret' => $secret['hash']])->save();
+
+    AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $bs['user']->id,
+        'scopes' => $scopes,
+        'scopes_hash' => AuthorizationGrant::hashScopes($scopes),
+    ]);
+
+    $code = 'oacd_'.bin2hex(random_bytes(16));
+    DB::table('oauth_authorization_codes')->insert([
+        'code' => $code,
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $bs['user']->id,
+        'scopes' => json_encode($scopes, JSON_THROW_ON_ERROR),
+        'redirect_uri' => 'https://app.example.com/oauth/callback',
+        'expires_at' => now()->addSeconds(OauthTokenController::ACCESS_TOKEN_TTL_SECONDS),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $basic = base64_encode($app->client_id.':'.$secret['plaintext']);
+    $r = test()->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+        ]);
+    $r->assertOk();
+
+    return ['f' => $f, 'bs' => $bs, 'access_token' => $r->json('access_token')];
+}
+
+it('returns sub only when only the openid scope was granted', function (): void {
+    $ctx = userinfoAccessToken(['openid']);
+
+    $r = test()->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Authorization' => 'Bearer '.$ctx['access_token'],
+    ])->withoutOpenApiAssertions()
+        ->getJson('https://acme.authn.local/oauth/userinfo');
+
+    $r->assertOk()
+        ->assertJsonPath('sub', $ctx['bs']['user']->id);
+    expect($r->json())->not->toHaveKey('email');
+    expect($r->json())->not->toHaveKey('given_name');
+});
+
+it('returns profile claims when profile scope is granted', function (): void {
+    $ctx = userinfoAccessToken(['openid', 'profile']);
+
+    $r = test()->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Authorization' => 'Bearer '.$ctx['access_token'],
+    ])->withoutOpenApiAssertions()
+        ->getJson('https://acme.authn.local/oauth/userinfo');
+
+    $r->assertOk()
+        ->assertJsonPath('given_name', 'Alice')
+        ->assertJsonPath('family_name', '')
+        ->assertJsonPath('name', 'Alice');
+    expect($r->json())->not->toHaveKey('email');
+});
+
+it('returns email + email_verified when email scope is granted', function (): void {
+    $ctx = userinfoAccessToken(['openid', 'email']);
+
+    $r = test()->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Authorization' => 'Bearer '.$ctx['access_token'],
+    ])->withoutOpenApiAssertions()
+        ->getJson('https://acme.authn.local/oauth/userinfo');
+
+    $r->assertOk()
+        ->assertJsonPath('email', 'alice@example.com')
+        ->assertJsonPath('email_verified', true);
+});
+
+it('refuses without a Bearer token', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+
+    $r = test()->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->getJson('https://acme.authn.local/oauth/userinfo');
+
+    $r->assertStatus(401)->assertJsonPath('error', 'missing_token');
+});
+
+it('refuses an unknown / malformed Bearer token', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+
+    $r = test()->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Authorization' => 'Bearer not-a-real-token',
+    ])->withoutOpenApiAssertions()
+        ->getJson('https://acme.authn.local/oauth/userinfo');
+
+    $r->assertStatus(401)->assertJsonPath('error', 'invalid_token');
+});
+
+it('refuses an access_token whose scope set lacks openid (insufficient_scope)', function (): void {
+    // Mint an access_token with a custom scope only — userinfo refuses.
+    // Easiest path: grant the openid + custom scope, then strip openid from
+    // the access-token claim. Since the controller signs the JWT itself we
+    // can't easily forge one — use the fact that minting with just `profile`
+    // (no openid) is rejected by AU-7's invalid_grant. Instead, mint with
+    // openid + profile + email, then build a stub assertion via a fresh app
+    // whose grant doesn't include openid. We assert at the userinfo level
+    // by trimming openid out of the access token's scope via direct token
+    // forge: not feasible without breaking sign — so we test the
+    // controller branch via a path the spec actually exposes.
+    //
+    // Reality check: an access_token issued without `openid` is a perfectly
+    // valid OAuth access token, just not an OIDC one. /oauth/userinfo
+    // specifically asks for OIDC, so we refuse. Mint via the
+    // authorization-code path with scopes=['profile'] and a covering grant.
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+        'scopes' => ['profile'],
+    ]);
+    $secret = OauthApplication::mintClientSecret();
+    $app->forceFill(['hashed_client_secret' => $secret['hash']])->save();
+    AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $bs['user']->id,
+        'scopes' => ['profile'],
+        'scopes_hash' => AuthorizationGrant::hashScopes(['profile']),
+    ]);
+    $code = 'oacd_'.bin2hex(random_bytes(16));
+    DB::table('oauth_authorization_codes')->insert([
+        'code' => $code,
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $bs['user']->id,
+        'scopes' => json_encode(['profile'], JSON_THROW_ON_ERROR),
+        'redirect_uri' => 'https://app.example.com/oauth/callback',
+        'expires_at' => now()->addSeconds(OauthTokenController::ACCESS_TOKEN_TTL_SECONDS),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    $basic = base64_encode($app->client_id.':'.$secret['plaintext']);
+    $minted = test()->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+        ]);
+    $minted->assertOk();
+    expect($minted->json('id_token'))->toBeNull();
+    $accessToken = (string) $minted->json('access_token');
+
+    $r = test()->withHeaders([
+        'Host' => 'acme.authn.local',
+        'Authorization' => 'Bearer '.$accessToken,
+    ])->withoutOpenApiAssertions()
+        ->getJson('https://acme.authn.local/oauth/userinfo');
+
+    $r->assertStatus(401)->assertJsonPath('error', 'insufficient_scope');
+});
+
+it('exposes the v0.7 IdP endpoints in /.well-known/openid-configuration', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+
+    $r = test()->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->getJson('https://acme.authn.local/.well-known/openid-configuration');
+
+    $r->assertOk()
+        ->assertJsonPath('issuer', 'https://acme.authn.local')
+        ->assertJsonPath('authorization_endpoint', 'https://acme.authn.local/oauth/authorize')
+        ->assertJsonPath('token_endpoint', 'https://acme.authn.local/oauth/token')
+        ->assertJsonPath('userinfo_endpoint', 'https://acme.authn.local/oauth/userinfo')
+        ->assertJsonPath('introspection_endpoint', 'https://acme.authn.local/oauth/token_info');
+    expect($r->json('grant_types_supported'))->toBe(['authorization_code', 'refresh_token']);
+    expect($r->json('code_challenge_methods_supported'))->toBe(['S256']);
+    expect($r->json('scopes_supported'))->toContain('openid', 'profile', 'email');
+    expect($r->headers->get('Cache-Control'))->toContain('public');
+});


### PR DESCRIPTION
Closes #244 (AU-8). Replacement for #267 (which was closed before merging). Based on fresh main with AU-7 already in.

## Summary

```
GET /oauth/userinfo                       (Bearer-authenticated)
GET /.well-known/openid-configuration     (extended)
```

`/oauth/userinfo` is bearer-authenticated by an `access_token` from AU-7's `/oauth/token`. The controller re-parses + signature-verifies the JWT against the env's active `SigningKey` (same key the `kid` pins to in `/.well-known/jwks.json`) and refuses with `invalid_token` on mismatch / expiry / unknown `kid` / non-access `token_use`.

## Scope → claim mapping (OIDC §5.4)

- `openid` — always required (absence → 401 `insufficient_scope`). Returns `sub`.
- `profile` — `name`, `given_name`, `family_name`, `preferred_username`, `picture`.
- `email` — `email`, `email_verified`.

## OIDC discovery

Already shipped at v0.1 with issuer + JWKS URL. v0.7 extends it with:

- IdP endpoints (`authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `introspection_endpoint`).
- `grant_types_supported` = `authorization_code`, `refresh_token`.
- `token_endpoint_auth_methods_supported` = `client_secret_basic`, `client_secret_post`, `none` (public PKCE).
- `code_challenge_methods_supported` = `S256`.
- Scope-driven claim list.

## Pest

7 tests, all passing: each scope combo (openid / openid+profile / openid+email); missing/malformed Bearer → 401; access_token lacking `openid` → 401 `insufficient_scope`; discovery payload assertions (IdP endpoints + grant types + PKCE methods + cache headers).