### PR TITLE
feat(AU-18): wire FAPI /v1/organizations/{org}/domains CRUD

### DIFF
--- a/app/Http/Controllers/Fapi/OrganizationDomainController.php
+++ b/app/Http/Controllers/Fapi/OrganizationDomainController.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Fapi;
+
+use App\Auth\ErrorCodes;
+use App\Events\Organizations\OrganizationDomainCreated;
+use App\Events\Organizations\OrganizationDomainDeleted;
+use App\Events\Organizations\OrganizationDomainUpdated;
+use App\Http\Requests\Bapi\Organizations\CreateDomainRequest;
+use App\Http\Requests\Bapi\Organizations\UpdateDomainRequest;
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\OrganizationDomainResource;
+use App\Models\Client;
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationDomain;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class OrganizationDomainController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $org = app(Organization::class);
+
+        $query = OrganizationDomain::query()->where('organization_id', $org->id);
+        if ($request->has('verified')) {
+            $query->where('verified', $request->boolean('verified'));
+        }
+        if ($request->has('enrollment_mode')) {
+            $query->where('enrollment_mode', (string) $request->input('enrollment_mode'));
+        }
+        $query->latest('created_at');
+
+        $limit = max(1, min(500, (int) $request->input('limit', 10)));
+        $offset = max(0, (int) $request->input('offset', 0));
+        $total = (clone $query)->count();
+        $rows = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => $rows->map(fn (OrganizationDomain $d) => OrganizationDomainResource::from($d))->all(),
+            'total_count' => $total,
+        ])->header('Cache-Control', 'no-store');
+    }
+
+    public function store(CreateDomainRequest $request): JsonResponse
+    {
+        $env = app(Environment::class);
+        $org = app(Organization::class);
+
+        $name = strtolower((string) $request->input('name'));
+        $duplicate = OrganizationDomain::query()
+            ->where('environment_id', $env->id)
+            ->where('name', $name)
+            ->exists();
+        if ($duplicate) {
+            return $this->error(409, ErrorCodes::FORM_IDENTIFIER_EXISTS, 'A domain with that name is already registered in this environment.');
+        }
+
+        $domain = OrganizationDomain::create([
+            'environment_id' => $env->id,
+            'organization_id' => $org->id,
+            'name' => $name,
+            'verified' => false,
+            'enrollment_mode' => $request->input('enrollment_mode', OrganizationDomain::MODE_MANUAL_INVITATION),
+            'affiliation_email_address' => $request->input('affiliation_email_address'),
+        ]);
+
+        OrganizationDomainCreated::dispatch($domain);
+
+        return $this->envelope(OrganizationDomainResource::from($domain->fresh()));
+    }
+
+    public function show(Request $request): JsonResponse
+    {
+        $domain = $this->find($request);
+        if ($domain === null) {
+            return $this->error(404, 'organization_domain_not_found', 'No domain matches that id in this organization.');
+        }
+
+        return response()->json(OrganizationDomainResource::from($domain))
+            ->header('Cache-Control', 'no-store');
+    }
+
+    public function update(UpdateDomainRequest $request): JsonResponse
+    {
+        $domain = $this->find($request);
+        if ($domain === null) {
+            return $this->error(404, 'organization_domain_not_found', 'No domain matches that id in this organization.');
+        }
+
+        if ($request->has('enrollment_mode')) {
+            $domain->enrollment_mode = (string) $request->input('enrollment_mode');
+        }
+        if ($request->has('affiliation_email_address')) {
+            $domain->affiliation_email_address = $request->input('affiliation_email_address');
+        }
+        $domain->save();
+
+        OrganizationDomainUpdated::dispatch($domain->fresh());
+
+        return $this->envelope(OrganizationDomainResource::from($domain->fresh()));
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $domain = $this->find($request);
+        if ($domain === null) {
+            return $this->error(404, 'organization_domain_not_found', 'No domain matches that id in this organization.');
+        }
+
+        $snapshot = OrganizationDomainResource::from($domain);
+
+        $copy = $domain->replicate();
+        $copy->setRawAttributes($domain->getAttributes(), sync: true);
+        $domain->delete();
+
+        OrganizationDomainDeleted::dispatch($copy);
+
+        return $this->envelope($snapshot);
+    }
+
+    private function find(Request $request): ?OrganizationDomain
+    {
+        $org = app(Organization::class);
+        $domainId = (string) $request->route('domain_id');
+
+        return OrganizationDomain::query()
+            ->where('organization_id', $org->id)
+            ->where('id', $domainId)
+            ->first();
+    }
+
+    private function envelope(mixed $response, int $status = 200): JsonResponse
+    {
+        $client = app()->bound(Client::class) ? app(Client::class) : null;
+
+        return response()->json([
+            'response' => $response,
+            'client' => ClientResource::from($client?->fresh()),
+        ], $status)->header('Cache-Control', 'no-store');
+    }
+
+    private function error(int $status, string $code, string $message): JsonResponse
+    {
+        return response()->json([
+            'errors' => [[
+                'code' => $code,
+                'message' => $message,
+                'long_message' => $message,
+                'meta' => [],
+            ]],
+            'trace_id' => null,
+        ], $status);
+    }
+}

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\Fapi\OauthConsentController;
 use App\Http\Controllers\Fapi\OauthTokenController;
 use App\Http\Controllers\Fapi\OauthUserinfoController;
 use App\Http\Controllers\Fapi\OrganizationController as FapiOrganizationController;
