### PR TITLE
fix(AU-19): drop sms block from FAPI /v1/environment response

### DIFF
--- a/app/Http/Resources/EnvironmentResource.php
+++ b/app/Http/Resources/EnvironmentResource.php
@@ -21,29 +21,6 @@ use App\Settings\MultiFactorSettings;
  */
 final class EnvironmentResource
 {
-    /**
-     * Public half of `Environment.sms`. Strips every credential field —
-     * `auth_token` / `api_secret` are write-only and never leak via the
-     * FAPI bootstrap.
-     *
-     * @param  array<string, mixed>  $userSettings
-     * @return array{driver: ?string, from_number: ?string}
-     */
-    private static function smsBootstrap(array $userSettings): array
-    {
-        $sms = is_array($userSettings['sms'] ?? null) ? $userSettings['sms'] : [];
-        $driver = $sms['driver'] ?? null;
-        if (! in_array($driver, ['twilio', 'vonage', null], true)) {
-            $driver = null;
-        }
-        $from = is_string($sms['from_number'] ?? null) ? (string) $sms['from_number'] : null;
-
-        return [
-            'driver' => $driver,
-            'from_number' => $from,
-        ];
-    }
-
     public static function from(Environment $environment): array
     {
         $appearance = is_array($environment->appearance) ? $environment->appearance : [];
@@ -165,8 +142,6 @@ final class EnvironmentResource
                     : null,
                 'strategy' => 'oauth_'.$p->provider_key,
             ])->all(),
-
-            'sms' => self::smsBootstrap($userSettings),
 
             'paths' => $appearance['paths'] ?? [],
 


### PR DESCRIPTION
Closes #290.

## Summary

Drop \`smsBootstrap()\` and the \`'sms' => ...\` key from \`EnvironmentResource\` to match openapi#109 (which removed \`Environment.sms\` from the spec — SMS driver/credential config is system-only now, never read by the SDK).

## Why

10 tests on every PR were failing with:
\`\`\`
OpenAPI contract violation: GET /v1/environment -> 200
- : The property sms is not defined and the definition does not allow additional properties
\`\`\`

This is blocking AU-17 / AU-18 / AU-16 from going green in CI. Filed mid-flight while implementing AU-17.

## Test plan

- [x] \`vendor/bin/pint --test\`
- [x] \`php artisan test\` on the 10 previously-failing tests — all green