### PR TITLE
Add IdP audit log + webhook events + Pest e2e (#249)

### DIFF
--- a/app/Http/Controllers/Bapi/OauthApplicationController.php
+++ b/app/Http/Controllers/Bapi/OauthApplicationController.php
@@ -161,22 +161,35 @@ final class OauthApplicationController
 
         $snapshot = OauthApplicationResource::from($row);
 
-        DB::transaction(function () use ($row): void {
-            // Revoke every active grant for this app in the same tx so
-            // tokens carrying a still-active grant can't survive the
-            // application's soft-delete.
+        $revokedGrantIds = DB::transaction(function () use ($row): array {
+            // Capture the grant ids before revoking so AU-15 can fire a
+            // cascade `authorizationGrant.revoked` event per row.
+            $ids = AuthorizationGrant::query()->withoutGlobalScopes()
+                ->where('oauth_application_id', $row->id)
+                ->whereNull('revoked_at')
+                ->pluck('id')->all();
             AuthorizationGrant::query()->withoutGlobalScopes()
                 ->where('oauth_application_id', $row->id)
                 ->whereNull('revoked_at')
                 ->update(['revoked_at' => now()]);
             $row->delete();
+
+            return $ids;
         });
 
-        Log::info('audit:bapi.oauth_application.deleted', [
+        Log::info('audit:auth.idp.app_revoked', [
             'environment_id' => $env->id,
             'oauth_application_id' => $row->id,
+            'cascade_grant_count' => count($revokedGrantIds),
         ]);
         app(Emitter::class)->emit('oauthApplication.deleted', $snapshot, $env);
+        foreach ($revokedGrantIds as $grantId) {
+            app(Emitter::class)->emit('authorizationGrant.revoked', [
+                'authorization_grant_id' => $grantId,
+                'oauth_application_id' => $row->id,
+                'cascade_from' => 'oauth_application_deleted',
+            ], $env);
+        }
 
         return response()->json(null, 204);
     }
@@ -197,11 +210,16 @@ final class OauthApplicationController
         $minted = OauthApplication::mintClientSecret();
         $row->forceFill(['hashed_client_secret' => $minted['hash']])->save();
 
-        Log::info('audit:bapi.oauth_application.secret_rotated', [
+        Log::info('audit:auth.idp.app_secret_rotated', [
             'environment_id' => $env->id,
             'oauth_application_id' => $row->id,
         ]);
-        app(Emitter::class)->emit('oauthApplication.secret_rotated', OauthApplicationResource::from($row->fresh()), $env);
+        // Surface secret rotation as an `oauthApplication.updated` event with
+        // a `client_secret_rotated: true` flag so subscribers don't need to
+        // listen on a separate type per spec OA-7.
+        $payload = OauthApplicationResource::from($row->fresh());
+        $payload['client_secret_rotated'] = true;
+        app(Emitter::class)->emit('oauthApplication.updated', $payload, $env);
 
         return response()->json(OauthApplicationResource::withSecret($row->fresh(), $minted['plaintext']))
             ->header('Cache-Control', 'no-store');

--- a/app/Http/Controllers/Fapi/OauthTokenController.php
+++ b/app/Http/Controllers/Fapi/OauthTokenController.php
@@ -73,6 +73,12 @@ final class OauthTokenController
             return response()->json(['active' => false])->header('Cache-Control', 'no-store');
         }
 
+        Log::info('audit:auth.idp.token_introspected', [
+            'environment_id' => $env->id,
+            'oauth_application_id' => $parsed['client_id'],
+            'sub' => $parsed['sub'],
+        ]);
+
         return response()->json([
             'active' => true,
             'sub' => $parsed['sub'],
@@ -294,7 +300,7 @@ final class OauthTokenController
             'updated_at' => $now,
         ]);
 
-        Log::info('audit:fapi.oauth.token_issued', [
+        Log::info('audit:auth.idp.token_issued', [
             'environment_id' => $env->id,
             'oauth_application_id' => $app->id,
             'user_id' => $userId,

--- a/tests/Feature/Oauth/OauthIdpEndToEndTest.php
+++ b/tests/Feature/Oauth/OauthIdpEndToEndTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\AuthorizationGrant;
+use App\Models\OauthApplication;
+use App\Models\User;
+use App\Models\WebhookEndpoint;
+use App\Models\WebhookEvent;
+use App\Services\Sessions\SessionTokenIssuer;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Token\Parser;
+use Tests\Feature\Http\Bapi\BapiTestSupport;
+use Tests\Feature\Http\Me\MeTestSupport;
+use Tests\Feature\Http\Sessions\SessionsTestSupport;
+
+/**
+ * AU-15 — end-to-end Pest sweep through the full OAuth provider mode
+ * ceremony plus the cascade revoke surface.
+ */
+function withWildcardWebhookEndpoint(string $envId): WebhookEndpoint
+{
+    return WebhookEndpoint::query()->withoutGlobalScopes()->create([
+        'environment_id' => $envId,
+        'url' => 'https://hooks.example.test/v07',
+        'signing_secret' => str_repeat('a', 32),
+        'enabled' => true,
+        'enabled_event_types' => ['*'],
+    ]);
+}
+
+it('runs the confidential client IdP flow end-to-end: authorize (silent reuse) → token → userinfo', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    withWildcardWebhookEndpoint($f['env']->id);
+    $app = OauthApplication::factory()->create([
+        'environment_id' => $f['env']->id,
+        'name' => 'Acme Dashboard',
+        'callback_urls' => ['https://app.example.com/oauth/callback'],
+        'scopes' => ['openid', 'profile', 'email'],
+    ]);
+    $secret = OauthApplication::mintClientSecret();
+    $app->forceFill(['hashed_client_secret' => $secret['hash']])->save();
+    // Pre-existing AuthorizationGrant — `/oauth/authorize` silent-reuses
+    // straight into a redirect with code=&state=, no consent screen.
+    // (The /oauth/consent/accept dance is covered by AU-9's own test file.)
+    AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $bs['user']->id,
+        'scopes' => ['openid', 'profile', 'email'],
+        'scopes_hash' => AuthorizationGrant::hashScopes(['openid', 'profile', 'email']),
+    ]);
+
+    // 1) /oauth/authorize — silent reuse, mints code + redirects to redirect_uri.
+    $authorize = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get('https://acme.authn.local/oauth/authorize?'.http_build_query([
+            'client_id' => $app->client_id,
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+            'response_type' => 'code',
+            'scope' => 'openid profile email',
+            'state' => 'e2e-state',
+            'nonce' => 'e2e-nonce',
+        ]));
+    $authorize->assertStatus(302);
+    $loc = (string) $authorize->headers->get('Location');
+    expect($loc)->toStartWith('https://app.example.com/oauth/callback?');
+    expect($loc)->toContain('code=oacd_');
+    parse_str((string) parse_url($loc, PHP_URL_QUERY), $q);
+    $code = (string) $q['code'];
+
+    // Grant row visible via /v1/me/authorized-apps.
+    $userJwt = app(SessionTokenIssuer::class)->mint($bs['session']->fresh())['jwt'];
+    $listed = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$userJwt,
+        ])->withoutOpenApiAssertions()
+        ->getJson('https://acme.authn.local/v1/me/authorized-apps');
+    $listed->assertOk()->assertJsonPath('total_count', 1);
+
+    // 3) /oauth/token — exchange code for access + id + refresh tokens.
+    $basic = base64_encode($app->client_id.':'.$secret['plaintext']);
+    $token = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => 'https://app.example.com/oauth/callback',
+        ]);
+    $token->assertOk();
+    $accessToken = (string) $token->json('access_token');
+    $refreshToken = (string) $token->json('refresh_token');
+    $idToken = (string) $token->json('id_token');
+
+    // id_token validates against the env JWKS (kid header points at the env's
+    // active SigningKey).
+    $parsed = (new Parser(new JoseEncoder))->parse($idToken);
+    expect((string) $parsed->headers()->get('kid'))->not->toBe('');
+    expect($parsed->claims()->get('nonce'))->toBe('e2e-nonce');
+
+    // 4) /oauth/userinfo — Bearer-authenticated by access_token, returns claims.
+    $userinfo = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$accessToken])
+        ->withoutOpenApiAssertions()
+        ->getJson('https://acme.authn.local/oauth/userinfo');
+    $userinfo->assertOk()
+        ->assertJsonPath('sub', $bs['user']->id)
+        ->assertJsonPath('email', 'alice@example.com')
+        ->assertJsonPath('email_verified', true);
+
+    // 5) /oauth/token grant_type=refresh_token — rotates.
+    $rotate = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'refresh_token',
+            'refresh_token' => $refreshToken,
+        ]);
+    $rotate->assertOk();
+    expect((string) $rotate->json('refresh_token'))->not->toBe($refreshToken);
+
+    // Re-use of the old refresh token is rejected.
+    $reuse = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Basic '.$basic])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'refresh_token',
+            'refresh_token' => $refreshToken,
+        ]);
+    $reuse->assertStatus(400)->assertJsonPath('error', 'invalid_grant');
+
+    // token_info introspects the live access_token.
+    $introspect = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token_info', ['token' => $accessToken]);
+    $introspect->assertOk()->assertJsonPath('active', true);
+
+    // Webhook events fired across the run.
+    $types = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->pluck('type')->toArray();
+    expect($types)->toContain('oauthToken.issued');
+});
+
+it('runs the public PKCE client IdP flow end-to-end via silent-reuse', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $bs = SessionsTestSupport::makeUserWithSession($f['env']);
+    $app = OauthApplication::factory()->public()->create([
+        'environment_id' => $f['env']->id,
+        'callback_urls' => ['https://spa.example/cb'],
+        'scopes' => ['openid'],
+    ]);
+    AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $bs['user']->id,
+        'scopes' => ['openid'],
+        'scopes_hash' => AuthorizationGrant::hashScopes(['openid']),
+    ]);
+
+    $verifier = bin2hex(random_bytes(32));
+    $challenge = rtrim(strtr(base64_encode(hash('sha256', $verifier, true)), '+/', '-_'), '=');
+
+    $authorize = $this->withCredentials()
+        ->withUnencryptedCookie('__client', $bs['cookie'])
+        ->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->get('https://acme.authn.local/oauth/authorize?'.http_build_query([
+            'client_id' => $app->client_id,
+            'redirect_uri' => 'https://spa.example/cb',
+            'response_type' => 'code',
+            'scope' => 'openid',
+            'state' => 'pkce-state',
+            'nonce' => 'pkce-nonce',
+            'code_challenge' => $challenge,
+            'code_challenge_method' => 'S256',
+        ]));
+    $authorize->assertStatus(302);
+    parse_str((string) parse_url((string) $authorize->headers->get('Location'), PHP_URL_QUERY), $q);
+
+    // Public client: PKCE verifier, no Basic auth.
+    $token = $this->withHeaders(['Host' => 'acme.authn.local'])
+        ->withoutOpenApiAssertions()
+        ->post('https://acme.authn.local/oauth/token', [
+            'grant_type' => 'authorization_code',
+            'code' => $q['code'],
+            'redirect_uri' => 'https://spa.example/cb',
+            'client_id' => $app->client_id,
+            'code_verifier' => $verifier,
+        ]);
+    $token->assertOk();
+    expect($token->json('id_token'))->toBeString();
+});
+
+it('cascades authorizationGrant.revoked webhooks when an OauthApplication is deleted via BAPI', function (): void {
+    $bapi = BapiTestSupport::bootEnv('cascade');
+    withWildcardWebhookEndpoint($bapi['env']->id);
+    $app = OauthApplication::factory()->create(['environment_id' => $bapi['env']->id]);
+    $user = User::create(['environment_id' => $bapi['env']->id]);
+    AuthorizationGrant::factory()->create([
+        'environment_id' => $bapi['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $user->id,
+    ]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($bapi['token']))
+        ->deleteJson(BapiTestSupport::url('/oauth-applications/'.$app->id));
+    $r->assertNoContent();
+
+    $types = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $bapi['env']->id)
+        ->pluck('type')->toArray();
+    expect($types)->toContain('oauthApplication.deleted');
+    expect($types)->toContain('authorizationGrant.revoked');
+});
+
+it('emits oauthApplication.updated with client_secret_rotated: true on rotate-secret', function (): void {
+    $bapi = BapiTestSupport::bootEnv('rotate-evt');
+    withWildcardWebhookEndpoint($bapi['env']->id);
+    $app = OauthApplication::factory()->create(['environment_id' => $bapi['env']->id]);
+
+    $r = $this->withHeaders(BapiTestSupport::headers($bapi['token']))
+        ->postJson(BapiTestSupport::url('/oauth-applications/'.$app->id.'/rotate-secret'));
+    $r->assertOk();
+
+    $event = WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $bapi['env']->id)
+        ->where('type', 'oauthApplication.updated')
+        ->first();
+    expect($event)->not->toBeNull();
+    expect($event->data['client_secret_rotated'] ?? false)->toBeTrue();
+});
+
+it('emits authorizationGrant.revoked when the user revokes their own grant', function (): void {
+    $f = SessionsTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $app = OauthApplication::factory()->create(['environment_id' => $f['env']->id]);
+    $grant = AuthorizationGrant::factory()->create([
+        'environment_id' => $f['env']->id,
+        'oauth_application_id' => $app->id,
+        'user_id' => $auth['user']->id,
+    ]);
+
+    $r = $this->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$auth['jwt'],
+        ])->withoutOpenApiAssertions()
+        ->deleteJson('https://acme.authn.local/v1/me/authorized-apps/'.$grant->id);
+    $r->assertOk();
+
+    expect(WebhookEvent::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('type', 'authorizationGrant.revoked')
+        ->exists())->toBeTrue();
+});


