### PR TITLE
feat(AU-17): wire FAPI /me/password DELETE and /me/profile-image POST+DELETE

### DIFF
--- a/app/Http/Controllers/Fapi/MeController.php
+++ b/app/Http/Controllers/Fapi/MeController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Fapi;
 
 use App\Auth\ErrorCodes;
+use App\Http\Requests\Bapi\Users\ProfileImageRequest;
 use App\Http\Resources\ClientResource;
 use App\Http\Resources\EmailAddressResource;
 use App\Http\Resources\UserResource;
@@ -17,6 +18,7 @@ use App\Models\User;
 use App\Services\Sessions\SessionLifecycle;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * `/v1/me` — the authenticated end-user's view of themselves. Powers the
@@ -32,6 +34,10 @@ final class MeController
     private const WRITABLE_PROFILE_FIELDS = [
         'first_name', 'last_name', 'username', 'image_url', 'locale',
     ];
+
+    private const IMAGE_DISK = 's3';
+
+    private const ALLOWED_IMAGE_MIMES = ['image/png', 'image/jpeg', 'image/webp'];
 
     public function __construct(
         private readonly SessionLifecycle $lifecycle,
@@ -268,7 +274,102 @@ final class MeController
         return $this->clientEnvelope(['object' => 'change_password', 'success' => true]);
     }
 
+    public function removeMyPassword(Request $request): JsonResponse
+    {
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot remove the password.');
+        }
+
+        $user = app(User::class);
+        if ($user->password_hash === null) {
+            return $this->error(422, ErrorCodes::FORM_PASSWORD_VALIDATION_FAILED, 'No password set on this user.');
+        }
+
+        $env = app(Environment::class);
+        if ($this->environmentRequiresPassword($env)) {
+            return $this->error(422, ErrorCodes::FORM_PASSWORD_VALIDATION_FAILED, 'This environment requires a password.');
+        }
+
+        $current = $request->input('current_password');
+        if (! is_string($current) || $current === '' || ! $user->checkPassword($current)) {
+            return $this->error(422, ErrorCodes::FORM_PASSWORD_INCORRECT, 'Current password is incorrect.');
+        }
+
+        $user->forceFill(['password_hash' => null])->save();
+
+        return $this->clientEnvelope(UserResource::from($user->fresh()));
+    }
+
+    /* -------------------- profile image -------------------- */
+
+    public function uploadMyProfileImage(ProfileImageRequest $request): JsonResponse
+    {
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot mutate the profile image.');
+        }
+
+        $user = app(User::class);
+        $file = $request->file('file');
+        if ($file === null) {
+            return $this->error(422, ErrorCodes::FORM_PARAM_NIL, 'A file is required.');
+        }
+
+        $info = @getimagesize($file->getRealPath());
+        $detectedMime = is_array($info) ? ($info['mime'] ?? null) : null;
+        if (! is_string($detectedMime) || ! in_array($detectedMime, self::ALLOWED_IMAGE_MIMES, true)) {
+            return $this->error(415, ErrorCodes::FORM_PARAM_FORMAT_INVALID, 'File must be one of: '.implode(', ', self::ALLOWED_IMAGE_MIMES));
+        }
+
+        $disk = Storage::disk(self::IMAGE_DISK);
+        $extension = $file->getClientOriginalExtension() ?: pathinfo($file->getClientOriginalName(), PATHINFO_EXTENSION) ?: 'png';
+        $path = "user-images/{$user->environment_id}/{$user->id}.{$extension}";
+        $disk->put($path, file_get_contents($file->getRealPath()), 'public');
+        $url = method_exists($disk, 'url') ? $disk->url($path) : $path;
+
+        $user->forceFill(['image_url' => $url, 'has_image' => true])->save();
+
+        return $this->clientEnvelope(UserResource::from($user->fresh()));
+    }
+
+    public function deleteMyProfileImage(): JsonResponse
+    {
+        $session = app(Session::class);
+        if ($session->isImpersonation()) {
+            return $this->error(403, ErrorCodes::ACTOR_SESSION_FORBIDDEN, 'Impersonation sessions cannot mutate the profile image.');
+        }
+
+        $user = app(User::class);
+        if ($user->image_url !== null) {
+            $disk = Storage::disk(self::IMAGE_DISK);
+            $candidates = [
+                "user-images/{$user->environment_id}/{$user->id}.png",
+                "user-images/{$user->environment_id}/{$user->id}.jpg",
+                "user-images/{$user->environment_id}/{$user->id}.jpeg",
+                "user-images/{$user->environment_id}/{$user->id}.webp",
+            ];
+            foreach ($candidates as $path) {
+                if ($disk->exists($path)) {
+                    $disk->delete($path);
+                }
+            }
+        }
+        $user->forceFill(['image_url' => null, 'has_image' => false])->save();
+
+        return $this->clientEnvelope(UserResource::from($user->fresh()));
+    }
+
     /* -------------------- helpers -------------------- */