+use App\Http\Controllers\Fapi\OrganizationDomainController as FapiOrganizationDomainController;
 use App\Http\Controllers\Fapi\OrganizationEnterpriseConnectionController;
 use App\Http\Controllers\Fapi\OrganizationInvitationController as FapiOrganizationInvitationController;
 use App\Http\Controllers\Fapi\OrganizationMembershipController as FapiOrganizationMembershipController;
@@ -257,6 +258,25 @@ Route::prefix('v1')->group(function (): void {
         Route::post('/organizations/{organization_id}/membership-requests/{request_id}/reject', [FapiOrganizationMembershipRequestController::class, 'reject'])
             ->middleware(EnsureOrgPermission::class.':org:sys_memberships:manage')
             ->name('fapi.organizations.membership_requests.reject');
+
+        // Per-org domains (AU-13 / OA-1). Drives the <OrganizationProfile />
+        // Domains section in sdk-react. BAPI hosts the verification-challenge
+        // sub-resource — FAPI only exposes the CRUD on the domain rows.
+        Route::get('/organizations/{organization_id}/domains', [FapiOrganizationDomainController::class, 'index'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_domains:read')
+            ->name('fapi.organizations.domains.index');
+        Route::post('/organizations/{organization_id}/domains', [FapiOrganizationDomainController::class, 'store'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_domains:manage')
+            ->name('fapi.organizations.domains.store');
+        Route::get('/organizations/{organization_id}/domains/{domain_id}', [FapiOrganizationDomainController::class, 'show'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_domains:read')
+            ->name('fapi.organizations.domains.show');
+        Route::patch('/organizations/{organization_id}/domains/{domain_id}', [FapiOrganizationDomainController::class, 'update'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_domains:manage')
+            ->name('fapi.organizations.domains.update');
+        Route::delete('/organizations/{organization_id}/domains/{domain_id}', [FapiOrganizationDomainController::class, 'destroy'])
+            ->middleware(EnsureOrgPermission::class.':org:sys_domains:manage')
+            ->name('fapi.organizations.domains.destroy');
 
         // Per-org enterprise SSO connections (AU-6 / OA-5). Drives the
         // <OrganizationProfile /> SSO section in sdk-react.

--- a/tests/Feature/Http/Fapi/OrganizationDomainsTest.php
+++ b/tests/Feature/Http/Fapi/OrganizationDomainsTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Environment;
+use App\Models\Organization;
+use App\Models\OrganizationDomain;
+use App\Models\OrganizationMembership;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\Http\Me\MeTestSupport;
+
+function fapiDomainReq(string $method, string $path, string $jwt, array $body = []): TestResponse
+{
+    return test()->withCredentials()
+        ->withHeaders([
+            'Host' => 'acme.authn.local',
+            'Origin' => 'https://app.example.com',
+            'Authorization' => 'Bearer '.$jwt,
+        ])
+        ->json($method, "https://acme.authn.local/v1{$path}", $body);
+}
+
+function fapiDomainMakeOrg(Environment $env, User $user, string $roleKey = 'org:admin'): Organization
+{
+    $org = Organization::create(['environment_id' => $env->id, 'name' => 'Acme', 'slug' => 'acme-'.uniqid()]);
+    $role = Role::query()->withoutGlobalScopes()
+        ->where('environment_id', $env->id)
+        ->where('key', $roleKey)
+        ->firstOrFail();
+    OrganizationMembership::create([
+        'environment_id' => $env->id,
+        'organization_id' => $org->id,
+        'user_id' => $user->id,
+        'role_id' => $role->id,
+    ]);
+
+    return $org;
+}
+
+it('rejects non-members with 404 organization_not_found', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Outside', 'slug' => 'outside']);
+
+    fapiDomainReq('GET', "/organizations/{$org->id}/domains", $auth['jwt'])
+        ->assertStatus(404)
+        ->assertJsonPath('errors.0.code', 'organization_not_found');
+});
+
+it('lets members read but rejects POST with 403 (read-only role)', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiDomainMakeOrg($f['env'], $auth['user'], 'org:member');
+
+    fapiDomainReq('GET', "/organizations/{$org->id}/domains", $auth['jwt'])->assertOk();
+
+    fapiDomainReq('POST', "/organizations/{$org->id}/domains", $auth['jwt'], ['name' => 'denied.test'])
+        ->assertStatus(403)
+        ->assertJsonPath('errors.0.code', 'authorization_invalid');
+});
+
+it('lists domains for the path organization only', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiDomainMakeOrg($f['env'], $auth['user']);
+    $other = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Other', 'slug' => 'other']);
+
+    OrganizationDomain::create(['environment_id' => $f['env']->id, 'organization_id' => $org->id, 'name' => 'acme.test', 'verified' => true]);
+    OrganizationDomain::create(['environment_id' => $f['env']->id, 'organization_id' => $org->id, 'name' => 'acme2.test', 'verified' => false]);
+    OrganizationDomain::create(['environment_id' => $f['env']->id, 'organization_id' => $other->id, 'name' => 'other.test', 'verified' => true]);
+
+    $r = fapiDomainReq('GET', "/organizations/{$org->id}/domains", $auth['jwt']);
+    $r->assertOk()
+        ->assertJsonPath('total_count', 2);
+});
+
+it('filters by verified=true via the query string', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiDomainMakeOrg($f['env'], $auth['user']);
+
+    OrganizationDomain::create(['environment_id' => $f['env']->id, 'organization_id' => $org->id, 'name' => 'verified.test', 'verified' => true]);
+    OrganizationDomain::create(['environment_id' => $f['env']->id, 'organization_id' => $org->id, 'name' => 'unverified.test', 'verified' => false]);
+
+    $r = fapiDomainReq('GET', "/organizations/{$org->id}/domains?verified=true", $auth['jwt']);
+    $r->assertOk()
+        ->assertJsonPath('total_count', 1)
+        ->assertJsonPath('data.0.name', 'verified.test');
+});
+
+it('creates a domain via POST with enrollment_mode', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiDomainMakeOrg($f['env'], $auth['user']);
+
+    $r = fapiDomainReq('POST', "/organizations/{$org->id}/domains", $auth['jwt'], [
+        'name' => 'ACME.com',
+        'enrollment_mode' => 'automatic_invitation',
+    ]);
+    $r->assertOk()
+        ->assertJsonPath('response.object', 'organization_domain')
+        ->assertJsonPath('response.name', 'acme.com')
+        ->assertJsonPath('response.verified', false)
+        ->assertJsonPath('response.enrollment_mode', 'automatic_invitation')
+        ->assertJsonPath('client.object', 'client');
+});
+
+it('returns 409 when the domain already exists in the environment', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiDomainMakeOrg($f['env'], $auth['user']);
+    OrganizationDomain::create(['environment_id' => $f['env']->id, 'organization_id' => $org->id, 'name' => 'acme.com', 'verified' => false]);
+
+    fapiDomainReq('POST', "/organizations/{$org->id}/domains", $auth['jwt'], ['name' => 'acme.com'])
+        ->assertStatus(409)
+        ->assertJsonPath('errors.0.code', 'form_identifier_exists');
+});
+
+it('returns 404 when the domain belongs to another organization', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiDomainMakeOrg($f['env'], $auth['user']);
+    $other = Organization::create(['environment_id' => $f['env']->id, 'name' => 'Other', 'slug' => 'other-fapi-domain']);
+    $foreign = OrganizationDomain::create(['environment_id' => $f['env']->id, 'organization_id' => $other->id, 'name' => 'foreign.test', 'verified' => false]);
+
+    fapiDomainReq('GET', "/organizations/{$org->id}/domains/{$foreign->id}", $auth['jwt'])
+        ->assertStatus(404)
+        ->assertJsonPath('errors.0.code', 'organization_domain_not_found');
+});
+
+it('updates enrollment_mode via PATCH', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiDomainMakeOrg($f['env'], $auth['user']);
+    $domain = OrganizationDomain::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'name' => 'flip.test',
+        'verified' => true,
+        'enrollment_mode' => OrganizationDomain::MODE_MANUAL_INVITATION,
+    ]);
+
+    $r = fapiDomainReq('PATCH', "/organizations/{$org->id}/domains/{$domain->id}", $auth['jwt'], [
+        'enrollment_mode' => 'automatic_suggestion',
+    ]);
+    $r->assertOk()
+        ->assertJsonPath('response.enrollment_mode', 'automatic_suggestion');
+
+    expect(OrganizationDomain::query()->find($domain->id)->enrollment_mode)->toBe('automatic_suggestion');
+});
+
+it('DELETE removes the domain and returns the snapshot enveloped', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    $org = fapiDomainMakeOrg($f['env'], $auth['user']);
+    $domain = OrganizationDomain::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'name' => 'goodbye.test',
+        'verified' => false,
+    ]);
+
+    $r = fapiDomainReq('DELETE', "/organizations/{$org->id}/domains/{$domain->id}", $auth['jwt']);
+    $r->assertOk()
+        ->assertJsonPath('response.object', 'organization_domain')
+        ->assertJsonPath('response.id', $domain->id);
+
+    expect(OrganizationDomain::query()->find($domain->id))->toBeNull();
+});
+
+it('rejects PATCH from members lacking org:sys_domains:manage', function (): void {
+    $f = MeTestSupport::bootEnv();
+    $auth = MeTestSupport::makeAuthenticatedUser($f['env']);
+    // Pre-seed a domain via an admin so we can test the read-only role.
+    $admin = User::create(['environment_id' => $f['env']->id, 'first_name' => 'Admin']);
+    $org = fapiDomainMakeOrg($f['env'], $admin, 'org:admin');
+
+    // Add the auth'd user as a member-only role.
+    $memberRole = Role::query()->withoutGlobalScopes()
+        ->where('environment_id', $f['env']->id)
+        ->where('key', 'org:member')
+        ->firstOrFail();
+    OrganizationMembership::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'user_id' => $auth['user']->id,
+        'role_id' => $memberRole->id,
+    ]);
+
+    $domain = OrganizationDomain::create([
+        'environment_id' => $f['env']->id,
+        'organization_id' => $org->id,
+        'name' => 'readonly.test',
+        'verified' => false,
+    ]);
+
+    fapiDomainReq('PATCH', "/organizations/{$org->id}/domains/{$domain->id}", $auth['jwt'], [
+        'enrollment_mode' => 'automatic_invitation',
+    ])->assertStatus(403);
+});


### PR DESCRIPTION
Closes #275.

## Summary

- New \`Fapi\\OrganizationDomainController\` mirrors the BAPI logic, emits \`ClientResponseEnvelope\` on writes, and pulls the organization off the container (bound by \`EnsureOrgPermission\`) rather than re-resolving from the path.
- Routes gated by \`org:sys_domains:read\` (GET) and \`org:sys_domains:manage\` (POST/PATCH/DELETE).
- 10 new Pest cases.

## Why

The openapi spec has documented this surface since v0.4 but \`routes/fapi.php\` only ever wired the BAPI counterpart. SDK methods (\`listOrganizationDomains\`, \`createOrganizationDomain\`, \`updateOrganizationDomain\`, \`deleteOrganizationDomain\`) 404'd in production and the \`<OrganizationProfile>\` Domains section in sdk-react had no FAPI endpoint to call.

## Test plan

- [x] \`vendor/bin/pint --test\`
- [x] \`php artisan test tests/Feature/Http/Fapi/OrganizationDomainsTest.php\` — 10 tests pass