### PR TITLE
0.7.2: bump JS SDK deps to ^0.7.1 stable + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.7.2] — 2026-05-15
+
+First wave of dashboard backend persistence + cleanup follow-ups behind the v0.7.1 UI rebuild. Issue references on GitHub.
+
+### Added
+
+- **`SignInMethodsSettings` value object + `PATCH /configure/sign-in-methods`** (#277) — `user_settings.sign_in_methods.email.{enabled, code}`. `SignInResource` and `ChallengeController` filter `email_code` / `reset_password_email_code` from the supported-strategies list when the parent toggles are off so the SDK never advertises a strategy the server will refuse.
+- **`SignUpMethodsSettings` value object + `PATCH /configure/sign-up-methods`** (#281) — `user_settings.sign_up_methods.password.{enabled, signup_with_password, add_password}` and `phone.{enabled, required}`. `StageRequirements` skips the password attribute when `signup_with_password` is off; FAPI `/me/password` returns `403 add_password_disabled` when a passwordless user tries to set one and `add_password` is off.
+- **`RedirectsSettings` value object + `PATCH /configure/redirects`** (#286) — 5 SDK fallback URLs (`after_sign_up`, `after_sign_in`, `home`, `after_create_organization`, `after_leave_organization`) under `user_settings.redirects`. URL origins must match the env's `allowed_origins` (refuses to plant open-redirect targets). `EnvironmentResource.display_config.redirects` carries the resolved tree to the SDK at boot.
+- **`PresetContract::availableScopes()`** (#284) — every preset enumerates the full scope catalog the IdP supports. Dashboard Provider page renders scopes as a multi-select (with a custom-scope add input) instead of a free-text field. `defaultScopes()` continues to seed the pre-checked subset.
+
+### Changed
+
+- **System org permission keys drop the `sys_` infix** (#287) — `org:sys_profile:read` → `org:profile:read` across the 13 system permission keys. `Permission.is_system` continues to distinguish system vs custom. Data migration renames existing rows in place. OpenAPI examples follow (`authn-sh/openapi#aa69d83`).
+- **Phone storage migrated** (#282) — flips from the legacy `user_settings.attributes.phone_number` tri-state to `user_settings.sign_up_methods.phone.{enabled, required}`. `EnvironmentResource` and BAPI `/instance` PATCH switch to the new shape; webhook event renames from `instance.config.attributes_updated` → `instance.config.sign_up_methods_updated`. BAPI `/instance` GET continues to surface the inflated `attribute_settings.phone_number` shape for back-compat consumers. Data migration converts existing rows (`off` → `{enabled:false}`, `optional` → `{enabled:true, required:false}`, `required` → `{enabled:true, required:true}`).
+- **OAuth providers no longer pre-seeded per environment** (#284) — `OauthProviderSeeder` deleted; `OauthProvider` rows now only exist for *configured* providers. `PresetRegistry` is the source-of-truth for the built-in catalog (Google, GitHub, Apple, Microsoft, Discord, Facebook, LinkedIn, X, GitLab, Slack). One-shot migration deletes existing empty seeded rows. Dashboard provider list already unioned presets with persisted rows; phantom rows just disappear.
+- **JS SDK packages pinned to `^0.7.1` stable** — exits the alpha cycle from v0.7.1.
+
+### Removed
+
+- **`email_link` first-factor / sign-up verification strategy** (#283) — drops `STRATEGY_EMAIL_LINK`, `PURPOSE_MAGIC_LINK`, `EmailLinkStrategy`, `MagicLinkController` + `MagicLinkIssuer` + `MagicLinkVerifier`, the `SendMagicLinkEmail` job, `SLUG_MAGIC_LINK_SIGN_IN` / `SLUG_MAGIC_LINK_SIGN_UP` / `SLUG_MAGIC_LINK_USER_PROFILE` email templates, the `/v1/client/magic-link/redeem` route, the `clients.token_version` column (sole consumer was the cross-device magic-link flow), `SignIn` / `SignUp` `EmailLinkTest` suites, and every `email_link` branch in `ChallengeController` / `StrategyResolver`. `Verification::STATUS_TRANSFERABLE` stays (used by ticket and OAuth transfer); invitation email-links stay (separate flow, carries state); `reset_password_email_code` stays. OpenAPI strips `email_link` from FAPI schemas (`authn-sh/openapi#dd92a81`).
+
 ## [0.7.1] — 2026-05-15
 
 Patch release: contract gaps + fail-open fixes flagged in the cross-repo critical review, plus a Dashboard / Account Portal UI rebuild.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,10 @@
     "packages": {
         "": {
             "dependencies": {
-                "@authn-sh/sdk-js": "^0.7.0",
-                "@authn-sh/sdk-react": "^0.7.1-alpha.0",
-                "@authn-sh/types": "^0.7.0",
-                "@authn-sh/ui": "^0.7.1-alpha.0"
+                "@authn-sh/sdk-js": "^0.7.1",
+                "@authn-sh/sdk-react": "^0.7.1",
+                "@authn-sh/types": "^0.7.1",
+                "@authn-sh/ui": "^0.7.1"
             },
             "devDependencies": {
                 "@inertiajs/react": "^3.0.3",
@@ -28,36 +28,36 @@
             }
         },
         "node_modules/@authn-sh/sdk-js": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.7.0.tgz",
-            "integrity": "sha512-BGDht+GTVFDCMmUNth5apmC1NKwW9MfbdY4FHQUptsBIXX8cq3UI52ex49PwdSgAkDjUU9zy/5I6H0JUMK5feg==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-js/-/sdk-js-0.7.1.tgz",
+            "integrity": "sha512-epaxb3bDGRqBjG2gnhYd1zwrRHUet3iG7QFYC1Q4rBHoElVkkGjgC31dI+KFaAVhjSpkfAg29PqdIlgVWhFUVg==",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "intl-messageformat": "^11.2.4"
             }
         },
         "node_modules/@authn-sh/sdk-react": {
-            "version": "0.7.1-alpha.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-0.7.1-alpha.0.tgz",
-            "integrity": "sha512-oAKNEongkjokmD+KjdNVCJBgqpFddA6H5ykBxlE7FPVlR1qv8CZUpG/oE/DGOKMJ7UINu/xx8auhS6vs40dsHA==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@authn-sh/sdk-react/-/sdk-react-0.7.1.tgz",
+            "integrity": "sha512-7HWw4iArBpv/wgL9lThuMJRsAk7pJCM1kO/rJ1AzXrh1k6/xYLQ7rXpLP3x25S0+rGeFZKxh1rmYlvUMvmmrUA==",
             "license": "AGPL-3.0-only",
             "peerDependencies": {
-                "@authn-sh/sdk-js": "0.7.0",
-                "@authn-sh/ui": "0.7.1-alpha.0",
+                "@authn-sh/sdk-js": "0.7.1",
+                "@authn-sh/ui": "0.7.1",
                 "react": "^18 || ^19",
                 "react-dom": "^18 || ^19"
             }
         },
         "node_modules/@authn-sh/types": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.7.0.tgz",
-            "integrity": "sha512-aPNr97fQlJn9Xr+02das8OiF/YpYD5NZjw1OzdkVamNl30AcnOXJWoxdu1aFn2gskeKNaH01DbmAL+hFsVIneQ==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@authn-sh/types/-/types-0.7.1.tgz",
+            "integrity": "sha512-3yEeBnhp6v+O2/TE5x5Grmez3F60jlh6iq3U4Y37WlQwpzGpNipOfOBr7001vMgJpH3S88tClMzGwGiQcjFs7A==",
             "license": "AGPL-3.0-only"
         },
         "node_modules/@authn-sh/ui": {
-            "version": "0.7.1-alpha.0",
-            "resolved": "https://registry.npmjs.org/@authn-sh/ui/-/ui-0.7.1-alpha.0.tgz",
-            "integrity": "sha512-b1/VgPWBErgXLRoPMPohsH2zZJR0ZOT5JFPo0FAkxO8bxwQBZtSLTV2SdaF38hn+VlB8OeBCI/CoRqVca67zcQ==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@authn-sh/ui/-/ui-0.7.1.tgz",
+            "integrity": "sha512-aOiRmblZmg/w5Rna1WoEC33RDAxDWeM7dyUK2fpf6JZlgAVPOpXv5Tu707MH2WbWg68afjjnLj8EROUq7Wp4sw==",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@radix-ui/react-avatar": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
         "vite": "^8.0.0"
     },
     "dependencies": {
-        "@authn-sh/sdk-js": "^0.7.0",
-        "@authn-sh/sdk-react": "^0.7.1-alpha.0",
-        "@authn-sh/types": "^0.7.0",
-        "@authn-sh/ui": "^0.7.1-alpha.0"
+        "@authn-sh/sdk-js": "^0.7.1",
+        "@authn-sh/sdk-react": "^0.7.1",
+        "@authn-sh/types": "^0.7.1",
+        "@authn-sh/ui": "^0.7.1"
     }
 }


### PR DESCRIPTION
## Summary

Now that authn-sh/javascript#141 cut v0.7.1 stable (sdk-js, sdk-react, sdk-node, types, ui all at 0.7.1 on npm), drop the \`-alpha.0\` pin and align on the stable line.

Also adds the 0.7.2 CHANGELOG entry covering the seven issue follow-ups landed in #295: #277 (sign-in email_code toggle), #281 (sign-up password card), #286 (redirects persistence), #284 (OAuth presets-as-source-of-truth + availableScopes), #287 (drop sys_ prefix), #282 (phone storage migration), #283 (email_link removal).

## Test plan
- [ ] CI green
- [ ] Tag v0.7.2 after merge