+
+    private function environmentRequiresPassword(Environment $env): bool
+    {
+        $userSettings = is_array($env->user_settings) ? $env->user_settings : [];
+        $attributes = is_array($userSettings['attributes'] ?? null) ? $userSettings['attributes'] : [];
+        $password = is_array($attributes['password'] ?? null) ? $attributes['password'] : [];
+
+        return ($password['enabled'] ?? true) === true && ($password['required'] ?? true) === true;
+    }
 
     private function loadEmail(Request $request): EmailAddress|JsonResponse
     {

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -187,6 +187,10 @@ Route::prefix('v1')->group(function (): void {
 
         Route::get('/me/sessions', [MeController::class, 'listSessions'])->name('fapi.me.sessions.list');
         Route::post('/me/change-password', [MeController::class, 'changePassword'])->name('fapi.me.change_password');
+        Route::delete('/me/password', [MeController::class, 'removeMyPassword'])->name('fapi.me.password.delete');
+
+        Route::post('/me/profile-image', [MeController::class, 'uploadMyProfileImage'])->name('fapi.me.profile_image.upload');
+        Route::delete('/me/profile-image', [MeController::class, 'deleteMyProfileImage'])->name('fapi.me.profile_image.delete');
 
         Route::post('/me/totp', [MeTotpController::class, 'start'])->name('fapi.me.totp.start');
         Route::post('/me/totp/verify', [MeTotpController::class, 'verify'])->name('fapi.me.totp.verify');

--- a/tests/Feature/Http/Me/MeEndpointsTest.php
+++ b/tests/Feature/Http/Me/MeEndpointsTest.php
@@ -7,6 +7,8 @@ use App\Models\Session;
 use App\Models\User;
 use App\Models\Verification;
 use App\Models\VerificationCode;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Testing\TestResponse;
 use Tests\Feature\Http\Me\MeTestSupport;
 
@@ -152,4 +154,152 @@ it('GET /v1/me/sessions lists the user sessions', function (): void {
     $r->assertOk()
         ->assertJsonPath('total_count', 1)
         ->assertJsonPath('data.0.id', $auth['session']->id);
+});
+
+it('DELETE /v1/me/password clears the password hash when env permits it', function (): void {
+    $f = MeTestSupport::bootEnv([
+        'attributes' => ['password' => ['enabled' => true, 'required' => false]],
+    ]);
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    meReq('DELETE', '/me/password', $auth['jwt'], [
+        'current_password' => 'super-secret-password',
+    ])->assertOk()
+        ->assertJsonPath('response.password_enabled', false);
+
+    expect(User::query()->withoutGlobalScopes()->where('id', $auth['user']->id)->first()->password_hash)->toBeNull();
+});
+
+it('DELETE /v1/me/password returns 422 form_password_incorrect on wrong current password', function (): void {
+    $f = MeTestSupport::bootEnv([
+        'attributes' => ['password' => ['enabled' => true, 'required' => false]],
+    ]);
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    meReq('DELETE', '/me/password', $auth['jwt'], [
+        'current_password' => 'wrong',
+    ])->assertStatus(422)->assertJsonPath('errors.0.code', 'form_password_incorrect');
+});
+
+it('DELETE /v1/me/password returns 422 when the environment requires a password', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    meReq('DELETE', '/me/password', $auth['jwt'], [
+        'current_password' => 'super-secret-password',
+    ])->assertStatus(422)->assertJsonPath('errors.0.code', 'form_password_validation_failed');
+});
+
+it('DELETE /v1/me/password returns 422 when the user has no password set', function (): void {
+    $f = MeTestSupport::bootEnv([
+        'attributes' => ['password' => ['enabled' => true, 'required' => false]],
+    ]);
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $auth['user']->forceFill(['password_hash' => null])->save();
+
+    meReq('DELETE', '/me/password', $auth['jwt'], [
+        'current_password' => 'super-secret-password',
+    ])->assertStatus(422)->assertJsonPath('errors.0.code', 'form_password_validation_failed');
+});
+
+it('DELETE /v1/me/password is forbidden for impersonation sessions', function (): void {
+    $f = MeTestSupport::bootEnv([
+        'attributes' => ['password' => ['enabled' => true, 'required' => false]],
+    ]);
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env'], [
+        'actor' => ['iss' => 'https://actor.example.com', 'sub' => 'admin', 'sid' => 'sess_admin'],
+    ]);
+
+    meReq('DELETE', '/me/password', $auth['jwt'], [
+        'current_password' => 'super-secret-password',
+    ])->assertStatus(403)->assertJsonPath('errors.0.code', 'actor_session_forbidden');
+});
+
+it('POST /v1/me/profile-image stores the image and updates image_url', function (): void {
+    Storage::fake('s3', ['url' => 'https://images.example.com']);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $file = UploadedFile::fake()->image('avatar.png', 64, 64);
+
+    test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$auth['jwt'],
+            'Accept' => 'application/json',
+        ])
+        ->post('https://acme.authn.local/v1/me/profile-image', ['file' => $file])
+        ->assertOk()
+        ->assertJsonPath('response.has_image', true);
+
+    expect(User::query()->withoutGlobalScopes()->where('id', $auth['user']->id)->first()->image_url)->not->toBeNull();
+});
+
+it('POST /v1/me/profile-image returns 415 for an unsupported MIME', function (): void {
+    Storage::fake('s3', ['url' => 'https://images.example.com']);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+
+    $file = UploadedFile::fake()->create('avatar.txt', 4, 'text/plain');
+
+    test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$auth['jwt'],
+            'Accept' => 'application/json',
+        ])
+        ->post('https://acme.authn.local/v1/me/profile-image', ['file' => $file])
+        ->assertStatus(415)
+        ->assertJsonPath('errors.0.code', 'form_param_format_invalid');
+});
+
+it('POST /v1/me/profile-image is forbidden for impersonation sessions', function (): void {
+    Storage::fake('s3', ['url' => 'https://images.example.com']);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env'], [
+        'actor' => ['iss' => 'https://actor.example.com', 'sub' => 'admin', 'sid' => 'sess_admin'],
+    ]);
+
+    $file = UploadedFile::fake()->image('avatar.png', 64, 64);
+
+    test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$auth['jwt'],
+            'Accept' => 'application/json',
+        ])
+        ->post('https://acme.authn.local/v1/me/profile-image', ['file' => $file])
+        ->assertStatus(403)
+        ->assertJsonPath('errors.0.code', 'actor_session_forbidden');
+});
+
+it('DELETE /v1/me/profile-image clears image_url and is idempotent', function (): void {
+    Storage::fake('s3', ['url' => 'https://images.example.com']);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $auth['user']->forceFill(['image_url' => 'https://example.com/avatar.png', 'has_image' => true])->save();
+
+    meReq('DELETE', '/me/profile-image', $auth['jwt'])
+        ->assertOk()
+        ->assertJsonPath('response.has_image', false);
+
+    expect(User::query()->withoutGlobalScopes()->where('id', $auth['user']->id)->first()->image_url)->toBeNull();
+
+    // Second call is idempotent — no error.
+    meReq('DELETE', '/me/profile-image', $auth['jwt'])->assertOk();
+});
+
+it('DELETE /v1/me/profile-image is forbidden for impersonation sessions', function (): void {
+    Storage::fake('s3', ['url' => 'https://images.example.com']);
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env'], [
+        'actor' => ['iss' => 'https://actor.example.com', 'sub' => 'admin', 'sid' => 'sess_admin'],
+    ]);
+
+    meReq('DELETE', '/me/profile-image', $auth['jwt'])
+        ->assertStatus(403)
+        ->assertJsonPath('errors.0.code', 'actor_session_forbidden');
 });


### PR DESCRIPTION
Closes #274.

## Summary

- `DELETE /v1/me/password` — clears the user's password hash after verifying `current_password`; fail-closes with 422 when the environment's `user_settings.attributes.password.required` is true.
- `POST /v1/me/profile-image` — multipart upload, magic-byte MIME sniff, 5 MiB cap (matches BAPI admin endpoint).
- `DELETE /v1/me/profile-image` — clears \`image_url\` + storage object; idempotent.
- All three reject impersonation sessions to match the existing \`/v1/me/*\` mutating endpoints.
- 10 new Pest cases.

## Why

Without these routes, three openapi operations (\`removeMyPassword\`, \`uploadMyProfileImage\`, \`deleteMyProfileImage\`) ship in the JS SDK and 404 against any authn deployment.

## Test plan

- [x] \`vendor/bin/pint --test\`
- [x] \`php artisan test tests/Feature/Http/Me/\` — 44 tests pass