### PR DESCRIPTION
Closes #249 (AU-15). Final v0.7 authn issue.

Third take — #268 phantom-merged against a stale base; #270 auto-closed when its base branch was deleted by the AU-8 squash-merge. This PR branches off current `main` (which now has AU-7 + AU-8 + everything else from the wave-3 stack).

## Summary

Final v0.7 audit pass per OA-7 + the AU-15 issue spec.

## Audit log alignment

Renamed the per-controller `audit:fapi.*` / `audit:bapi.*` entries that touch the IdP surface to the unified `audit:auth.idp.*` family:

```
audit:auth.idp.token_issued        (OauthTokenController::mintTokens)
audit:auth.idp.token_introspected  (OauthTokenController::tokenInfo)
audit:auth.idp.app_revoked         (OauthApplicationController::destroy)
audit:auth.idp.app_secret_rotated  (OauthApplicationController::rotateSecret)
```

## Webhook surface tidying

- `OauthApplicationController::destroy` now emits a per-row `authorizationGrant.revoked` webhook in addition to `oauthApplication.deleted` (cascade subscribers no longer need to listen on the soft-delete).
- rotate-secret consolidates into `oauthApplication.updated` with `client_secret_rotated: true` flag (was a bespoke `oauthApplication.secret_rotated` type) per OA-7.

## Pest e2e (`tests/Feature/Oauth/OauthIdpEndToEndTest`)

5 tests, all passing locally on a fresh `main` (which now has AU-8 in it, so the `/oauth/userinfo` step actually exercises live code):

- Confidential client silent-reuse flow: `/oauth/authorize` → `code` + `state` → `/v1/me/authorized-apps` lists the grant → `/oauth/token` (Basic auth) → access + id + refresh tokens → `/oauth/userinfo` with scoped claim filtering → `grant_type=refresh_token` rotation + re-use rejection → `/oauth/token_info` introspection.
- Public PKCE client silent-reuse flow.
- Cascade webhook on BAPI `DELETE /v1/oauth-applications/{id}`: emits `oauthApplication.deleted` + `authorizationGrant.revoked` per linked grant.
- rotate-secret emits `oauthApplication.updated` with `client_secret_rotated: true`.
- `/v1/me/authorized-apps` DELETE emits `authorizationGrant.revoked`.

The full `/oauth/authorize` → consent → `/oauth/token` chain is already covered by AU-9's `OauthConsentTest`; this e2e exercises the silent-reuse branch.