### PR TITLE
feat(AU-16): implement SCIM 2.0 Users PUT + PATCH (RFC 7644 §3.5)

### DIFF
--- a/app/Http/Controllers/Scim/UsersController.php
+++ b/app/Http/Controllers/Scim/UsersController.php
@@ -165,6 +165,131 @@ final class UsersController
         return $this->scimResponse($this->mapper->toResource($user, $this->parseAttributesParam($request->query('attributes'))));
     }
 
+    /**
+     * SCIM 2.0 PUT (RFC 7644 §3.5.1) — full resource replace. The IdP
+     * re-sends the entire user representation; any attribute absent from
+     * the payload reverts to its mapped default (or `null` for nullable
+     * columns). `active` is the deprovisioning lever — `active: false`
+     * sets `User.banned = true`.
+     */
+    public function update(Request $request): JsonResponse
+    {
+        $id = (string) $request->route('id');
+        $token = app(ScimToken::class);
+        $organization = $this->organizationOf($token);
+
+        $user = $this->scopedUserQuery($token->environment_id, $organization)->where('users.id', $id)->first();
+        if ($user === null) {
+            return $this->scimError(404, 'notFound', "User {$id} not found.");
+        }
+
+        $payload = $request->all();
+        if (! is_array($payload)) {
+            return $this->scimError(400, 'invalidValue', 'SCIM payload must be a JSON object.');
+        }
+
+        $mapped = $this->mapper->fromResource($payload, $organization);
+        $primaryEmail = $mapped['primary_email'];
+
+        DB::transaction(function () use ($user, $mapped, $primaryEmail, $token): void {
+            /** @var array<string, mixed> $attrs */
+            $attrs = $mapped['user'];
+
+            // PUT semantics: attributes omitted from the payload reset to
+            // their column default (null for nullables). Apply each
+            // writable column explicitly so the round-trip is lossless.
+            foreach (['first_name', 'last_name', 'external_id', 'username', 'locale'] as $column) {
+                $user->{$column} = $attrs[$column] ?? null;
+            }
+            if (array_key_exists('banned', $attrs)) {
+                $user->banned = (bool) $attrs['banned'];
+            }
+            $user->save();
+
+            if ($primaryEmail !== null) {
+                $this->replacePrimaryEmail($user, $token->environment_id, $primaryEmail);
+            }
+        });
+
+        $fresh = $user->fresh();
+        $this->emitUpdated($fresh, $token, 'put');
+
+        return $this->scimResponse($this->mapper->toResource($fresh));
+    }
+
+    /**
+     * SCIM 2.0 PATCH (RFC 7644 §3.5.2) — partial update via an
+     * `Operations[]` envelope. Supports the canonical deprovisioning
+     * play (`replace` on `active`) plus `replace` on the scalar
+     * attributes the IdP commonly drifts (`displayName`, `userName`,
+     * `externalId`, `locale`, `name.givenName`, `name.familyName`).
+     *
+     * Add/remove ops + complex filter paths on multi-valued
+     * `emails` / `phoneNumbers` are intentionally out of scope until
+     * v0.8 — IdP deprovisioning works against `replace`/`active` today.
+     */
+    public function patch(Request $request): JsonResponse
+    {
+        $id = (string) $request->route('id');
+        $token = app(ScimToken::class);
+        $organization = $this->organizationOf($token);
+
+        $user = $this->scopedUserQuery($token->environment_id, $organization)->where('users.id', $id)->first();
+        if ($user === null) {
+            return $this->scimError(404, 'notFound', "User {$id} not found.");
+        }
+
+        $payload = $request->all();
+        $ops = is_array($payload) && is_array($payload['Operations'] ?? null) ? $payload['Operations'] : null;
+        if ($ops === null || $ops === []) {
+            return $this->scimError(400, 'invalidValue', 'SCIM PATCH requires a non-empty Operations array.');
+        }
+
+        DB::transaction(function () use ($ops, $user, $token, $organization): void {
+            foreach ($ops as $op) {
+                if (! is_array($op)) {
+                    continue;
+                }
+                $verb = strtolower((string) ($op['op'] ?? ''));
+                $path = is_string($op['path'] ?? null) ? (string) $op['path'] : null;
+                $value = $op['value'] ?? null;
+
+                if ($verb === 'replace' && $path === null && is_array($value)) {
+                    $mapped = $this->mapper->fromResource($value, $organization)['user'] ?? [];
+                    foreach ($mapped as $column => $newValue) {
+                        $user->{$column} = $newValue;
+                    }
+
+                    continue;
+                }
+
+                if ($verb !== 'replace' || $path === null) {
+                    // 'add' / 'remove', or 'replace' without a usable path,
+                    // is silently no-op'd in v0.7.1 — IdPs that rely on
+                    // those flows will see no change rather than a 500.
+                    continue;
+                }
+
+                match (strtolower($path)) {
+                    'active' => $user->banned = ! (bool) $value,
+                    'displayname' => $user->username = is_string($value) ? $value : null,
+                    'username' => $this->replacePrimaryEmail($user, $token->environment_id, is_string($value) ? strtolower($value) : ''),
+                    'externalid' => $user->external_id = is_string($value) ? $value : null,
+                    'locale' => $user->locale = is_string($value) ? $value : null,
+                    'name.givenname' => $user->first_name = is_string($value) ? $value : null,
+                    'name.familyname' => $user->last_name = is_string($value) ? $value : null,
+                    default => null,
+                };
+            }
+            $user->save();
+        });
+
+        $fresh = $user->fresh();
+        $this->emitUpdated($fresh, $token, 'patch');
+
+        return $this->scimResponse($this->mapper->toResource($fresh));
+    }
+
     public function destroy(Request $request): JsonResponse
     {
         $id = (string) $request->route('id');
@@ -190,6 +315,66 @@ final class UsersController
         ]);
 
         return response()->json(null, 204, ['Content-Type' => 'application/scim+json']);
+    }
+
+    private function replacePrimaryEmail(User $user, string $environmentId, string $newEmail): void
+    {
+        if ($newEmail === '' || ! filter_var($newEmail, FILTER_VALIDATE_EMAIL)) {
+            return;
+        }
+
+        $existing = EmailAddress::query()
+            ->withoutGlobalScopes()
+            ->where('environment_id', $environmentId)
+            ->where('email_address', $newEmail)
+            ->first();
+
+        if ($existing !== null && $existing->user_id !== $user->id) {
+            // Another user already claims this address — bail rather than
+            // silently overwrite. The patch operation no-ops; the SCIM
+            // response will reflect the unchanged email.
+            return;
+        }
+
+        if ($existing !== null && $existing->user_id === $user->id) {
+            EmailAddress::query()->withoutGlobalScopes()
+                ->where('user_id', $user->id)
+                ->where('id', '!=', $existing->id)
+                ->update(['is_primary' => false]);
+            $existing->forceFill(['is_primary' => true, 'verified_at' => $existing->verified_at ?? now()])->save();
+            $user->primary_email_address_id = $existing->id;
+
+            return;
+        }
+
+        EmailAddress::query()->withoutGlobalScopes()
+            ->where('user_id', $user->id)
+            ->update(['is_primary' => false]);
+        $row = EmailAddress::query()->withoutGlobalScopes()->create([
+            'environment_id' => $environmentId,
+            'user_id' => $user->id,
+            'email_address' => $newEmail,
+            'verified_at' => now(),
+            'is_primary' => true,
+        ]);
+        $user->primary_email_address_id = $row->id;
+    }
+
+    private function emitUpdated(User $user, ScimToken $token, string $verb): void
+    {
+        Log::info('audit:auth.enterprise_sso.scim_updated', [
+            'environment_id' => $token->environment_id,
+            'organization_id' => $token->organization_id,
+            'scim_token_id' => $token->id,
+            'user_id' => $user->id,
+            'verb' => $verb,
+        ]);
+        app(Emitter::class)->emit('scimUser.updated', [
+            'object' => 'user_minimal',
+            'user_id' => $user->id,
+            'organization_id' => $token->organization_id,
+            'enterprise_connection_id' => $token->enterprise_connection_id,
+        ]);
     }
 
     /**

--- a/routes/fapi.php
+++ b/routes/fapi.php
@@ -88,6 +88,8 @@ Route::withoutMiddleware([EnforceFapiOrigin::class])->prefix('scim/v2')->middlew
     Route::get('/Users', [ScimUsersController::class, 'index'])->name('scim.users.index');
     Route::post('/Users', [ScimUsersController::class, 'store'])->name('scim.users.store');
     Route::get('/Users/{id}', [ScimUsersController::class, 'show'])->name('scim.users.show');
+    Route::put('/Users/{id}', [ScimUsersController::class, 'update'])->name('scim.users.update');
+    Route::patch('/Users/{id}', [ScimUsersController::class, 'patch'])->name('scim.users.patch');
     Route::delete('/Users/{id}', [ScimUsersController::class, 'destroy'])->name('scim.users.destroy');
 
     Route::get('/Groups', [ScimGroupsController::class, 'index'])->name('scim.groups.index');

--- a/tests/Feature/Http/Scim/ScimUsersTest.php
+++ b/tests/Feature/Http/Scim/ScimUsersTest.php
@@ -216,6 +216,187 @@ it('soft-deletes the User on DELETE', function (): void {
     expect($reloaded?->deleted_at)->not->toBeNull();
 });
 
+it('PUT /Users/{id} replaces the user attributes (RFC 7644 §3.5.1)', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $u = User::create(['environment_id' => $f['env']->id, 'first_name' => 'Old', 'last_name' => 'Name', 'username' => 'old_user', 'external_id' => 'ext-old']);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $u->id,
+        'email_address' => 'old@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->putJson('https://acme.authn.local/scim/v2/Users/'.$u->id, [
+            'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'userName' => 'fresh@acme.test',
+            'name' => ['givenName' => 'Fresh', 'familyName' => 'User'],
+            'emails' => [['value' => 'fresh@acme.test', 'primary' => true, 'type' => 'work']],
+            'externalId' => 'ext-new',
+            'active' => true,
+        ]);
+
+    $r->assertOk()
+        ->assertJsonPath('userName', 'fresh@acme.test')
+        ->assertJsonPath('name.givenName', 'Fresh')
+        ->assertJsonPath('name.familyName', 'User')
+        ->assertJsonPath('externalId', 'ext-new')
+        ->assertJsonPath('active', true);
+
+    $reloaded = User::query()->withoutGlobalScopes()->where('id', $u->id)->first();
+    expect($reloaded->first_name)->toBe('Fresh');
+    expect($reloaded->last_name)->toBe('User');
+    expect($reloaded->external_id)->toBe('ext-new');
+});
+
+it('PUT /Users/{id} omitting active leaves banned untouched (PUT-as-replace surfaces null → false)', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $u = User::create(['environment_id' => $f['env']->id, 'banned' => true]);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $u->id,
+        'email_address' => 'banned@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    // Omit 'active' → mapper drops the key, controller leaves banned alone.
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->putJson('https://acme.authn.local/scim/v2/Users/'.$u->id, [
+            'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'userName' => 'banned@acme.test',
+            'name' => ['givenName' => 'Still', 'familyName' => 'Banned'],
+            'emails' => [['value' => 'banned@acme.test', 'primary' => true]],
+        ]);
+
+    $r->assertOk()->assertJsonPath('active', false);
+    expect(User::query()->withoutGlobalScopes()->where('id', $u->id)->first()->banned)->toBeTrue();
+});
+
+it('PATCH /Users/{id} replace active=false bans the user (deprovisioning play)', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $u = User::create(['environment_id' => $f['env']->id]);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $u->id,
+        'email_address' => 'deprov@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->patchJson('https://acme.authn.local/scim/v2/Users/'.$u->id, [
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'Operations' => [['op' => 'replace', 'path' => 'active', 'value' => false]],
+        ]);
+
+    $r->assertOk()->assertJsonPath('active', false);
+    expect(User::query()->withoutGlobalScopes()->where('id', $u->id)->first()->banned)->toBeTrue();
+});
+
+it('PATCH /Users/{id} replace active=true unbans the user', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $u = User::create(['environment_id' => $f['env']->id, 'banned' => true]);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $u->id,
+        'email_address' => 'reprov@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->patchJson('https://acme.authn.local/scim/v2/Users/'.$u->id, [
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'Operations' => [['op' => 'replace', 'path' => 'active', 'value' => true]],
+        ]);
+
+    $r->assertOk()->assertJsonPath('active', true);
+});
+
+it('PATCH /Users/{id} replace on scalar paths updates the user', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $u = User::create(['environment_id' => $f['env']->id, 'first_name' => 'Old']);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $u->id,
+        'email_address' => 'patch@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->patchJson('https://acme.authn.local/scim/v2/Users/'.$u->id, [
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'Operations' => [
+                ['op' => 'replace', 'path' => 'name.givenName', 'value' => 'New'],
+                ['op' => 'replace', 'path' => 'externalId', 'value' => 'ext-fresh'],
+                ['op' => 'replace', 'path' => 'locale', 'value' => 'pt-BR'],
+            ],
+        ]);
+
+    $r->assertOk();
+    $reloaded = User::query()->withoutGlobalScopes()->where('id', $u->id)->first();
+    expect($reloaded->first_name)->toBe('New');
+    expect($reloaded->external_id)->toBe('ext-fresh');
+    expect($reloaded->locale)->toBe('pt-BR');
+});
+
+it('PATCH /Users/{id} no-path replace applies a full resource replace', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $u = User::create(['environment_id' => $f['env']->id, 'first_name' => 'Before']);
+    EmailAddress::query()->withoutGlobalScopes()->create([
+        'environment_id' => $f['env']->id,
+        'user_id' => $u->id,
+        'email_address' => 'nopath@acme.test',
+        'verified_at' => now(),
+        'is_primary' => true,
+    ]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->patchJson('https://acme.authn.local/scim/v2/Users/'.$u->id, [
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'Operations' => [['op' => 'replace', 'value' => ['name' => ['givenName' => 'After']]]],
+        ]);
+
+    $r->assertOk();
+    expect(User::query()->withoutGlobalScopes()->where('id', $u->id)->first()->first_name)->toBe('After');
+});
+
+it('PATCH /Users/{id} returns 400 when Operations is missing', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+    $u = User::create(['environment_id' => $f['env']->id]);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->patchJson('https://acme.authn.local/scim/v2/Users/'.$u->id, [
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+        ]);
+
+    $r->assertStatus(400)->assertJsonPath('scimType', 'invalidValue');
+});
+
+it('PUT /Users/{id} returns 404 for a user outside the token scope', function (): void {
+    $f = bootScimEnv();
+    $plaintext = mintScimToken($f['env'], $f['creator']);
+
+    $r = $this->withHeaders(['Host' => 'acme.authn.local', 'Authorization' => 'Bearer '.$plaintext])
+        ->putJson('https://acme.authn.local/scim/v2/Users/usr_missing', [
+            'schemas' => ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'userName' => 'whoever@acme.test',
+            'emails' => [['value' => 'whoever@acme.test', 'primary' => true]],
+        ]);
+
+    $r->assertStatus(404)->assertJsonPath('scimType', 'notFound');
+});
+
 it('projects only the requested attributes when attributes= is supplied', function (): void {
     $f = bootScimEnv();
     $plaintext = mintScimToken($f['env'], $f['creator']);


### PR DESCRIPTION
Refs #273 (Users half — Groups half retargeted to v0.8).

## Summary

- \`update()\` (PUT, §3.5.1 full-replace) and \`patch()\` (PATCH, §3.5.2) on \`ScimUsersController\`.
- PATCH supports the canonical IdP deprovisioning op \`replace\`/\`active\`=false plus \`replace\` on \`displayName\`, \`userName\`, \`externalId\`, \`locale\`, \`name.givenName\`, \`name.familyName\`, and no-path replace with a full resource.
- Webhook \`scimUser.updated\` + audit log entry on every successful PUT / PATCH.
- 8 new Pest cases.

## Why

Okta / Azure AD provisioning workflows that PATCH \`active:false\` for deprovisioning previously 405'd against authn.sh v0.7.0. The openapi spec already documents the surface — this just wires it up.

## Scope cut

Groups POST / PUT / PATCH / DELETE (the second half of #273) sits on top of the virtual \`(organization, role)\` group projection and needs the role-self-service refactor that isn't patch-scope. Filing as a v0.8 follow-up.

## Test plan

- [x] \`vendor/bin/pint --test\`
- [x] \`php artisan test tests/Feature/Http/Scim/ScimUsersTest.php\` — 17 tests pass